### PR TITLE
FAT2-236 - add_trading_name_providers_list

### DIFF
--- a/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Models/WhenCastingGetProviderCourseItemFromMediatorType.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Models/WhenCastingGetProviderCourseItemFromMediatorType.cs
@@ -61,6 +61,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Models
             var response = new GetProviderCourseItem().Map(source, sectorSubjectArea,5, true);
 
             response.Name.Should().Be(source.ProviderStandard.Name);
+            response.TradingName.Should().Be(source.ProviderStandard.TradingName);
             response.ProviderId.Should().Be(source.ProviderStandard.Ukprn);
             response.OverallCohort.Should().Be(item.OverallCohort);
             response.OverallAchievementRate.Should().Be(item.OverallAchievementRate);
@@ -88,6 +89,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Models
             var response = new GetProviderCourseItem().Map(source, sectorSubjectArea,2, true);
 
             response.Name.Should().Be(source.ProviderStandard.Name);
+            response.TradingName.Should().Be(source.ProviderStandard.TradingName);
             response.ProviderId.Should().Be(source.ProviderStandard.Ukprn);
             response.OverallCohort.Should().Be(item.OverallCohort);
             response.NationalOverallCohort.Should().Be(item3.OverallCohort);
@@ -114,6 +116,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Models
             var response = new GetProviderCourseItem().Map(source, sectorSubjectArea, 1, true);
 
             response.Name.Should().Be(source.ProviderStandard.Name);
+            response.TradingName.Should().Be(source.ProviderStandard.TradingName);
             response.ProviderId.Should().Be(source.ProviderStandard.Ukprn);
             response.OverallCohort.Should().BeNull();
             response.NationalOverallCohort.Should().BeNull();

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api/Models/GetProviderCourseItem.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api/Models/GetProviderCourseItem.cs
@@ -31,6 +31,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Models
                 Phone = source.ProviderStandard.Phone,
                 Email = source.ProviderStandard.Email,
                 Name = source.ProviderStandard.Name,
+                TradingName = source.ProviderStandard.TradingName,
                 ProviderId = source.ProviderStandard.Ukprn,
                 OverallCohort = achievementRate?.OverallCohort,
                 NationalOverallCohort = nationalRate?.OverallCohort,

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api/Models/GetTrainingCourseProviderListItem.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api/Models/GetTrainingCourseProviderListItem.cs
@@ -45,6 +45,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Models
             return new GetTrainingCourseProviderListItem
             {
                 Name = source.Name,
+                TradingName = source.TradingName,
                 ProviderId = source.Ukprn,
                 OverallCohort = achievementRate?.OverallCohort,
                 OverallAchievementRate = achievementRate?.OverallAchievementRate,

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api/Models/ProviderCourseBase.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api/Models/ProviderCourseBase.cs
@@ -10,6 +10,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Models
         public int ProviderId { get ; set ; }
 
         public string Name { get ; set ; }
+        public string TradingName { get; set; }
         public List<GetDeliveryType> DeliveryModes { get ; set ; }
         public int? OverallCohort { get; set; }
         public decimal? OverallAchievementRate { get ; set ; }

--- a/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCourseProvider/GetTrainingCourseProviderQueryHandler.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCourseProvider/GetTrainingCourseProviderQueryHandler.cs
@@ -44,7 +44,6 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.TrainingCourses.Queries
 
             var coursesTask = _cacheHelper.GetRequest<GetStandardsListResponse>(_coursesApiClient,
                 new GetStandardsListRequest(), nameof(GetStandardsListResponse), out var saveToCache);
-
             await Task.WhenAll(courseTask, providerTask, coursesTask, providerCoursesTask, ukprnsCount);
 
             if (providerTask.Result == null && location != null)

--- a/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Responses/GetProviderStandardItem.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Responses/GetProviderStandardItem.cs
@@ -6,6 +6,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.InnerApi.Responses
     {
         public int Ukprn { get; set; }
         public string Name { get; set; }
+        public string TradingName { get; set; }
         public string ContactUrl { get; set; }
         public string Email { get; set; }
         public string Phone { get; set; }

--- a/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Responses/GetProvidersListItem.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Responses/GetProvidersListItem.cs
@@ -6,6 +6,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.InnerApi.Responses
     {
         public int Ukprn { get; set; }
         public string Name { get; set; }
+        public string TradingName { get; set; }
         public IEnumerable<GetAchievementRateItem> AchievementRates { get; set; }
         public IEnumerable<GetDeliveryTypeItem> DeliveryTypes { get; set; }
         public IEnumerable<GetFeedbackAttributeItem> FeedbackAttributes { get; set; }


### PR DESCRIPTION
On the Course Providers list, if a provider has a trading name that is different from it's primary name it will be displayed under 'Other Names'