### PR TITLE
FAT2-316 Provider Ordering Changes

### DIFF
--- a/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Extensions/WhenOrderingByProviderRating.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Extensions/WhenOrderingByProviderRating.cs
@@ -702,7 +702,12 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Extensions
                         new GetDeliveryType
                         {
                             DeliveryModeType = DeliveryModeType.DayRelease,
-                            DistanceInMiles = 3.9m
+                            DistanceInMiles = 5.9m
+                        },
+                        new GetDeliveryType
+                        {
+                            DeliveryModeType = DeliveryModeType.Workplace,
+                            DistanceInMiles = 0m
                         }
                     },
                     HasLocation = true

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Extensions/WhenOrderingByProviderRating.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Extensions/WhenOrderingByProviderRating.cs
@@ -67,6 +67,43 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Extensions
             list.Skip(3).Take(1).First().ProviderId.Should().Be(2);
             list.Last().ProviderId.Should().Be(5);
         }
+
+        [Test]
+        public void Then_If_Only_One_Has_Percentile_Score_Then_That_Scores_Highest()
+        {
+            var list = new List<GetTrainingCourseProviderListItem>
+            {
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 1,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 4,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 3,
+                    OverallAchievementRate = 84.8m,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                }
+            };
+
+            list = list.OrderByProviderRating().ToList();
+
+            list.First().ProviderId.Should().Be(3);
+        }
         
         [Test]
         public void Then_The_Percentile_Is_Calculated_And_Rank_Assigned_For_AchievementRates()
@@ -126,6 +163,201 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Extensions
                     {
                         
                     } 
+                }
+            };
+
+            list = list.OrderByProviderRating().ToList();
+
+            list.First().ProviderId.Should().Be(3);
+            list.Last().ProviderId.Should().Be(1);
+        }
+        
+        
+        [Test]
+        public void Then_The_Percentile_Is_Calculated_And_Rank_Assigned_For_AchievementRates_And_If_Same_Ordered_By_PassRate()
+        {
+            var list = new List<GetTrainingCourseProviderListItem>
+            {
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 1,
+                    OverallAchievementRate = 52.6m,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 4,
+                    OverallAchievementRate = 81.6m,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 3,
+                    OverallAchievementRate = 84.8m,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 2,
+                    OverallAchievementRate = 81.8m,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 7,
+                    OverallAchievementRate = 81.8m,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 6,
+                    OverallAchievementRate = 82.8m,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 5,
+                    OverallAchievementRate = null,
+                    Feedback = new GetProviderFeedbackResponse
+                    {
+                        
+                    } 
+                }
+            };
+
+            list = list.OrderByProviderRating().ToList();
+
+            list.First().ProviderId.Should().Be(3);
+            list.Last().ProviderId.Should().Be(1);
+        }
+        
+        [Test]
+        public void Then_The_Percentile_Is_Calculated_And_Rank_Assigned_For_AchievementRates_And_If_Same_Ordered_By_PassRate_With_Distance()
+        {
+            var list = new List<GetTrainingCourseProviderListItem>
+            {
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 1,
+                    OverallAchievementRate = 52.6m,
+                    Feedback = new GetProviderFeedbackResponse(),
+                    HasLocation = true,
+                    DeliveryModes = new List<GetDeliveryType>
+                    {
+                        new GetDeliveryType
+                        {
+                            DeliveryModeType = DeliveryModeType.BlockRelease,
+                            DistanceInMiles = 1
+                        }
+                    }
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 4,
+                    OverallAchievementRate = 81.6m,
+                    Feedback = new GetProviderFeedbackResponse(),
+                    HasLocation = true,
+                    DeliveryModes = new List<GetDeliveryType>
+                    {
+                        new GetDeliveryType
+                        {
+                            DeliveryModeType = DeliveryModeType.BlockRelease,
+                            DistanceInMiles = 1
+                        }
+                    }
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 3,
+                    OverallAchievementRate = 84.8m,
+                    Feedback = new GetProviderFeedbackResponse(),
+                    HasLocation = true,
+                    DeliveryModes = new List<GetDeliveryType>
+                    {
+                        new GetDeliveryType
+                        {
+                            DeliveryModeType = DeliveryModeType.BlockRelease,
+                            DistanceInMiles = 1
+                        }
+                    }
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 2,
+                    OverallAchievementRate = 81.8m,
+                    Feedback = new GetProviderFeedbackResponse(),
+                    HasLocation = true,
+                    DeliveryModes = new List<GetDeliveryType>
+                    {
+                        new GetDeliveryType
+                        {
+                            DeliveryModeType = DeliveryModeType.BlockRelease,
+                            DistanceInMiles = 1
+                        }
+                    }
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 7,
+                    OverallAchievementRate = 81.8m,
+                    Feedback = new GetProviderFeedbackResponse(),
+                    HasLocation = true,
+                    DeliveryModes = new List<GetDeliveryType>
+                    {
+                        new GetDeliveryType
+                        {
+                            DeliveryModeType = DeliveryModeType.BlockRelease,
+                            DistanceInMiles = 1
+                        }
+                    }
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 6,
+                    OverallAchievementRate = 82.8m,
+                    Feedback = new GetProviderFeedbackResponse(),
+                    HasLocation = true,
+                    DeliveryModes = new List<GetDeliveryType>
+                    {
+                        new GetDeliveryType
+                        {
+                            DeliveryModeType = DeliveryModeType.BlockRelease,
+                            DistanceInMiles = 1
+                        }
+                    }
+                },
+                new GetTrainingCourseProviderListItem
+                {
+                    ProviderId = 5,
+                    OverallAchievementRate = null,
+                    Feedback = new GetProviderFeedbackResponse(),
+                    HasLocation = true,
+                    DeliveryModes = new List<GetDeliveryType>
+                    {
+                        new GetDeliveryType
+                        {
+                            DeliveryModeType = DeliveryModeType.BlockRelease,
+                            DistanceInMiles = 1
+                        }
+                    }
                 }
             };
 

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api/Extensions/TrainingCourseProviderOrderByExtension.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api/Extensions/TrainingCourseProviderOrderByExtension.cs
@@ -37,6 +37,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Extensions
                     return getTrainingCourseProviderListItem;
                 })
                 .OrderByDescending(c=>c.Score)
+                .ThenByDescending(c=>c.OverallAchievementRate)
                 .ThenByDescending(c=>c.OverallCohort)
                 .ThenByDescending(c=>c.Feedback.TotalEmployerResponses)
                 .ThenBy(c=>c.Name)
@@ -96,6 +97,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Extensions
                 .ThenBy(c=>c.DeliveryModes
                     .OrderByDescending(x=>x.DistanceInMiles)
                     .First().DistanceInMiles)
+                .ThenByDescending(c=>c.OverallAchievementRate)
                 .ThenByDescending(c=>c.OverallCohort)
                 .ThenByDescending(c=>c.Feedback.TotalEmployerResponses)
                 .ThenBy(c=>c.Name);
@@ -132,18 +134,26 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Extensions
                     .Select(x => x.Proportion)
                     .Sum() * 100
             }).ToList();
-            
-            
-            foreach (var listItem in getTrainingCourseProviderListItems
-                .Where(c => c.OverallAchievementRate.HasValue)
-                .OrderByDescending(c => c.OverallAchievementRate))
+
+            if (getTrainingCourseProviderListItems.Count(c => c.OverallAchievementRate.HasValue) == 1)
             {
-                var score = percentileValues.FirstOrDefault(x => x.Value == listItem.OverallAchievementRate); 
-                var scoreValue = GetAchievementRateScore((float)(score?.Proportion??0));
-                
-                _providerScores[listItem.ProviderId] += scoreValue;
-                
+                _providerScores[
+                    getTrainingCourseProviderListItems.First(c => c.OverallAchievementRate.HasValue).ProviderId] += 4;
             }
+            else
+            {
+                foreach (var listItem in getTrainingCourseProviderListItems
+                    .Where(c => c.OverallAchievementRate.HasValue)
+                    .OrderByDescending(c => c.OverallAchievementRate))
+                {
+                    var score = percentileValues.FirstOrDefault(x => x.Value == listItem.OverallAchievementRate); 
+                    var scoreValue = GetAchievementRateScore((float)(score?.Proportion??0));
+                
+                    _providerScores[listItem.ProviderId] += scoreValue;
+                
+                }    
+            }
+            
 
             foreach (var listItem in getTrainingCourseProviderListItems.Where(c => !c.OverallAchievementRate.HasValue))
             {

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api/Extensions/TrainingCourseProviderOrderByExtension.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api/Extensions/TrainingCourseProviderOrderByExtension.cs
@@ -95,7 +95,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Extensions
                 .Where(providerFilter)
                 .OrderByDescending(c=>c.Score)
                 .ThenBy(c=>c.DeliveryModes
-                    .OrderByDescending(x=>x.DistanceInMiles)
+                    .OrderBy(x=>x.DistanceInMiles)
                     .First().DistanceInMiles)
                 .ThenByDescending(c=>c.OverallAchievementRate)
                 .ThenByDescending(c=>c.OverallCohort)

--- a/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/TrainingCourses/Queries/WhenGettingProvidersByTrainingCourse.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/TrainingCourses/Queries/WhenGettingProvidersByTrainingCourse.cs
@@ -34,7 +34,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
             mockApiClient
                 .Setup(client => client.Get<GetProvidersListResponse>(It.Is<GetProvidersByCourseRequest>(c=>
                     c.GetUrl.Contains(query.Id.ToString()) 
-                    && c.GetUrl.Contains($"sectorSubjectArea={apiCourseResponse.SectorSubjectAreaTier2Description}")
+                    && c.GetUrl.Contains($"sectorSubjectArea={apiCourseResponse.SectorSubjectAreaTier2Description}&level={apiCourseResponse.Level}")
                 )))
                 .ReturnsAsync(apiResponse);
             mockCoursesApiClient

--- a/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/TrainingCourses/Queries/WhenGettingProvidersByTrainingCourse.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/TrainingCourses/Queries/WhenGettingProvidersByTrainingCourse.cs
@@ -28,6 +28,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
             [Frozen] Mock<ICourseDeliveryApiClient<CourseDeliveryApiConfiguration>> mockApiClient,
             GetTrainingCourseProvidersQueryHandler handler)
         {
+            apiCourseResponse.Level = 1;
             query.Location = "";
             query.Lat = 0;
             query.Lon = 0;

--- a/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/InnerApi/Requests/WhenBuildingTheGetProvidersByCourseRequest.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/InnerApi/Requests/WhenBuildingTheGetProvidersByCourseRequest.cs
@@ -8,19 +8,32 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.InnerApi.Requests
     public class WhenBuildingTheGetProvidersByCourseRequest
     {
         [Test, AutoData]
-        public void Then_The_Url_Is_Correctly_Built(int courseId, double latitude, double longitude, int sortOrder, string sectorSubjectArea, short level)
+        public void Then_The_Url_Is_Correctly_Built(int courseId, double latitude, double longitude, int sortOrder, string sectorSubjectArea)
         {
+            var level = 1;
             var actual = new GetProvidersByCourseRequest(courseId, sectorSubjectArea,level, latitude, longitude, sortOrder);
 
             actual.GetUrl.Should().Be($"api/courses/{courseId}/providers?lat={latitude}&lon={longitude}&sortOrder={sortOrder}&sectorSubjectArea={sectorSubjectArea}&level={level}");
         }
 
         [Test, AutoData]
-        public void Then_The_Url_Is_Correctly_Built_With_No_Location(int courseId, string sectorSubjectArea, short level)
+        public void Then_The_Url_Is_Correctly_Built_With_No_Location(int courseId, string sectorSubjectArea)
         {
+            var level = 1;
             var actual = new GetProvidersByCourseRequest(courseId, sectorSubjectArea, level);
 
             actual.GetUrl.Should().Be($"api/courses/{courseId}/providers?lat=&lon=&sortOrder=0&sectorSubjectArea={sectorSubjectArea}&level={level}");
+        }
+
+        [Test]
+        [InlineAutoData(5,"1")]
+        [InlineAutoData(3,"3")]
+        [InlineAutoData(4,"1")]
+        public void Then_Maps_The_Level_Correctly(int level, string expectedLevel, int courseId, string sectorSubjectArea)
+        {
+            var actual = new GetProvidersByCourseRequest(courseId, sectorSubjectArea, level);
+            
+            actual.GetUrl.Should().Be($"api/courses/{courseId}/providers?lat=&lon=&sortOrder=0&sectorSubjectArea={sectorSubjectArea}&level={expectedLevel}");
         }
     }
 }

--- a/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/InnerApi/Requests/WhenBuildingTheGetProvidersByCourseRequest.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/InnerApi/Requests/WhenBuildingTheGetProvidersByCourseRequest.cs
@@ -8,19 +8,19 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.InnerApi.Requests
     public class WhenBuildingTheGetProvidersByCourseRequest
     {
         [Test, AutoData]
-        public void Then_The_Url_Is_Correctly_Built(int courseId, double latitude, double longitude, int sortOrder, string sectorSubjectArea)
+        public void Then_The_Url_Is_Correctly_Built(int courseId, double latitude, double longitude, int sortOrder, string sectorSubjectArea, short level)
         {
-            var actual = new GetProvidersByCourseRequest(courseId, sectorSubjectArea, latitude, longitude, sortOrder);
+            var actual = new GetProvidersByCourseRequest(courseId, sectorSubjectArea,level, latitude, longitude, sortOrder);
 
-            actual.GetUrl.Should().Be($"api/courses/{courseId}/providers?lat={latitude}&lon={longitude}&sortOrder={sortOrder}&sectorSubjectArea={sectorSubjectArea}");
+            actual.GetUrl.Should().Be($"api/courses/{courseId}/providers?lat={latitude}&lon={longitude}&sortOrder={sortOrder}&sectorSubjectArea={sectorSubjectArea}&level={level}");
         }
 
         [Test, AutoData]
-        public void Then_The_Url_Is_Correctly_Built_With_No_Location(int courseId, string sectorSubjectArea)
+        public void Then_The_Url_Is_Correctly_Built_With_No_Location(int courseId, string sectorSubjectArea, short level)
         {
-            var actual = new GetProvidersByCourseRequest(courseId, sectorSubjectArea);
+            var actual = new GetProvidersByCourseRequest(courseId, sectorSubjectArea, level);
 
-            actual.GetUrl.Should().Be($"api/courses/{courseId}/providers?lat=&lon=&sortOrder=0&sectorSubjectArea={sectorSubjectArea}");
+            actual.GetUrl.Should().Be($"api/courses/{courseId}/providers?lat=&lon=&sortOrder=0&sectorSubjectArea={sectorSubjectArea}&level={level}");
         }
     }
 }

--- a/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCourseProviders/GetTrainingCourseProvidersQueryHandler.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCourseProviders/GetTrainingCourseProvidersQueryHandler.cs
@@ -1,14 +1,9 @@
-using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using SFA.DAS.FindApprenticeshipTraining.Configuration;
-using SFA.DAS.FindApprenticeshipTraining.Domain.Models;
 using SFA.DAS.FindApprenticeshipTraining.InnerApi.Requests;
 using SFA.DAS.FindApprenticeshipTraining.InnerApi.Responses;
-using SFA.DAS.FindApprenticeshipTraining.Interfaces;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Interfaces;
 
@@ -37,7 +32,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.TrainingCourses.Queries
 
             await Task.WhenAll(locationTask, courseTask);
             
-            var providers = await _courseDeliveryApiClient.Get<GetProvidersListResponse>(new GetProvidersByCourseRequest(request.Id, courseTask.Result.SectorSubjectAreaTier2Description,locationTask.Result?.GeoPoint?.FirstOrDefault(), locationTask.Result?.GeoPoint?.LastOrDefault(), request.SortOrder));
+            var providers = await _courseDeliveryApiClient.Get<GetProvidersListResponse>(new GetProvidersByCourseRequest(request.Id, courseTask.Result.SectorSubjectAreaTier2Description, courseTask.Result.Level,locationTask.Result?.GeoPoint?.FirstOrDefault(), locationTask.Result?.GeoPoint?.LastOrDefault(), request.SortOrder));
             
             return new GetTrainingCourseProvidersResult
             {

--- a/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Requests/GetProvidersByCourseRequest.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Requests/GetProvidersByCourseRequest.cs
@@ -11,6 +11,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.InnerApi.Requests
         private readonly string _sectorSubjectArea;
         private readonly int _level;
 
+        private const short AllLevels = 1;
         public GetProvidersByCourseRequest (  int id,  string sectorSubjectArea, int level, double? latitude = null, double? longitude = null, int sortOrder = 0)
         {
             _latitude = latitude;
@@ -19,6 +20,10 @@ namespace SFA.DAS.FindApprenticeshipTraining.InnerApi.Requests
             _courseId = id;
             _sectorSubjectArea = sectorSubjectArea;
             _level = level;
+            if (level > 3)
+            {
+                _level = AllLevels;
+            }
         }
         
         public string GetUrl => $"api/courses/{_courseId}/providers?lat={_latitude}&lon={_longitude}&sortOrder={_sortOrder}&sectorSubjectArea={_sectorSubjectArea}&level={_level}";

--- a/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Requests/GetProvidersByCourseRequest.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Requests/GetProvidersByCourseRequest.cs
@@ -9,16 +9,18 @@ namespace SFA.DAS.FindApprenticeshipTraining.InnerApi.Requests
         private readonly int _sortOrder;
         private readonly int _courseId;
         private readonly string _sectorSubjectArea;
+        private readonly int _level;
 
-        public GetProvidersByCourseRequest (  int id,  string sectorSubjectArea, double? latitude = null, double? longitude = null, int sortOrder = 0)
+        public GetProvidersByCourseRequest (  int id,  string sectorSubjectArea, int level, double? latitude = null, double? longitude = null, int sortOrder = 0)
         {
             _latitude = latitude;
             _longitude = longitude;
             _sortOrder = sortOrder;
             _courseId = id;
             _sectorSubjectArea = sectorSubjectArea;
+            _level = level;
         }
         
-        public string GetUrl => $"api/courses/{_courseId}/providers?lat={_latitude}&lon={_longitude}&sortOrder={_sortOrder}&sectorSubjectArea={_sectorSubjectArea}";
+        public string GetUrl => $"api/courses/{_courseId}/providers?lat={_latitude}&lon={_longitude}&sortOrder={_sortOrder}&sectorSubjectArea={_sectorSubjectArea}&level={_level}";
     }
 }


### PR DESCRIPTION
When there is only one percentile value in a range of providers that now gets 4pts. 
When they are tied on score, then the pass rate is also used to determine the order