### PR TITLE
FAT2-334 Change so that it takes name of sector instead of id

### DIFF
--- a/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/TrainingCourses/WhenCallingGetTrainingCoursesList.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/TrainingCourses/WhenCallingGetTrainingCoursesList.cs
@@ -51,7 +51,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Controllers.TrainingC
         public async Task Then_Gets_Training_Courses_From_Mediator_With_Keyword_And_RouteIds_And_Levels_And_OrderBy_If_Supplied(
             string keyword,
             List<int> levels,
-            List<Guid> routeIds,
+            List<string> routeIds,
             GetTrainingCoursesListResult mediatorResult,
             [Frozen] Mock<IMediator> mockMediator,
             [Greedy]TrainingCoursesController controller)

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api/Controllers/TrainingCoursesController.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api/Controllers/TrainingCoursesController.cs
@@ -33,7 +33,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetList( [FromQuery] string keyword = "", [FromQuery] List<Guid> routeIds = null, [FromQuery]List<int> levels = null, [FromQuery]string orderBy = "relevance")
+        public async Task<IActionResult> GetList( [FromQuery] string keyword = "", [FromQuery] List<string> routeIds = null, [FromQuery]List<int> levels = null, [FromQuery]string orderBy = "relevance")
         {
             try
             {

--- a/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCoursesList/GetTrainingCoursesListQuery.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCoursesList/GetTrainingCoursesListQuery.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.TrainingCourses.Queries
     public class GetTrainingCoursesListQuery : IRequest<GetTrainingCoursesListResult>
     {
         public string Keyword { get ; set ; }
-        public List<Guid> RouteIds { get ; set ; }
+        public List<string> RouteIds { get ; set ; }
         public List<int> Levels { get ; set ; }
         public OrderBy OrderBy { get; set; }
     }

--- a/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCoursesList/GetTrainingCoursesListQueryHandler.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCoursesList/GetTrainingCoursesListQueryHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -31,10 +32,19 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.TrainingCourses.Queries
         public async Task<GetTrainingCoursesListResult> Handle(GetTrainingCoursesListQuery request, CancellationToken cancellationToken)
         {
             _taskList = new List<Task>();
+            
+            var sectors = await _cacheHelper.GetRequest<GetSectorsListResponse>(_apiClient,
+                new GetSectorsListRequest(),nameof(GetSectorsListResponse), out _saveSectorsToCache);
+
+            var routeFilters = sectors
+                .Sectors
+                .Where(c=>request.RouteIds.Contains(c.Route)).Select(x=>x.Id)
+                .ToList();
+            
             var standardsRequest = new GetStandardsListRequest
             {
                 Keyword = request.Keyword,
-                RouteIds = request.RouteIds,
+                RouteIds = routeFilters,
                 Levels = request.Levels,
                 OrderBy = request.OrderBy
             };
@@ -54,16 +64,12 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.TrainingCourses.Queries
                     new GetStandardsListRequest
                 {
                     Keyword = request.Keyword,
-                    RouteIds = request.RouteIds,
+                    RouteIds = routeFilters,
                     Levels = request.Levels,
                     OrderBy = request.OrderBy
                 }, nameof(GetStandardsListResponse), out _saveStandardsToCache);
                 _taskList.Add(standardsTask);
             }
-
-            var sectorsTask = _cacheHelper.GetRequest<GetSectorsListResponse>(_apiClient,
-                new GetSectorsListRequest(),nameof(GetSectorsListResponse), out _saveSectorsToCache);
-           _taskList.Add(sectorsTask);
 
             var levelsTask = _cacheHelper.GetRequest<GetLevelsListResponse>(_apiClient,
                 new GetLevelsListRequest(), nameof(GetLevelsListResponse), out _saveLevelsToCache);
@@ -71,13 +77,13 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.TrainingCourses.Queries
             
             await Task.WhenAll(_taskList);
 
-            await _cacheHelper.UpdateCachedItems(sectorsTask, levelsTask, standardsTask, 
+            await _cacheHelper.UpdateCachedItems(Task.FromResult(sectors), levelsTask, standardsTask, 
                 new CacheHelper.SaveToCache{Levels = _saveLevelsToCache, Sectors = _saveSectorsToCache, Standards = _saveStandardsToCache});
             
             return new GetTrainingCoursesListResult
             {
                 Courses = standardsTask.Result.Standards,
-                Sectors = sectorsTask.Result.Sectors,
+                Sectors = sectors.Sectors,
                 Levels = levelsTask.Result.Levels,
                 Total = standardsTask.Result.Total,
                 TotalFiltered = standardsTask.Result.TotalFiltered,


### PR DESCRIPTION
The course search filtering now accepts the name of the sector and looks up the Id from the list of sectors