### PR TITLE
Updated das-platform-building-blocks tag from 0.2.6 to 0.3.3 and enable PR triggered builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/0.2.6
+    ref: refs/tags/0.3.3
     endpoint: GitHub (SFA)
   - repository: das-platform-automation
     type: github

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,8 +32,6 @@ trigger:
     include:
       - "*"
 
-pr: none
-
 variables:
 - group: Release Management Resources
 - group: Wildcard Cert Variables v2


### PR DESCRIPTION
Updated das-platform-building-blocks tag from 0.2.6 to 0.3.3 and enable PR triggered builds

Dependency Check task will only run on pull request triggered builds