### PR TITLE
FAT2-403 - Change so that empty list returned instead of 404

### DIFF
--- a/src/SFA.DAS.EpaoRegister.Api.UnitTests/Models/GetEpaoCoursesModelTests/WhenCastingGetEpaoCoursesApiModelFromMediatorType.cs
+++ b/src/SFA.DAS.EpaoRegister.Api.UnitTests/Models/GetEpaoCoursesModelTests/WhenCastingGetEpaoCoursesApiModelFromMediatorType.cs
@@ -5,20 +5,30 @@ using FluentAssertions;
 using NUnit.Framework;
 using SFA.DAS.EpaoRegister.Api.Models;
 using SFA.DAS.EpaoRegister.Application.Epaos.Queries.GetEpaoCourses;
-using SFA.DAS.SharedOuterApi.Models;
+using SFA.DAS.EpaoRegister.InnerApi.Responses;
 
 namespace SFA.DAS.EpaoRegister.Api.UnitTests.Models.GetEpaoCoursesModelTests
 {
     public class WhenCastingGetEpaoCoursesApiModelFromMediatorType
     {
         [Test, AutoData]
-        public void Then_Maps_Fields_Appropriately(
-            GetEpaoCoursesResult source)
+        public void Then_Maps_Fields_Appropriately(GetEpaoCoursesResult source)
         {
             var response = (GetEpaoCoursesApiModel)source;
 
             response.EpaoId.Should().BeEquivalentTo(source.EpaoId);
             response.Courses.Count().Should().Be(source.Courses.Count);
+        }
+
+        [Test, AutoData]
+        public void Then_Maps_An_Empty_List(GetEpaoCoursesResult source)
+        {
+            source.Courses = new List<GetStandardResponse>();
+            
+            var response = (GetEpaoCoursesApiModel)source;
+
+            response.EpaoId.Should().BeEquivalentTo(source.EpaoId);
+            response.Courses.Should().BeEmpty();
         }
 
         [Test]

--- a/src/SFA.DAS.EpaoRegister.UnitTests/Application/Epaos/Queries/WhenHandlingGetEpaoCoursesQuery.cs
+++ b/src/SFA.DAS.EpaoRegister.UnitTests/Application/Epaos/Queries/WhenHandlingGetEpaoCoursesQuery.cs
@@ -42,7 +42,7 @@ namespace SFA.DAS.EpaoRegister.UnitTests.Application.Epaos.Queries
         }
 
         [Test, MoqAutoData]
-        public void And_No_Epao_Courses_Then_Throws_NotFoundException(
+        public async Task And_No_Epao_Courses_Then_Returns_Empty_List(
             GetEpaoCoursesQuery query,
             [Frozen] Mock<IAssessorsApiClient<AssessorsApiConfiguration>> mockAssessorsApiClient,
             GetEpaoCoursesQueryHandler handler)
@@ -52,9 +52,9 @@ namespace SFA.DAS.EpaoRegister.UnitTests.Application.Epaos.Queries
                     It.Is<GetEpaoCoursesRequest>(request => request.EpaoId == query.EpaoId)))
                 .ReturnsAsync(new List<GetEpaoCoursesListItem>());
 
-            Func<Task> act = async () => await handler.Handle(query, CancellationToken.None);
+            var actual = await handler.Handle(query, CancellationToken.None);
 
-            act.Should().Throw<NotFoundException<GetEpaoCoursesResult>>();
+            actual.Courses.Should().BeEmpty();
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.EpaoRegister/Application/Epaos/Queries/GetEpaoCourses/GetEpaoCoursesQueryHandler.cs
+++ b/src/SFA.DAS.EpaoRegister/Application/Epaos/Queries/GetEpaoCourses/GetEpaoCoursesQueryHandler.cs
@@ -48,7 +48,11 @@ namespace SFA.DAS.EpaoRegister.Application.Epaos.Queries.GetEpaoCourses
 
             if (epaoCourses == null || epaoCourses.Count == 0)
             {
-                throw new NotFoundException<GetEpaoCoursesResult>();
+                return new GetEpaoCoursesResult
+                {
+                    EpaoId = request.EpaoId,
+                    Courses = new List<GetStandardResponse>()
+                };
             }
 
             var courses = await _cacheStorageService.RetrieveFromCache<GetStandardsListResponse>(


### PR DESCRIPTION
If there are no standards for a provider this was returning a 404 response. now it returns an empty list instead