### PR TITLE
SV-444 Added postman test collection for standards endpoint in all apis

### DIFF
--- a/IntegrationTests/Outer API Tests For Standards.postman_collection.json
+++ b/IntegrationTests/Outer API Tests For Standards.postman_collection.json
@@ -1,0 +1,706 @@
+{
+	"info": {
+		"_postman_id": "0e78b910-0aeb-4332-a683-03d3b4f78b05",
+		"name": "Outer API Tests For Standards",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Courses - Authenticate",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200, 201, 202]);\r",
+							"});\r",
+							"\r",
+							"var jsonData = pm.response.json();\r",
+							"pm.environment.set(\"authToken\", jsonData.access_token);\r",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/x-www-form-urlencoded",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"key": "grant_type",
+							"value": "client_credentials",
+							"type": "text"
+						},
+						{
+							"key": "client_id",
+							"value": "{{courses-api-client-id}}",
+							"type": "text"
+						},
+						{
+							"key": "client_secret",
+							"value": "{{courses-api-client-secret}}",
+							"type": "text"
+						},
+						{
+							"key": "resource",
+							"value": "{{courses-api-resource}}",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "https://login.microsoftonline.com/{{courses-api-tenant}}/oauth2/token",
+					"protocol": "https",
+					"host": [
+						"login",
+						"microsoftonline",
+						"com"
+					],
+					"path": [
+						"{{courses-api-tenant}}",
+						"oauth2",
+						"token"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Courses - Get List - Active Available",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"var jsonData = pm.response.json();\r",
+							"pm.environment.set(\"m_activeAvailableCount\", jsonData.totalFiltered);\r",
+							"pm.environment.set(\"m_larsCode\", jsonData.standards[0].larsCode);\r",
+							"pm.environment.set(\"m_title\", jsonData.standards[0].title);\r",
+							"pm.environment.set(\"m_level\", jsonData.standards[0].level);\r",
+							"pm.environment.set(\"m_route\", jsonData.standards[0].route);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"user-agent": true,
+					"accept-encoding": true,
+					"connection": true,
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "X-Version",
+						"value": "1.0",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{courses-api-base-url}}/Standards?filter=ActiveAvailable",
+					"host": [
+						"{{courses-api-base-url}}"
+					],
+					"path": [
+						"Standards"
+					],
+					"query": [
+						{
+							"key": "filter",
+							"value": "ActiveAvailable"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Courses - Get List - Active",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"var jsonData = pm.response.json();\r",
+							"pm.environment.set(\"m_activeCount\", jsonData.totalFiltered);\r",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {
+					"user-agent": true,
+					"accept-encoding": true,
+					"connection": true,
+					"accept": true
+				}
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{authToken}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "X-Version",
+						"value": "1.0",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{courses-api-base-url}}/Standards?filter=Active",
+					"host": [
+						"{{courses-api-base-url}}"
+					],
+					"path": [
+						"Standards"
+					],
+					"query": [
+						{
+							"key": "filter",
+							"value": "Active"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Standards - Approvals",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Array matches count\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.trainingCourses.length).to.eql(pm.variables.get(\"m_activeAvailableCount\"));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Body matches string\", function () {\r",
+							"    var expectedValue = \"\\\"id\\\":\" + pm.variables.get(\"m_larsCode\");\r",
+							"    expectedValue += \",\\\"title\\\":\\\"\" + pm.variables.get(\"m_title\");\r",
+							"    expectedValue += \"\\\",\\\"level\\\":\" + pm.variables.get(\"m_level\");\r",
+							"    pm.expect(pm.response.text()).to.include(expectedValue);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{apim-subscription-key}}",
+						"description": "This key is provided by DevOps which authenticates the APIM gateway.  ",
+						"type": "text"
+					},
+					{
+						"key": "X-Version",
+						"value": "1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{apim-base-url}}/findapprenticeshiptraining/TrainingCourses",
+					"host": [
+						"{{apim-base-url}}"
+					],
+					"path": [
+						"findapprenticeshiptraining",
+						"TrainingCourses"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Standards - Assessors",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Array matches count\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.courses.length).to.eql(pm.variables.get(\"m_activeCount\"));\r",
+							"});\r",
+							"\r",
+							"// This test should be enabled after SV-372 is merged\r",
+							"// pm.test(\"Body matches string\", function () {\r",
+							"//     var expectedValue = \"\\\"id\\\":\" + pm.variables.get(\"m_larsCode\");\r",
+							"//     expectedValue += \",\\\"title\\\":\\\"\" + pm.variables.get(\"m_title\");\r",
+							"//     expectedValue += \"\\\",\\\"level\\\":\" + pm.variables.get(\"m_level\");\r",
+							"//     pm.expect(pm.response.text()).to.include(expectedValue);\r",
+							"// });\r",
+							"\r",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{apim-subscription-key}}",
+						"description": "This key is provided by DevOps which authenticates the APIM gateway.  ",
+						"type": "text"
+					},
+					{
+						"key": "X-Version",
+						"value": "1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{apim-base-url}}/assessors/TrainingCourses",
+					"host": [
+						"{{apim-base-url}}"
+					],
+					"path": [
+						"assessors",
+						"TrainingCourses"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Standards - Campaign",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Body matches string\", function () {\r",
+							"    var expectedValue = \"\\\"id\\\":\" + pm.variables.get(\"m_larsCode\");\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{apim-subscription-key}}",
+						"description": "This key is provided by DevOps which authenticates the APIM gateway.  ",
+						"type": "text"
+					},
+					{
+						"key": "X-Version",
+						"value": "1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{apim-base-url}}/campaign/TrainingCourses?sector={{m_route}}",
+					"host": [
+						"{{apim-base-url}}"
+					],
+					"path": [
+						"campaign",
+						"TrainingCourses"
+					],
+					"query": [
+						{
+							"key": "sector",
+							"value": "{{m_route}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Standards - FAT",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Array matches count\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.trainingCourses.length).to.eql(pm.variables.get(\"m_activeAvailableCount\"));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Body matches string\", function () {\r",
+							"    var expectedValue = \"\\\"id\\\":\" + pm.variables.get(\"m_larsCode\");\r",
+							"    expectedValue += \",\\\"title\\\":\\\"\" + pm.variables.get(\"m_title\");\r",
+							"    expectedValue += \"\\\",\\\"level\\\":\" + pm.variables.get(\"m_level\");\r",
+							"    pm.expect(pm.response.text()).to.include(expectedValue);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{apim-subscription-key}}",
+						"description": "This key is provided by DevOps which authenticates the APIM gateway.  ",
+						"type": "text"
+					},
+					{
+						"key": "X-Version",
+						"value": "1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{apim-base-url}}/findapprenticeshiptraining/TrainingCourses",
+					"host": [
+						"{{apim-base-url}}"
+					],
+					"path": [
+						"findapprenticeshiptraining",
+						"TrainingCourses"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Standards - Find EPAO",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Array matches count\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.courses.length).to.eql(pm.variables.get(\"m_activeCount\"));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Body matches string\", function () {\r",
+							"    var expectedValue = \"\\\"title\\\":\\\"\" + pm.variables.get(\"m_title\");\r",
+							"    expectedValue += \"\\\",\\\"level\\\":\" + pm.variables.get(\"m_level\");\r",
+							"    expectedValue += \",\\\"id\\\":\" + pm.variables.get(\"m_larsCode\");\r",
+							"    pm.expect(pm.response.text()).to.include(expectedValue);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{apim-subscription-key}}",
+						"description": "This key is provided by DevOps which authenticates the APIM gateway.  ",
+						"type": "text"
+					},
+					{
+						"key": "X-Version",
+						"value": "1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{apim-base-url}}/findepao/courses",
+					"host": [
+						"{{apim-base-url}}"
+					],
+					"path": [
+						"findepao",
+						"courses"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Standards - Forecasting",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Array matches count\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.standards.length).to.eql(pm.variables.get(\"m_activeAvailableCount\"));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Body matches string\", function () {\r",
+							"    var expectedValue = \"\\\"id\\\":\\\"\" + pm.variables.get(\"m_larsCode\");\r",
+							"    expectedValue += \"\\\",\\\"title\\\":\\\"\" + pm.variables.get(\"m_title\");\r",
+							"    pm.expect(pm.response.text()).to.include(expectedValue);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{apim-subscription-key}}",
+						"description": "This key is provided by DevOps which authenticates the APIM gateway.  ",
+						"type": "text"
+					},
+					{
+						"key": "X-Version",
+						"value": "1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{apim-base-url}}/forecasting/Courses/standards",
+					"host": [
+						"{{apim-base-url}}"
+					],
+					"path": [
+						"forecasting",
+						"Courses",
+						"standards"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Standards - MA",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Array matches count\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.standards.length).to.eql(pm.variables.get(\"m_activeCount\"));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Body matches string\", function () {\r",
+							"    var expectedValue = \"\\\"id\\\":\" + pm.variables.get(\"m_larsCode\");\r",
+							"    expectedValue += \",\\\"level\\\":\" + pm.variables.get(\"m_level\");\r",
+							"    expectedValue += \",\\\"title\\\":\\\"\" + pm.variables.get(\"m_title\");\r",
+							"    pm.expect(pm.response.text()).to.include(expectedValue);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{apim-subscription-key}}",
+						"description": "This key is provided by DevOps which authenticates the APIM gateway.  ",
+						"type": "text"
+					},
+					{
+						"key": "X-Version",
+						"value": "1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{apim-base-url}}/manageapprenticeships/TrainingCourses/standards",
+					"host": [
+						"{{apim-base-url}}"
+					],
+					"path": [
+						"manageapprenticeships",
+						"TrainingCourses",
+						"standards"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Standards - Recruit",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Body matches string\", function () {\r",
+							"    var expectedValue = \"\\\"id\\\":\\\"\" + pm.variables.get(\"m_larsCode\");\r",
+							"    expectedValue += \"\\\",\\\"apprenticeshipType\\\":0,\";\r",
+							"    expectedValue += \"\\\"title\\\":\\\"\" + pm.variables.get(\"m_title\");\r",
+							"    pm.expect(pm.response.text()).to.include(expectedValue);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{apim-subscription-key}}",
+						"description": "This key is provided by DevOps which authenticates the APIM gateway.  ",
+						"type": "text"
+					},
+					{
+						"key": "X-Version",
+						"value": "1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{apim-base-url}}/recruit/trainingprogrammes",
+					"host": [
+						"{{apim-base-url}}"
+					],
+					"path": [
+						"recruit",
+						"trainingprogrammes"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Standards - Reservations",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Successful POST request\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Array matches count\", function () {\r",
+							"    var jsonData = pm.response.json();\r",
+							"    pm.expect(jsonData.standards.length).to.eql(pm.variables.get(\"m_activeAvailableCount\"));\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Body matches string\", function () {\r",
+							"    var expectedValue = \"\\\"title\\\":\\\"\" + pm.variables.get(\"m_title\");\r",
+							"    expectedValue += \"\\\",\\\"level\\\":\" + pm.variables.get(\"m_level\");\r",
+							"    expectedValue += \",\\\"id\\\":\" + pm.variables.get(\"m_larsCode\");\r",
+							"    pm.expect(pm.response.text()).to.include(expectedValue);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Ocp-Apim-Subscription-Key",
+						"value": "{{apim-subscription-key}}",
+						"description": "This key is provided by DevOps which authenticates the APIM gateway.  ",
+						"type": "text"
+					},
+					{
+						"key": "X-Version",
+						"value": "1",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{apim-base-url}}/reservations/TrainingCourses",
+					"host": [
+						"{{apim-base-url}}"
+					],
+					"path": [
+						"reservations",
+						"TrainingCourses"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/IntegrationTests/Outer API Tests For Standards.postman_environment.json
+++ b/IntegrationTests/Outer API Tests For Standards.postman_environment.json
@@ -1,0 +1,49 @@
+{
+	"id": "12cbe017-af61-4ce5-b734-2f6a057ccfad",
+	"name": "Test",
+	"values": [
+		{
+			"key": "test-environment",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "courses-api-client-id",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "courses-api-client-secret",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "courses-api-resource",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "courses-api-tenant",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "courses-api-base-url",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "apim-subscription-key",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "apim-base-url",
+			"value": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2021-02-16T17:08:35.552Z",
+	"_postman_exported_using": "Postman/8.0.5"
+}

--- a/src/SFA.DAS.Approvals.Api.UnitTests/Models/WhenMappingGetStandardResponseFromMediatorResponse.cs
+++ b/src/SFA.DAS.Approvals.Api.UnitTests/Models/WhenMappingGetStandardResponseFromMediatorResponse.cs
@@ -19,12 +19,14 @@ namespace SFA.DAS.Approvals.Api.UnitTests.Models
                 .Excluding(c=>c.StandardDates)
                 .Excluding(c=>c.TypicalDuration)
                 .Excluding(c=>c.IsActive)
+                .Excluding(c => c.StandardUId)
+                .Excluding(c => c.LarsCode)
             );
             actual.EffectiveFrom.Should().Be(source.StandardDates.EffectiveFrom);
             actual.EffectiveTo.Should().Be(source.StandardDates.EffectiveTo);
             actual.LastDateForNewStarts.Should().Be(source.StandardDates.LastDateStarts);
             actual.Duration.Should().Be(source.TypicalDuration);
-
+            actual.Id.Should().Be(source.LarsCode);
         }
     }
 }

--- a/src/SFA.DAS.Approvals.Api/Models/GetStandardResponse.cs
+++ b/src/SFA.DAS.Approvals.Api/Models/GetStandardResponse.cs
@@ -22,7 +22,7 @@ namespace SFA.DAS.Approvals.Api.Models
         {
             return new GetStandardResponse
             {
-                Id = source.Id,
+                Id = source.LarsCode,
                 Title = source.Title,
                 Level = source.Level,
                 Duration = source.TypicalDuration,

--- a/src/SFA.DAS.Approvals/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Approvals/InnerApi/Responses/GetStandardsListItem.cs
@@ -6,7 +6,6 @@ namespace SFA.DAS.Approvals.InnerApi.Responses
     {
         public string StandardUId { get; set; }
         public int LarsCode { get; set; }
-
         public string Title { get; set; }
         public int Level { get; set; }
     }

--- a/src/SFA.DAS.Approvals/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Approvals/InnerApi/Responses/GetStandardsListItem.cs
@@ -4,7 +4,9 @@ namespace SFA.DAS.Approvals.InnerApi.Responses
 {
     public class GetStandardsListItem : StandardApiResponseBase
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
+
         public string Title { get; set; }
         public int Level { get; set; }
     }

--- a/src/SFA.DAS.Assessors.Api/Models/GetCourseListItem.cs
+++ b/src/SFA.DAS.Assessors.Api/Models/GetCourseListItem.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.Assessors.Api.Models
         {
             return new GetCourseListItem
             {
-                Id = source.Id,
+                Id = source.LarsCode,
                 Title = source.Title,
                 Level = source.Level,
                 MaxFunding = source.MaxFunding,

--- a/src/SFA.DAS.Assessors.Api/Models/GetCourseListItem.cs
+++ b/src/SFA.DAS.Assessors.Api/Models/GetCourseListItem.cs
@@ -5,25 +5,60 @@ namespace SFA.DAS.Assessors.Api.Models
 {
     public class GetCourseListItem
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
+        public string IFateReferenceNumber { get; set; }
         public string Title { get; set; }
         public int Level { get; set; }
+        public string Route { get; set; }
+        public string Status { get; set; }
+        public DateTime? EarliestStartDate { get; set; }
+        public DateTime? LatestStartDate { get; set; }
+        public DateTime? LatestEndDate { get; set; }
+        public DateTime? ApprovedForDelivery { get; set; }
         public int MaxFunding { get; set; }
         public int TypicalDuration { get; set; }
         public bool IsActive { get; set; }
         public StandardDate StandardDates { get; set; }
+        public string EqaProviderName { get; set; }
+        public string EqaProviderContactName { get; set; }
+        public string EqaProviderContactEmail { get; set; }
+        public string EqaProviderWebLink { get; set; }
+        public string IntegratedDegree { get; set; }
+        public string TrailBlazerContact { get; set; }
+        public string OverviewOfRole { get; set; }
+        public string AssessmentPlanUrl { get; set; }
+        public string StandardPageUrl { get; set; }
+
 
         public static implicit operator GetCourseListItem(GetStandardsListItem source)
         {
             return new GetCourseListItem
             {
-                Id = source.LarsCode,
+                StandardUId = source.StandardUId,
+                LarsCode = source.LarsCode,
+                IFateReferenceNumber = source.IFateReferenceNumber,
                 Title = source.Title,
                 Level = source.Level,
+                Route = source.Route,
+                Status = source.Status,
+                EarliestStartDate = source.EarliestStartDate,
+                LatestStartDate = source.LatestStartDate,
+                LatestEndDate = source.LatestEndDate,
+                ApprovedForDelivery = source.ApprovedForDelivery,
                 MaxFunding = source.MaxFunding,
                 TypicalDuration = source.TypicalDuration,
                 IsActive = source.IsActive,
-                StandardDates = source.StandardDates
+                StandardDates = source.StandardDates,
+                EqaProviderContactEmail = source.EqaProviderContactEmail,
+                EqaProviderContactName = source.EqaProviderContactName,
+                EqaProviderName = source.EqaProviderName,
+                EqaProviderWebLink = source.EqaProviderWebLink,
+                IntegratedDegree = source.IntegratedDegree,
+                TrailBlazerContact = source.TrailBlazerContact,
+                OverviewOfRole = source.OverviewOfRole,
+                AssessmentPlanUrl = source.AssessmentPlanUrl,
+                StandardPageUrl = source.StandardPageUrl
             };
         }
 
@@ -37,12 +72,13 @@ namespace SFA.DAS.Assessors.Api.Models
 
             public static implicit operator StandardDate(SharedOuterApi.InnerApi.Responses.StandardDate source)
             {
-                return new StandardDate
-                {
-                    EffectiveFrom = source.EffectiveFrom,
-                    EffectiveTo = source.EffectiveTo,
-                    LastDateStarts = source.LastDateStarts
-                };
+                return source == null ? null :
+                    new StandardDate
+                    {
+                        EffectiveFrom = source.EffectiveFrom,
+                        EffectiveTo = source.EffectiveTo,
+                        LastDateStarts = source.LastDateStarts
+                    };
             }
         }
     }

--- a/src/SFA.DAS.Assessors.UnitTests/Application/Queries/WhenHandlingGetTrainingCoursesQuery.cs
+++ b/src/SFA.DAS.Assessors.UnitTests/Application/Queries/WhenHandlingGetTrainingCoursesQuery.cs
@@ -5,9 +5,9 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.Assessors.Application.Queries.GetTrainingCourses;
+using SFA.DAS.Assessors.InnerApi.Requests;
 using SFA.DAS.Assessors.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Configuration;
-using SFA.DAS.SharedOuterApi.InnerApi.Requests;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.Testing.AutoFixture;
 
@@ -23,7 +23,7 @@ namespace SFA.DAS.Assessors.UnitTests.Application.Queries
             GetTrainingCoursesQueryHandler handler)
         {
             mockApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsRequest>()))
                 .ReturnsAsync(apiResponse);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.Assessors/Application/Queries/GetTrainingCourses/GetTrainingCoursesQueryHandler.cs
+++ b/src/SFA.DAS.Assessors/Application/Queries/GetTrainingCourses/GetTrainingCoursesQueryHandler.cs
@@ -1,9 +1,9 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using SFA.DAS.Assessors.InnerApi.Requests;
 using SFA.DAS.Assessors.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Configuration;
-using SFA.DAS.SharedOuterApi.InnerApi.Requests;
 using SFA.DAS.SharedOuterApi.Interfaces;
 
 namespace SFA.DAS.Assessors.Application.Queries.GetTrainingCourses
@@ -18,8 +18,7 @@ namespace SFA.DAS.Assessors.Application.Queries.GetTrainingCourses
         }
         public async Task<GetTrainingCoursesResult> Handle(GetTrainingCoursesQuery request, CancellationToken cancellationToken)
         {
-            var standardsList = await _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsListRequest());
-
+            var standardsList = await _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsRequest());
 
             return new GetTrainingCoursesResult
             {

--- a/src/SFA.DAS.Assessors/InnerApi/Requests/GetAllStandardsRequest.cs
+++ b/src/SFA.DAS.Assessors/InnerApi/Requests/GetAllStandardsRequest.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.Assessors.InnerApi.Requests
+{
+    public class GetAllStandardsRequest : IGetApiRequest
+    {
+        public string GetUrl => "api/courses/standards";
+    }
+}

--- a/src/SFA.DAS.Assessors/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Assessors/InnerApi/Responses/GetStandardsListItem.cs
@@ -1,4 +1,5 @@
 ﻿using SFA.DAS.SharedOuterApi.InnerApi.Responses;
+using System;
 
 namespace SFA.DAS.Assessors.InnerApi.Responses
 {
@@ -6,7 +7,23 @@ namespace SFA.DAS.Assessors.InnerApi.Responses
     {
         public string StandardUId { get; set; }
         public int LarsCode { get; set; }
+        public string IFateReferenceNumber { get; set; }
         public string Title { get; set; }
         public int Level { get; set; }
+        public string Route { get; set; }
+        public string Status { get; set; }
+        public DateTime? EarliestStartDate { get; set; }
+        public DateTime? LatestStartDate { get; set; }
+        public DateTime? LatestEndDate { get; set; }
+        public DateTime? ApprovedForDelivery { get; set; }
+        public string EqaProviderName { get; set; }
+        public string EqaProviderContactName { get; set; }
+        public string EqaProviderContactEmail { get; set; }
+        public string EqaProviderWebLink { get; set; }
+        public string IntegratedDegree { get; set; }
+        public string TrailBlazerContact { get; set; }
+        public string OverviewOfRole { get; set; }
+        public string AssessmentPlanUrl { get; set; }
+        public string StandardPageUrl { get; set; }
     }
 }

--- a/src/SFA.DAS.Assessors/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Assessors/InnerApi/Responses/GetStandardsListItem.cs
@@ -4,7 +4,8 @@ namespace SFA.DAS.Assessors.InnerApi.Responses
 {
     public class GetStandardsListItem : StandardApiResponseBase
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
         public string Title { get; set; }
         public int Level { get; set; }
     }

--- a/src/SFA.DAS.Campaign.Api.UnitTests/Controllers/TrainingCourses/WhenGettingStandardsBySector.cs
+++ b/src/SFA.DAS.Campaign.Api.UnitTests/Controllers/TrainingCourses/WhenGettingStandardsBySector.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,11 +25,11 @@ namespace SFA.DAS.Campaign.Api.UnitTests.Controllers.TrainingCourses
             string sector,
             GetStandardsQueryResult mediatorResult,
             [Frozen] Mock<IMediator> mockMediator,
-            [Greedy]TrainingCoursesController controller)
+            [Greedy] TrainingCoursesController controller)
         {
             mockMediator
                 .Setup(mediator => mediator.Send(
-                    It.Is<GetStandardsQuery>(c=>c.Sector.Equals(sector)),
+                    It.Is<GetStandardsQuery>(c => c.Sector.Equals(sector)),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mediatorResult);
 
@@ -37,13 +39,15 @@ namespace SFA.DAS.Campaign.Api.UnitTests.Controllers.TrainingCourses
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
             var model = controllerResult.Value as GetStandardsResponse;
             Assert.IsNotNull(model);
-            model.Standards.Should().BeEquivalentTo(mediatorResult.Standards, options => options);
+
+            var response = mediatorResult.Standards.Select(s => new GetStandardsResponseItem { Id = s.LarsCode });
+            model.Standards.Should().BeEquivalentTo(response);
         }
 
         [Test, MoqAutoData]
         public async Task And_Exception_Then_Returns_Bad_Request(
             [Frozen] Mock<IMediator> mockMediator,
-            [Greedy]TrainingCoursesController controller)
+            [Greedy] TrainingCoursesController controller)
         {
             mockMediator
                 .Setup(mediator => mediator.Send(

--- a/src/SFA.DAS.Campaign.Api.UnitTests/Models/WhenMappingGetStandardsResponseFromMediatorType.cs
+++ b/src/SFA.DAS.Campaign.Api.UnitTests/Models/WhenMappingGetStandardsResponseFromMediatorType.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.Campaign.Api.UnitTests.Models
             var actual = (GetStandardsResponseItem) source;
 
             //Assert
-            actual.Id.Should().Be(source.Id);
+            actual.Id.Should().Be(source.LarsCode);
         }
     }
 }

--- a/src/SFA.DAS.Campaign.Api/Models/GetStandardsResponse.cs
+++ b/src/SFA.DAS.Campaign.Api/Models/GetStandardsResponse.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.Campaign.Api.Models
         {
             return new GetStandardsResponseItem
             {
-                Id = source.Id
+                Id = source.LarsCode
             };
         }
     }

--- a/src/SFA.DAS.Campaign/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Campaign/InnerApi/Responses/GetStandardsListItem.cs
@@ -4,6 +4,5 @@
     {
         public string StandardUId { get; set; }
         public int LarsCode { get; set; }
-
     }
 }

--- a/src/SFA.DAS.Campaign/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Campaign/InnerApi/Responses/GetStandardsListItem.cs
@@ -2,6 +2,8 @@
 {
     public class GetStandardsListItem 
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
+
     }
 }

--- a/src/SFA.DAS.EpaoRegister.Api.UnitTests/Models/GetEpaoCoursesModelTests/WhenCastingEpaoCourseFromMediatorType.cs
+++ b/src/SFA.DAS.EpaoRegister.Api.UnitTests/Models/GetEpaoCoursesModelTests/WhenCastingEpaoCourseFromMediatorType.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.EpaoRegister.Api.UnitTests.Models.GetEpaoCoursesModelTests
         {
             var response = (EpaoCourse)source;
 
-            response.Id.Should().Be(source.Id);
+            response.Id.Should().Be(source.LarsCode);
             response.Periods.Should().BeEquivalentTo(source.StandardDates);
         }
 

--- a/src/SFA.DAS.EpaoRegister.Api/Models/EpaoCourse.cs
+++ b/src/SFA.DAS.EpaoRegister.Api/Models/EpaoCourse.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.EpaoRegister.Api.Models
         {
             return new EpaoCourse
             {
-                Id = source.Id,
+                Id = source.LarsCode,
                 Periods = (CourseDates)source.StandardDates
             };
         }

--- a/src/SFA.DAS.EpaoRegister.UnitTests/Application/Epaos/Queries/WhenHandlingGetEpaoCoursesQuery.cs
+++ b/src/SFA.DAS.EpaoRegister.UnitTests/Application/Epaos/Queries/WhenHandlingGetEpaoCoursesQuery.cs
@@ -92,7 +92,7 @@ namespace SFA.DAS.EpaoRegister.UnitTests.Application.Epaos.Queries
         {
             foreach (var course in matchingStandards)
             {
-                course.Id = apiResponse[0].StandardCode;
+                course.LarsCode = apiResponse[0].StandardCode;
             }
             var allStandards = new List<GetStandardResponse>(); 
             allStandards.AddRange(matchingStandards);
@@ -130,7 +130,7 @@ namespace SFA.DAS.EpaoRegister.UnitTests.Application.Epaos.Queries
             var expectedExpirationInHours = 1;
             foreach (var course in matchingStandards)
             {
-                course.Id = apiResponse[0].StandardCode;
+                course.LarsCode = apiResponse[0].StandardCode;
             }
             var allStandards = new List<GetStandardResponse>(); 
             allStandards.AddRange(matchingStandards);

--- a/src/SFA.DAS.EpaoRegister/Application/Epaos/Queries/GetEpaoCourses/GetEpaoCoursesQueryHandler.cs
+++ b/src/SFA.DAS.EpaoRegister/Application/Epaos/Queries/GetEpaoCourses/GetEpaoCoursesQueryHandler.cs
@@ -68,7 +68,7 @@ namespace SFA.DAS.EpaoRegister.Application.Epaos.Queries.GetEpaoCourses
             var matchingCourses = courses.Standards
                 .Where(response => epaoCourses
                     .Select(item => item.StandardCode)
-                    .Contains(response.Id))
+                    .Contains(response.LarsCode))
                 .ToList();
             
             return new GetEpaoCoursesResult

--- a/src/SFA.DAS.EpaoRegister/InnerApi/Responses/GetStandardResponse.cs
+++ b/src/SFA.DAS.EpaoRegister/InnerApi/Responses/GetStandardResponse.cs
@@ -4,7 +4,9 @@ namespace SFA.DAS.EpaoRegister.InnerApi.Responses
 {
     public class GetStandardResponse
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
+
         public GetStandardDates StandardDates { get; set; }
     }
 

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/TrainingCourses/WhenCallingGetTrainingCourse.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/TrainingCourses/WhenCallingGetTrainingCourse.cs
@@ -44,6 +44,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Controllers.TrainingC
             Assert.IsNotNull(model);
             model.TrainingCourse.Should().BeEquivalentTo((GetTrainingCourseListItem)mediatorResult.Course);
 
+            model.TrainingCourse.Id.Should().Be(mediatorResult.Course.LarsCode);
             model.ProvidersCount.TotalProviders.Should().Be(mediatorResult.ProvidersCount);
             model.ProvidersCount.ProvidersAtLocation.Should().Be(mediatorResult.ProvidersCountAtLocation);
 

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/TrainingCourses/WhenCallingGetTrainingCourseProvider.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/TrainingCourses/WhenCallingGetTrainingCourseProvider.cs
@@ -60,8 +60,10 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Controllers.TrainingC
                         .Excluding(c=>c.FeedbackAttributes)
                         .Excluding(c=>c.ProviderAddress)
                 );
+            
             model.AdditionalCourses.Courses.Should().BeEquivalentTo(mediatorResult.AdditionalCourses);
             model.TrainingCourse.Should().NotBeNull();
+            model.TrainingCourse.Id.Should().Be(mediatorResult.Course.LarsCode);
             model.ProvidersCount.ProvidersAtLocation.Should().Be(mediatorResult.TotalProvidersAtLocation);
             model.ProvidersCount.TotalProviders.Should().Be(mediatorResult.TotalProviders);
             model.Location.Location.GeoPoint.Should().BeEquivalentTo(mediatorResult.Location.GeoPoint);

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Models/WhenCastingGetTrainingCourseResponseFromMediatorType.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Models/WhenCastingGetTrainingCourseResponseFromMediatorType.cs
@@ -16,15 +16,19 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Models
         {
             var response = (GetTrainingCourseListItem)source;
 
-            response.Should().BeEquivalentTo(source, options=> options
-                .Excluding(c=>c.ApprenticeshipFunding)
+            response.Should().BeEquivalentTo(source, options => options
+                .Excluding(c => c.ApprenticeshipFunding)
                 .Excluding(tc => tc.Skills)
                 .Excluding(tc => tc.TypicalJobTitles)
                 .Excluding(tc => tc.CoreAndOptions)
                 .Excluding(tc => tc.CoreDuties)
                 .Excluding(tc => tc.CoreSkillsCount)
                 .Excluding(tc => tc.IsActive)
+                .Excluding(tc => tc.LarsCode)
+                .Excluding(tc => tc.StandardUId)
             );
+
+            response.Id.Should().Be(source.LarsCode);
         }
 
         [Test, AutoData]

--- a/src/SFA.DAS.FindApprenticeshipTraining.Api/Models/GetTrainingCourseListItem.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.Api/Models/GetTrainingCourseListItem.cs
@@ -32,7 +32,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Models
         {
             return new GetTrainingCourseListItem
             {
-                Id = source.Id,
+                Id = source.LarsCode,
                 Title = source.Title,
                 Level = source.Level,
                 LevelEquivalent = source.LevelEquivalent,

--- a/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/TrainingCourses/Queries/WhenGettingProviderByTrainingCourse.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/TrainingCourses/Queries/WhenGettingProviderByTrainingCourse.cs
@@ -134,7 +134,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
                 .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAvailableToStartStandardsListRequest>()))
                 .ReturnsAsync(allCoursesApiResponse);
 
-            var additionalCourses = allCoursesApiResponse.Standards.Select(c => c.Id).ToList();
+            var additionalCourses = allCoursesApiResponse.Standards.Select(c => c.LarsCode).ToList();
 
             additionalCourses.Add(-10);
 
@@ -238,10 +238,10 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
             [Frozen] Mock<ICourseDeliveryApiClient<CourseDeliveryApiConfiguration>> mockApiClient,
             GetTrainingCourseProviderQueryHandler handler)
         {
-            apiCourseResponse.Id = query.CourseId;
+            apiCourseResponse.LarsCode = query.CourseId;
             allStandards.Add(new GetStandardsListItem
             {
-                Id = apiCourseResponse.Id,
+                LarsCode = apiCourseResponse.LarsCode,
                 Title = apiCourseResponse.Title,
                 Level = apiCourseResponse.Level
             });
@@ -286,7 +286,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
                         ))))
                 .ReturnsAsync(new GetProviderAdditionalStandardsItem
                 {
-                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.Id).ToList()
+                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.LarsCode).ToList()
                 });
             mockCoursesApiClient
                 .Setup(client =>
@@ -355,7 +355,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
                         ))))
                 .ReturnsAsync(new GetProviderAdditionalStandardsItem
                 {
-                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.Id).ToList()
+                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.LarsCode).ToList()
                 });
             mockCoursesApiClient
                 .Setup(client =>
@@ -432,7 +432,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
                         ))))
                 .ReturnsAsync(new GetProviderAdditionalStandardsItem
                 {
-                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.Id).ToList()
+                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.LarsCode).ToList()
                 });
             mockCoursesApiClient
                 .Setup(client =>
@@ -504,7 +504,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
                         ))))
                 .ReturnsAsync(new GetProviderAdditionalStandardsItem
                 {
-                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.Id).ToList()
+                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.LarsCode).ToList()
                 });
             mockCoursesApiClient
                 .Setup(client =>
@@ -546,7 +546,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
                         ))))
                 .ReturnsAsync(new GetProviderAdditionalStandardsItem
                 {
-                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.Id).ToList()
+                    StandardIds = allCoursesApiResponse.Standards.Select(c => c.LarsCode).ToList()
                 });
 
             mockApiClient

--- a/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCourseProvider/GetTrainingCourseProviderQueryHandler.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Queries/GetTrainingCourseProvider/GetTrainingCourseProviderQueryHandler.cs
@@ -92,11 +92,11 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.TrainingCourses.Queries
             return providerCoursesTask
                 .Result
                 .StandardIds.Select(courseId =>
-                    coursesTask.Result.Standards.SingleOrDefault(c => c.Id.Equals(courseId)))
+                    coursesTask.Result.Standards.SingleOrDefault(c => c.LarsCode.Equals(courseId)))
                 .Where(c => c != null)
                 .Select(course => new GetAdditionalCourseListItem
                 {
-                    Id = course.Id,
+                    Id = course.LarsCode,
                     Level = course.Level,
                     Title = course.Title
                 })

--- a/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Responses/GetStandardsListItem.cs
@@ -9,7 +9,9 @@ namespace SFA.DAS.FindApprenticeshipTraining.InnerApi.Responses
 {
     public class GetStandardsListItem : StandardApiResponseBase
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
+
         public string Title { get; set; }
         public int Level { get; set; }
         public string LevelEquivalent { get; set; }

--- a/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/InnerApi/Responses/GetStandardsListItem.cs
@@ -11,7 +11,6 @@ namespace SFA.DAS.FindApprenticeshipTraining.InnerApi.Responses
     {
         public string StandardUId { get; set; }
         public int LarsCode { get; set; }
-
         public string Title { get; set; }
         public int Level { get; set; }
         public string LevelEquivalent { get; set; }

--- a/src/SFA.DAS.FindEpao.Api.UnitTests/Controllers/Courses/WhenGettingACourse.cs
+++ b/src/SFA.DAS.FindEpao.Api.UnitTests/Controllers/Courses/WhenGettingACourse.cs
@@ -36,7 +36,12 @@ namespace SFA.DAS.FindEpao.Api.UnitTests.Controllers.Courses
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
             var model = controllerResult.Value as GetCourseResponse;
             Assert.IsNotNull(model);
-            model.Course.Should().BeEquivalentTo(mediatorResult.Course);
+            model.Course.Should().BeEquivalentTo(mediatorResult.Course, options => options
+            .Excluding(c => c.LarsCode)
+            .Excluding(c => c.StandardUId));
+
+            model.Course.Id.Should().Be(mediatorResult.Course.LarsCode);
+
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.FindEpao.Api.UnitTests/Controllers/Courses/WhenGettingCourseList.cs
+++ b/src/SFA.DAS.FindEpao.Api.UnitTests/Controllers/Courses/WhenGettingCourseList.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,7 +36,10 @@ namespace SFA.DAS.FindEpao.Api.UnitTests.Controllers.Courses
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
             var model = controllerResult.Value as GetCourseListResponse;
             Assert.IsNotNull(model);
-            model.Courses.Should().BeEquivalentTo(mediatorResult.Courses);
+            model.Courses.Should().BeEquivalentTo(mediatorResult.Courses, options => options
+            .Excluding(c => c.StandardUId)
+            .Excluding(c => c.LarsCode));
+            model.Courses.All(c => c.Id > 0).Should().BeTrue();
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.FindEpao.Api.UnitTests/Models/WhenCastingGetTrainingCoursesResponseFromMediatorType.cs
+++ b/src/SFA.DAS.FindEpao.Api.UnitTests/Models/WhenCastingGetTrainingCoursesResponseFromMediatorType.cs
@@ -14,8 +14,8 @@ namespace SFA.DAS.FindEpao.Api.UnitTests.Models
         {
             var response = (GetCourseListItem)source;
 
-            response.Should().BeEquivalentTo(source);
+            response.Should().BeEquivalentTo(source, options => options.ExcludingMissingMembers());
+            response.Id.Should().Be(source.LarsCode);
         }
-        
     }
 }

--- a/src/SFA.DAS.FindEpao.Api/Models/GetCourseListItem.cs
+++ b/src/SFA.DAS.FindEpao.Api/Models/GetCourseListItem.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.FindEpao.Api.Models
         {
             return new GetCourseListItem
             {
-                Id = standard.Id,
+                Id = standard.LarsCode,
                 Level = standard.Level,
                 Title = standard.Title,
                 IntegratedApprenticeship = standard.IntegratedApprenticeship

--- a/src/SFA.DAS.FindEpao.UnitTests/Application/Courses/Queries/GetCourseEpao/WhenHandlingGetCourseEpaoQuery.cs
+++ b/src/SFA.DAS.FindEpao.UnitTests/Application/Courses/Queries/GetCourseEpao/WhenHandlingGetCourseEpaoQuery.cs
@@ -106,8 +106,8 @@ namespace SFA.DAS.FindEpao.UnitTests.Application.Courses.Queries.GetCourseEpao
             GetCourseEpaoQueryHandler handler)
         {
             courseEpaosApiResponse[0].EpaoId = query.EpaoId.ToLower();
-            coursesFromCache.Standards.First().Id = epaoCoursesApiResponse.First().StandardCode;
-            coursesFromCache.Standards.ElementAt(1).Id = query.CourseId;
+            coursesFromCache.Standards.First().LarsCode = epaoCoursesApiResponse.First().StandardCode;
+            coursesFromCache.Standards.ElementAt(1).LarsCode = query.CourseId;
             mockAssessorsApiClient
                 .Setup(client => client.Get<GetEpaoResponse>(
                     It.Is<GetEpaoRequest>(request => request.EpaoId == query.EpaoId)))
@@ -138,11 +138,11 @@ namespace SFA.DAS.FindEpao.UnitTests.Application.Courses.Queries.GetCourseEpao
             result.Epao.Should().BeEquivalentTo(epaoApiResponse);
             result.EpaoDeliveryAreas.Should().BeEquivalentTo(courseEpaosApiResponse.Single(item => string.Equals(item.EpaoId, query.EpaoId, StringComparison.CurrentCultureIgnoreCase)).DeliveryAreas);
             result.CourseEpaosCount.Should().Be(courseEpaosApiResponse.Count(item => item.EpaoId == query.EpaoId.ToLower()));//filter returns true
-            result.Course.Should().BeEquivalentTo(coursesFromCache.Standards.Single(item => item.Id == query.CourseId));
+            result.Course.Should().BeEquivalentTo(coursesFromCache.Standards.Single(item => item.LarsCode == query.CourseId));
             result.DeliveryAreas.Should().BeEquivalentTo(areasFromCache);
             result.AllCourses.Should().BeEquivalentTo(
                 coursesFromCache.Standards.Where(item =>
-                    epaoCoursesApiResponse.Any(listItem => listItem.StandardCode == item.Id)));
+                    epaoCoursesApiResponse.Any(listItem => listItem.StandardCode == item.LarsCode)));
             foreach (var courseListItem in epaoCoursesApiResponse)
             {
                 mockCourseEpaoFilter.Verify(x=>x.ValidateEpaoStandardDates(courseListItem.DateStandardApprovedOnRegister,courseListItem.EffectiveTo,courseListItem.EffectiveFrom), 

--- a/src/SFA.DAS.FindEpao/Application/Courses/Queries/GetCourseEpao/GetCourseEpaoQueryHandler.cs
+++ b/src/SFA.DAS.FindEpao/Application/Courses/Queries/GetCourseEpao/GetCourseEpaoQueryHandler.cs
@@ -82,12 +82,12 @@ namespace SFA.DAS.FindEpao.Application.Courses.Queries.GetCourseEpao
                     x.EffectiveTo, x.EffectiveFrom)).ToList();
             var allCourses = coursesTask.Result.Standards
                 .Where(course =>filterAdditionalCourses 
-                    .Any(item => item.StandardCode == course.Id));
+                    .Any(item => item.StandardCode == course.LarsCode));
 
             return new GetCourseEpaoResult
             {
                 Epao = epaoTask.Result,
-                Course = coursesTask.Result.Standards.Single(item => item.Id == request.CourseId),
+                Course = coursesTask.Result.Standards.Single(item => item.LarsCode == request.CourseId),
                 EpaoDeliveryAreas = courseEpao.DeliveryAreas,
                 CourseEpaosCount = filteredCourseEpaos.Count,
                 DeliveryAreas = areasTask.Result,

--- a/src/SFA.DAS.FindEpao/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.FindEpao/InnerApi/Responses/GetStandardsListItem.cs
@@ -2,7 +2,9 @@ namespace SFA.DAS.FindEpao.InnerApi.Responses
 {
     public class GetStandardsListItem
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
+
         public string Title { get; set; }
         public int Level { get; set; }
         public bool IntegratedApprenticeship { get; set; }

--- a/src/SFA.DAS.FindEpao/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.FindEpao/InnerApi/Responses/GetStandardsListItem.cs
@@ -4,7 +4,6 @@ namespace SFA.DAS.FindEpao.InnerApi.Responses
     {
         public string StandardUId { get; set; }
         public int LarsCode { get; set; }
-
         public string Title { get; set; }
         public int Level { get; set; }
         public bool IntegratedApprenticeship { get; set; }

--- a/src/SFA.DAS.Forecasting.Api.UnitTests/Models/WhenCastingApprenticeshipCourseFromMediatorType.cs
+++ b/src/SFA.DAS.Forecasting.Api.UnitTests/Models/WhenCastingApprenticeshipCourseFromMediatorType.cs
@@ -23,11 +23,13 @@ namespace SFA.DAS.Forecasting.Api.UnitTests.Models
                     .Excluding(s => s.TypicalDuration)
                     .Excluding(s => s.StandardDates)
                     .Excluding(s => s.IsActive)
+                    .Excluding(s => s.StandardUId)
+                    .Excluding(s => s.LarsCode)
                 );
 
             response.Duration.Should().Be(source.TypicalDuration);
             response.FundingCap.Should().Be(source.MaxFunding);
-            
+            response.Id.Should().Be(source.LarsCode.ToString());
             for (var i = 0; i < response.FundingPeriods.Count; i++)
             {
                 response.FundingPeriods[i].FundingCap.Should().Be(source.ApprenticeshipFunding[i].MaxEmployerLevyCap);

--- a/src/SFA.DAS.Forecasting.Api/Models/ApprenticeshipCourse.cs
+++ b/src/SFA.DAS.Forecasting.Api/Models/ApprenticeshipCourse.cs
@@ -20,7 +20,7 @@ namespace SFA.DAS.Forecasting.Api.Models
         {
             return new ApprenticeshipCourse
             {
-                Id = standard.Id,
+                Id = standard.LarsCode.ToString(),
                 Title = standard.Title,
                 FundingCap = standard.MaxFunding,
                 Level = standard.Level,

--- a/src/SFA.DAS.Forecasting/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Forecasting/InnerApi/Responses/GetStandardsListItem.cs
@@ -7,7 +7,9 @@ namespace SFA.DAS.Forecasting.InnerApi.Responses
 {
     public class GetStandardsListItem : StandardApiResponseBase
     {
-        public string Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
+
         public string Title { get; set; }
         public int Level { get; set; }
 

--- a/src/SFA.DAS.Forecasting/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Forecasting/InnerApi/Responses/GetStandardsListItem.cs
@@ -9,7 +9,6 @@ namespace SFA.DAS.Forecasting.InnerApi.Responses
     {
         public string StandardUId { get; set; }
         public int LarsCode { get; set; }
-
         public string Title { get; set; }
         public int Level { get; set; }
 

--- a/src/SFA.DAS.ManageApprenticeships.Api.UnitTests/Models/WhenMappingGetStandardResponseFromMediatorType.cs
+++ b/src/SFA.DAS.ManageApprenticeships.Api.UnitTests/Models/WhenMappingGetStandardResponseFromMediatorType.cs
@@ -12,16 +12,19 @@ namespace SFA.DAS.ManageApprenticeships.Api.UnitTests.Models
         public void Then_The_Fields_Are_Correctly_Mapped(GetStandardsListItem source)
         {
             //Arrange
-            var actual = (GetStandardResponse) source;
-            
+            var actual = (GetStandardResponse)source;
+
             //Assert
             actual.Should().BeEquivalentTo(source, options=> options
                 .Excluding(x=>x.ApprenticeshipFunding)
                 .Excluding(x=>x.StandardDates)
                 .Excluding(x=>x.TypicalDuration)
                 .Excluding(x=>x.IsActive)
+                .Excluding(x => x.StandardUId)
+                .Excluding(x => x.LarsCode)
             );
             actual.Duration.Should().Be(source.TypicalDuration);
+            actual.Id.Should().Be(source.LarsCode);
         }
     }
 }

--- a/src/SFA.DAS.ManageApprenticeships.Api/Models/GetStandardResponse.cs
+++ b/src/SFA.DAS.ManageApprenticeships.Api/Models/GetStandardResponse.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.ManageApprenticeships.Api.Models
         {
             return new GetStandardResponse
             {
-                Id= source.Id,
+                Id= source.LarsCode,
                 Duration = source.TypicalDuration,
                 Level = source.Level,
                 Title = source.Title,

--- a/src/SFA.DAS.ManageApprenticeships/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.ManageApprenticeships/InnerApi/Responses/GetStandardsListItem.cs
@@ -4,7 +4,9 @@ namespace SFA.DAS.ManageApprenticeships.InnerApi.Responses
 {
     public class GetStandardsListItem : StandardApiResponseBase
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
+
         public string Title { get; set; }
         public int Level { get; set; }
     }

--- a/src/SFA.DAS.Recruit.UnitTests/Domain/WhenMappingToTrainingProgrammeFromStandard.cs
+++ b/src/SFA.DAS.Recruit.UnitTests/Domain/WhenMappingToTrainingProgrammeFromStandard.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.Recruit.UnitTests.Domain
             var actual = (TrainingProgramme) source;
             
             //Assert
-            actual.Id.Should().Be(source.Id.ToString());
+            actual.Id.Should().Be(source.LarsCode.ToString());
             actual.ApprenticeshipType.Should().Be(TrainingType.Standard);
             actual.Title.Should().Be(source.Title);
             actual.EffectiveFrom.Should().Be(source.StandardDates.EffectiveFrom);

--- a/src/SFA.DAS.Recruit/Domain/TrainingProgramme.cs
+++ b/src/SFA.DAS.Recruit/Domain/TrainingProgramme.cs
@@ -35,7 +35,7 @@ namespace SFA.DAS.Recruit.Domain
         {
             return new TrainingProgramme
             {
-                Id = source.Id.ToString(),
+                Id = source.LarsCode.ToString(),
                 ApprenticeshipType = TrainingType.Standard,
                 Title = source.Title,
                 EffectiveFrom = source.StandardDates.EffectiveFrom,

--- a/src/SFA.DAS.Recruit/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Recruit/InnerApi/Responses/GetStandardsListItem.cs
@@ -4,7 +4,8 @@ namespace SFA.DAS.Recruit.InnerApi.Responses
 {
     public class GetStandardsListItem : StandardApiResponseBase
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
         public string Title { get; set; }
         public int Level { get; set; }
     }

--- a/src/SFA.DAS.Reservations.Api.UnitTests/Controllers/WhenCallingGetTrainingCourseList.cs
+++ b/src/SFA.DAS.Reservations.Api.UnitTests/Controllers/WhenCallingGetTrainingCourseList.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,7 +37,10 @@ namespace SFA.DAS.Reservations.Api.UnitTests.Controllers
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
             var model = controllerResult.Value as GetTrainingCoursesListResponse;
             Assert.IsNotNull(model);
-            model.Standards.Should().BeEquivalentTo(mediatorResult.Courses);
+            model.Standards.Should().BeEquivalentTo(mediatorResult.Courses, options => options
+                .Excluding(s => s.StandardUId)
+                .Excluding(s => s.LarsCode));
+            model.Standards.All(m => m.Id > 0).Should().BeTrue();
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.Reservations.Api.UnitTests/Models/WhenCastingGetTrainingCoursesResponseFromMediatorType.cs
+++ b/src/SFA.DAS.Reservations.Api.UnitTests/Models/WhenCastingGetTrainingCoursesResponseFromMediatorType.cs
@@ -14,7 +14,10 @@ namespace SFA.DAS.Reservations.Api.UnitTests.Models
         {
             var response = (GetTrainingCoursesListItem)source;
 
-            response.Should().BeEquivalentTo(source);
+            response.Should().BeEquivalentTo(source, options => options
+                .Excluding(r => r.StandardUId)
+                .Excluding(r => r.LarsCode));
+            response.Id.Should().Be(source.LarsCode);
         }
         
     }

--- a/src/SFA.DAS.Reservations.Api/Models/GetTrainingCoursesListItem.cs
+++ b/src/SFA.DAS.Reservations.Api/Models/GetTrainingCoursesListItem.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.Reservations.Api.Models
         {
             return new GetTrainingCoursesListItem
             {
-                Id = standard.Id,
+                Id = standard.LarsCode,
                 Level = standard.Level,
                 Title = standard.Title,
                 EffectiveTo = standard.EffectiveTo

--- a/src/SFA.DAS.Reservations/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Reservations/InnerApi/Responses/GetStandardsListItem.cs
@@ -4,7 +4,8 @@ namespace SFA.DAS.Reservations.InnerApi.Responses
 {
     public class GetStandardsListItem
     {
-        public int Id { get; set; }
+        public string StandardUId { get; set; }
+        public int LarsCode { get; set; }
         public string Title { get; set; }
         public int Level { get; set; }
         public DateTime EffectiveTo { get; set; }

--- a/src/SFA.DAS.SharedOuterApi/InnerApi/Responses/StandardApiResponseBase.cs
+++ b/src/SFA.DAS.SharedOuterApi/InnerApi/Responses/StandardApiResponseBase.cs
@@ -42,6 +42,7 @@ namespace SFA.DAS.SharedOuterApi.InnerApi.Responses
 
         private bool IsStandardActive()
         {
+            if (StandardDates == null) return false;
             return StandardDates.EffectiveFrom.Date <= DateTime.UtcNow.Date
                    && (!StandardDates.EffectiveTo.HasValue ||
                        StandardDates.EffectiveTo.Value.Date >= DateTime.UtcNow.Date);


### PR DESCRIPTION
Begins with querying Get List on courses api and stores data in the environment which is used to assert calls to outer apis. 

The tests are written so that the counts match as well. Currently the filters are applied as such: 
Approvals = `ActiveAvailable`
Assessor = `Active`
Campaign = N/A as Campaign gets Lars Codes by sector
FAT = `ActiveAvailable`
Find EPAO = `Active`
Forecasting = `ActiveAvailable`
MA = `Active`
Recruit = Cannot tell as the same response brings back frameworks and standards
Reservations = `ActiveAvailable`