### PR TITLE
SV-467 Assessor outer API to return all standards

### DIFF
--- a/src/SFA.DAS.Approvals.UnitTests/Application/TrainingCourses/Queries/WhenGettingTrainingCourseStandards.cs
+++ b/src/SFA.DAS.Approvals.UnitTests/Application/TrainingCourses/Queries/WhenGettingTrainingCourseStandards.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.Approvals.UnitTests.Application.TrainingCourses.Queries
             GetStandardsQueryHandler handler)
         {
             mockApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
                 .ReturnsAsync(apiResponse);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.Approvals/Application/TrainingCourses/Queries/GetStandardsQueryHandler.cs
+++ b/src/SFA.DAS.Approvals/Application/TrainingCourses/Queries/GetStandardsQueryHandler.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.Approvals.Application.TrainingCourses.Queries
         }
         public async Task<GetStandardsResult> Handle(GetStandardsQuery request, CancellationToken cancellationToken)
         {
-            var standards = await _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsListRequest());
+            var standards = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
             
             return new GetStandardsResult
             {

--- a/src/SFA.DAS.Assessors.Api/Models/GetCourseListItem.cs
+++ b/src/SFA.DAS.Assessors.Api/Models/GetCourseListItem.cs
@@ -5,7 +5,7 @@ namespace SFA.DAS.Assessors.Api.Models
 {
     public class GetCourseListItem
     {
-        public int Id { get; set; }
+        public int LarsCode { get; set; }
         public string Title { get; set; }
         public int Level { get; set; }
         public int MaxFunding { get; set; }
@@ -17,7 +17,7 @@ namespace SFA.DAS.Assessors.Api.Models
         {
             return new GetCourseListItem
             {
-                Id = source.LarsCode,
+                LarsCode = source.LarsCode,
                 Title = source.Title,
                 Level = source.Level,
                 MaxFunding = source.MaxFunding,

--- a/src/SFA.DAS.Assessors.Api/Models/GetCourseListItem.cs
+++ b/src/SFA.DAS.Assessors.Api/Models/GetCourseListItem.cs
@@ -5,8 +5,12 @@ namespace SFA.DAS.Assessors.Api.Models
 {
     public class GetCourseListItem
     {
+        public string StandardUId { get; set; }
+        public string IfateReferenceNumber { get; set; }
         public int LarsCode { get; set; }
         public string Title { get; set; }
+        public decimal? Version { get; set; }
+        public string Status { get; set; }
         public int Level { get; set; }
         public int MaxFunding { get; set; }
         public int TypicalDuration { get; set; }
@@ -17,8 +21,12 @@ namespace SFA.DAS.Assessors.Api.Models
         {
             return new GetCourseListItem
             {
+                StandardUId = source.StandardUId,
+                IfateReferenceNumber = source.IfateReferenceNumber,
                 LarsCode = source.LarsCode,
                 Title = source.Title,
+                Version = source.Version,
+                Status = source.Status,
                 Level = source.Level,
                 MaxFunding = source.MaxFunding,
                 TypicalDuration = source.TypicalDuration,
@@ -37,6 +45,7 @@ namespace SFA.DAS.Assessors.Api.Models
 
             public static implicit operator StandardDate(SharedOuterApi.InnerApi.Responses.StandardDate source)
             {
+                if (source == null) return null;
                 return new StandardDate
                 {
                     EffectiveFrom = source.EffectiveFrom,

--- a/src/SFA.DAS.Assessors.UnitTests/Application/Queries/WhenHandlingGetTrainingCoursesQuery.cs
+++ b/src/SFA.DAS.Assessors.UnitTests/Application/Queries/WhenHandlingGetTrainingCoursesQuery.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.Assessors.UnitTests.Application.Queries
             GetTrainingCoursesQueryHandler handler)
         {
             mockApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsRequest>()))
                 .ReturnsAsync(apiResponse);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.Assessors.UnitTests/Application/Queries/WhenHandlingGetTrainingCoursesQuery.cs
+++ b/src/SFA.DAS.Assessors.UnitTests/Application/Queries/WhenHandlingGetTrainingCoursesQuery.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.Assessors.UnitTests.Application.Queries
             GetTrainingCoursesQueryHandler handler)
         {
             mockApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
                 .ReturnsAsync(apiResponse);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.Assessors/Application/Queries/GetTrainingCourses/GetTrainingCoursesQuery.cs
+++ b/src/SFA.DAS.Assessors/Application/Queries/GetTrainingCourses/GetTrainingCoursesQuery.cs
@@ -2,8 +2,5 @@
 
 namespace SFA.DAS.Assessors.Application.Queries.GetTrainingCourses
 {
-    public class GetTrainingCoursesQuery : IRequest<GetTrainingCoursesResult>
-    {
-        
-    }
+    public class GetTrainingCoursesQuery : IRequest<GetTrainingCoursesResult> {}
 }

--- a/src/SFA.DAS.Assessors/Application/Queries/GetTrainingCourses/GetTrainingCoursesQueryHandler.cs
+++ b/src/SFA.DAS.Assessors/Application/Queries/GetTrainingCourses/GetTrainingCoursesQueryHandler.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.Assessors.Application.Queries.GetTrainingCourses
         }
         public async Task<GetTrainingCoursesResult> Handle(GetTrainingCoursesQuery request, CancellationToken cancellationToken)
         {
-            var standardsList = await _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsListRequest());
+            var standardsList = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
 
             return new GetTrainingCoursesResult
             {

--- a/src/SFA.DAS.Assessors/Application/Queries/GetTrainingCourses/GetTrainingCoursesQueryHandler.cs
+++ b/src/SFA.DAS.Assessors/Application/Queries/GetTrainingCourses/GetTrainingCoursesQueryHandler.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.Assessors.Application.Queries.GetTrainingCourses
         }
         public async Task<GetTrainingCoursesResult> Handle(GetTrainingCoursesQuery request, CancellationToken cancellationToken)
         {
-            var standardsList = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
+            var standardsList = await _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsRequest());
 
             return new GetTrainingCoursesResult
             {

--- a/src/SFA.DAS.Assessors/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/SFA.DAS.Assessors/InnerApi/Responses/GetStandardsListItem.cs
@@ -5,8 +5,11 @@ namespace SFA.DAS.Assessors.InnerApi.Responses
     public class GetStandardsListItem : StandardApiResponseBase
     {
         public string StandardUId { get; set; }
+        public string IfateReferenceNumber { get; set; }
         public int LarsCode { get; set; }
         public string Title { get; set; }
+        public decimal? Version { get; set; }
         public int Level { get; set; }
+        public string Status { get; set; }
     }
 }

--- a/src/SFA.DAS.EpaoRegister.UnitTests/Application/Epaos/Queries/WhenHandlingGetEpaoCoursesQuery.cs
+++ b/src/SFA.DAS.EpaoRegister.UnitTests/Application/Epaos/Queries/WhenHandlingGetEpaoCoursesQuery.cs
@@ -72,7 +72,7 @@ namespace SFA.DAS.EpaoRegister.UnitTests.Application.Epaos.Queries
                     It.Is<GetEpaoCoursesRequest>(request => request.EpaoId == query.EpaoId)))
                 .ReturnsAsync(apiResponse);
             mockCoursesApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
                 .ReturnsAsync(getStandardResponses);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/TrainingCourses/Services/WhenGettingCourses.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/TrainingCourses/Services/WhenGettingCourses.cs
@@ -39,7 +39,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.UnitTests.Application.TrainingCours
             var expectedExpirationInHours = 1;
             mockCoursesApiClient
                 .Setup(client => client.Get<GetStandardsListResponse>(
-                    It.IsAny<GetAllStandardsListRequest>()))
+                    It.IsAny<GetActiveStandardsListRequest>()))
                 .ReturnsAsync(coursesFromApi);
             mockCacheService
                 .Setup(service => service.RetrieveFromCache<GetStandardsListResponse>(nameof(GetStandardsListResponse)))

--- a/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Services/CachedCoursesService.cs
+++ b/src/SFA.DAS.FindApprenticeshipTraining/Application/TrainingCourses/Services/CachedCoursesService.cs
@@ -30,7 +30,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.TrainingCourses.Service
             if (courses != null) 
                 return courses;
             
-            courses = await _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsListRequest());
+            courses = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
             await _cacheStorageService.SaveToCache(nameof(GetStandardsListResponse), courses, DeliveryAreaCacheDurationInHours);
 
             return courses;

--- a/src/SFA.DAS.FindEpao.UnitTests/Application/Courses/Queries/GetCourseList/WhenHandlingGetCourseListQuery.cs
+++ b/src/SFA.DAS.FindEpao.UnitTests/Application/Courses/Queries/GetCourseList/WhenHandlingGetCourseListQuery.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.FindEpao.UnitTests.Application.Courses.Queries.GetCourseList
             GetCourseListQueryHandler handler)
         {
             mockApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
                 .ReturnsAsync(apiResponse);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.FindEpao.UnitTests/Application/Courses/Services/WhenGettingCourses.cs
+++ b/src/SFA.DAS.FindEpao.UnitTests/Application/Courses/Services/WhenGettingCourses.cs
@@ -42,7 +42,7 @@ namespace SFA.DAS.FindEpao.UnitTests.Application.Courses.Services
             var expectedExpirationInHours = 1;
             mockCoursesApiClient
                 .Setup(client => client.Get<GetStandardsListResponse>(
-                    It.IsAny<GetAllStandardsListRequest>()))
+                    It.IsAny<GetActiveStandardsListRequest>()))
                 .ReturnsAsync(coursesFromApi);
             mockCacheService
                 .Setup(service => service.RetrieveFromCache<GetStandardsListResponse>(nameof(GetStandardsListResponse)))

--- a/src/SFA.DAS.FindEpao/Application/Courses/Queries/GetCourseList/GetCourseListQueryHandler.cs
+++ b/src/SFA.DAS.FindEpao/Application/Courses/Queries/GetCourseList/GetCourseListQueryHandler.cs
@@ -20,7 +20,7 @@ namespace SFA.DAS.FindEpao.Application.Courses.Queries.GetCourseList
 
         public async Task<GetCourseListResult> Handle(GetCourseListQuery request, CancellationToken cancellationToken)
         {
-            var courses = await _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsListRequest());
+            var courses = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
             
             return new GetCourseListResult
             {

--- a/src/SFA.DAS.FindEpao/Application/Courses/Services/CachedCoursesService.cs
+++ b/src/SFA.DAS.FindEpao/Application/Courses/Services/CachedCoursesService.cs
@@ -30,7 +30,7 @@ namespace SFA.DAS.FindEpao.Application.Courses.Services
             if (courses != null) 
                 return courses;
             
-            courses = await _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsListRequest());
+            courses = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
             await _cacheStorageService.SaveToCache(nameof(GetStandardsListResponse), courses, DeliveryAreaCacheDurationInHours);
 
             return courses;

--- a/src/SFA.DAS.ManageApprenticeships.UnitTests/Application/Queries/GetStandards/WhenHandlingTheGetStandardsQuery.cs
+++ b/src/SFA.DAS.ManageApprenticeships.UnitTests/Application/Queries/GetStandards/WhenHandlingTheGetStandardsQuery.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.ManageApprenticeships.UnitTests.Application.Queries.GetStandar
             GetStandardsQueryHandler handler)
         {
             mockApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
                 .ReturnsAsync(apiResponse);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.ManageApprenticeships/Application/Queries/GetStandards/GetStandardsQueryHandler.cs
+++ b/src/SFA.DAS.ManageApprenticeships/Application/Queries/GetStandards/GetStandardsQueryHandler.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.ManageApprenticeships.Application.Queries.GetStandards
         }
         public async Task<GetStandardsQueryResult> Handle(GetStandardsQuery request, CancellationToken cancellationToken)
         {
-            var response = await _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsListRequest());
+            var response = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
             
             return new GetStandardsQueryResult
             {

--- a/src/SFA.DAS.Recruit.UnitTests/Application/Queries/GetTrainingProgrammes/WhenHandlingTheGetTrainingProgrammesQuery.cs
+++ b/src/SFA.DAS.Recruit.UnitTests/Application/Queries/GetTrainingProgrammes/WhenHandlingTheGetTrainingProgrammesQuery.cs
@@ -34,7 +34,7 @@ namespace SFA.DAS.Recruit.UnitTests.Application.Queries.GetTrainingProgrammes
                 .Setup(client => client.Get<GetFrameworksListResponse>(It.IsAny<GetFrameworksRequest>()))
                 .ReturnsAsync(apiResponse);
             mockApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
                 .ReturnsAsync(new GetStandardsListResponse());
 
             var result = await handler.Handle(query, CancellationToken.None);
@@ -57,7 +57,7 @@ namespace SFA.DAS.Recruit.UnitTests.Application.Queries.GetTrainingProgrammes
                 .Setup(client => client.Get<GetFrameworksListResponse>(It.IsAny<GetFrameworksRequest>()))
                 .ReturnsAsync(new GetFrameworksListResponse());
             mockApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetAllStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
                 .ReturnsAsync(apiResponse);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.Recruit/Application/Queries/GetTrainingProgrammes/GetTrainingProgrammesQueryHandler.cs
+++ b/src/SFA.DAS.Recruit/Application/Queries/GetTrainingProgrammes/GetTrainingProgrammesQueryHandler.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.Recruit.Application.Queries.GetTrainingProgrammes
         public async Task<GetTrainingProgrammesQueryResult> Handle(GetTrainingProgrammesQuery request, CancellationToken cancellationToken)
         {
             var frameworksTask = _coursesApiClient.Get<GetFrameworksListResponse>(new GetFrameworksRequest());
-            var standardsTask = _coursesApiClient.Get<GetStandardsListResponse>(new GetAllStandardsListRequest());
+            var standardsTask = _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
 
             await Task.WhenAll(frameworksTask, standardsTask);
 

--- a/src/SFA.DAS.SharedOuterApi.UnitTests/InnerApi/Requests/WhenBuildingTheGetAllStandardsListRequest.cs
+++ b/src/SFA.DAS.SharedOuterApi.UnitTests/InnerApi/Requests/WhenBuildingTheGetAllStandardsListRequest.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.InnerApi.Requests
             List<int> levels)
         {
             
-            var actual = new GetAllStandardsListRequest
+            var actual = new GetActiveStandardsListRequest
             {
                 RouteIds = routeIds,
                 Levels = levels
@@ -28,7 +28,7 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.InnerApi.Requests
         public void Then_The_Url_Is_Correctly_Constructed_Without_RouteIds_And_Levels(
         )
         {
-            var actual = new GetAllStandardsListRequest();
+            var actual = new GetActiveStandardsListRequest();
 
             actual.GetUrl.Should()
                 .Be($"api/courses/standards?filter=Active");
@@ -38,7 +38,7 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.InnerApi.Requests
         public void Then_The_Url_Is_Correctly_Constructed_Without_RouteIds(
             List<int> levels)
         {
-            var actual = new GetAllStandardsListRequest
+            var actual = new GetActiveStandardsListRequest
             {
                 Levels = levels
             };
@@ -51,7 +51,7 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.InnerApi.Requests
         public void Then_The_Url_Is_Correctly_Constructed_Without_Levels(
             List<Guid> routeIds)
         {
-            var actual = new GetAllStandardsListRequest
+            var actual = new GetActiveStandardsListRequest
             { 
                 RouteIds = routeIds
             };

--- a/src/SFA.DAS.SharedOuterApi.UnitTests/InnerApi/Requests/WhenBuildingTheGetAllStandardsRequest.cs
+++ b/src/SFA.DAS.SharedOuterApi.UnitTests/InnerApi/Requests/WhenBuildingTheGetAllStandardsRequest.cs
@@ -1,0 +1,19 @@
+﻿using AutoFixture.NUnit3;
+using NUnit.Framework;
+using SFA.DAS.SharedOuterApi.InnerApi.Requests;
+
+namespace SFA.DAS.SharedOuterApi.UnitTests.InnerApi.Requests
+{
+    public class WhenBuildingTheGetAllStandardsRequest
+    {
+        [Test, AutoData]
+        public void Then_The_Url_Is_Correctly_Constructed()
+        {
+            //Act
+            var actual = new GetAllStandardsRequest();
+
+            //Assert
+            Assert.AreEqual("api/courses/standards?filter=None", actual.GetUrl);
+        }
+    }
+}

--- a/src/SFA.DAS.SharedOuterApi/InnerApi/Requests/GetActiveStandardsListRequest.cs
+++ b/src/SFA.DAS.SharedOuterApi/InnerApi/Requests/GetActiveStandardsListRequest.cs
@@ -5,7 +5,7 @@ using SFA.DAS.SharedOuterApi.Interfaces;
 
 namespace SFA.DAS.SharedOuterApi.InnerApi.Requests
 {
-    public class GetAllStandardsListRequest : IGetApiRequest
+    public class GetActiveStandardsListRequest : IGetApiRequest
     {
         public List<Guid> RouteIds { get ; set ; }
         public List<int> Levels { get ; set ; }

--- a/src/SFA.DAS.SharedOuterApi/InnerApi/Requests/GetAllStandardsRequest.cs
+++ b/src/SFA.DAS.SharedOuterApi/InnerApi/Requests/GetAllStandardsRequest.cs
@@ -4,6 +4,6 @@ namespace SFA.DAS.SharedOuterApi.InnerApi.Requests
 {
     public class GetAllStandardsRequest : IGetApiRequest
     {
-        public string GetUrl => $"api/courses/standards?filter=None";
+        public string GetUrl => "api/courses/standards?filter=None";
     }
 }

--- a/src/SFA.DAS.SharedOuterApi/InnerApi/Requests/GetAllStandardsRequest.cs
+++ b/src/SFA.DAS.SharedOuterApi/InnerApi/Requests/GetAllStandardsRequest.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.SharedOuterApi.InnerApi.Requests
+{
+    public class GetAllStandardsRequest : IGetApiRequest
+    {
+        public string GetUrl => $"api/courses/standards?filter=None";
+    }
+}


### PR DESCRIPTION
Original PR #299 was already approved and merged into SV-372. However this was required to be separated as it is not going out in the same release as SV-372. 

More work was done which is going out with SV-372, hence had to rebase the branch on top of StandardOptions release branch and reopen the PR. 

I have excluded postman changes as they become too difficult to merge. I will update them in a newer PR once this PR is merged into a release branch. 