### PR TITLE
SV-528 delete core skills count field

### DIFF
--- a/src/SFA.DAS.Assessors.Api/Models/GetStandardDetailsResponse.cs
+++ b/src/SFA.DAS.Assessors.Api/Models/GetStandardDetailsResponse.cs
@@ -21,7 +21,6 @@ namespace SFA.DAS.Assessors.Api.Models
         public string AssessmentPlanUrl { get; set; }
         public string TrailBlazerContact { get; set; }
         public string TypicalJobTitles { get; set; }
-        public string CoreSkillsCount { get; set; }
         public List<string> Skills { get; set; }
         public List<string> Knowledge { get; set; }
         public List<string> Behaviours { get; set; }
@@ -66,7 +65,6 @@ namespace SFA.DAS.Assessors.Api.Models
                 AssessmentPlanUrl = source.AssessmentPlanUrl,
                 TrailBlazerContact = source.TrailBlazerContact,
                 TypicalJobTitles = source.TypicalJobTitles,
-                CoreSkillsCount = source.CoreSkillsCount,
                 Skills = source.Skills,
                 Knowledge = source.Knowledge,
                 Behaviours = source.Behaviours,

--- a/src/SFA.DAS.Assessors/InnerApi/Responses/StandardDetailResponse.cs
+++ b/src/SFA.DAS.Assessors/InnerApi/Responses/StandardDetailResponse.cs
@@ -19,7 +19,6 @@ namespace SFA.DAS.Assessors.InnerApi.Responses
         public string AssessmentPlanUrl { get; set; }
         public string TrailBlazerContact { get; set; }
         public string TypicalJobTitles { get; set; }
-        public string CoreSkillsCount { get; set; }
         public List<string> Skills { get; set; }
         public List<string> Knowledge { get; set; }
         public List<string> Behaviours { get; set; }


### PR DESCRIPTION
Following on from this courses api [pull request](https://github.com/SkillsFundingAgency/das-courses-api/pull/84)

I have removed the CoreSkillsCount from Assessors API. There is still an existing CoreSkillsCount field on `SFA.DAS.FindApprenticeshipTraining.InnerApi.Responses.GetStandardsListItem` but this is populated with other data in the courses API response and not from its own field like in the Assessor outer API so I have left as is.

