### PR TITLE
Create Apprenticeship with its ApprovedOn date

### DIFF
--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/AddApprenticeship.feature
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Features/AddApprenticeship.feature
@@ -1,4 +1,4 @@
-﻿@loginApi
+@loginApi
 Feature: AddApprenticeship
 	When an Apprenticeship is approved and forwarded here
 	As an outer API
@@ -7,8 +7,8 @@ Feature: AddApprenticeship
 Background:
 	Given the following apprenticeships have been approved
 	| Id | First Name | Last Name | Course Name             | Course Code |
-	| 1  | Alexa      | Armstrong | Artificial Intelligence | 9001          |
-	| 2  | Zachary    | Zimmerman | Zoology                 | 9002          |
+	| 1  | Alexa      | Armstrong | Artificial Intelligence | 9001        |
+	| 2  | Zachary    | Zimmerman | Zoology                 | 9002        |
 
 	Given the following training providers exist
 	| Ukprn | Legal Name   | Trading Name    |
@@ -22,8 +22,8 @@ Background:
 
 Scenario: New apprenticeship is recieved and is valid 
 	When the following apprenticeship is posted
-	| ApprenticeshipId | Email         | Employer Name | Employer Account Legal Entity Id | Training Provider Id |
-	| 1                | Test@Test.com | Apple         | 123                              | 1002                 |
+	| ApprenticeshipId | Email         | Employer Name | Employer Account Legal Entity Id | Training Provider Id | Approved On |
+	| 1                | Test@Test.com | Apple         | 123                              | 1002                 | 2015-04-20  |
 	Then the inner API has received the posted values
 	And the Training Provider Name should be 'My Only Name'
 	And the course should be `Artificial Intelligence` level 1
@@ -31,8 +31,8 @@ Scenario: New apprenticeship is recieved and is valid
 
 Scenario: New apprenticeship is recieved and is valid and there is a trading name for provider
 	When the following apprenticeship is posted
-	| ApprenticeshipId | Email              | Employer Name | Employer Account Legal Entity Id | Training Provider Id |
-	| 2                | SomeOther@Test.com | Apple         | 123                              | 1001                 |
+	| ApprenticeshipId | Email              | Employer Name | Employer Account Legal Entity Id | Training Provider Id | Approved On |
+	| 2                | SomeOther@Test.com | Apple         | 123                              | 1001                 | 2019-03-31  |
 	Then the inner API has received the posted values
 	And the Training Provider Name should be 'My Trading Name'
 	And the invitation was sent successfully

--- a/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Steps/AddApprenticeshipSteps.cs
+++ b/src/SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests/Steps/AddApprenticeshipSteps.cs
@@ -1,16 +1,14 @@
 ﻿using FluentAssertions;
 using Newtonsoft.Json;
 using SFA.DAS.ApprenticeCommitments.Apis.ApprenticeLoginApi;
-using SFA.DAS.ApprenticeCommitments.Apis.CommitmentsV2InnerApi;
 using SFA.DAS.ApprenticeCommitments.Apis.InnerApi;
+using SFA.DAS.ApprenticeCommitments.Apis.TrainingProviderApi;
 using SFA.DAS.ApprenticeCommitments.Application.Commands.CreateApprenticeship;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Threading;
 using System.Threading.Tasks;
-using SFA.DAS.ApprenticeCommitments.Apis.TrainingProviderApi;
 using TechTalk.SpecFlow;
 using TechTalk.SpecFlow.Assist;
 using WireMock.Matchers;
@@ -161,6 +159,7 @@ namespace SFA.DAS.ApprenticeCommitments.Api.AcceptanceTests.Steps
             innerApiRequest.ApprenticeId.Should().NotBe(Guid.Empty);
             innerApiRequest.Email.Should().Be(_request.Email);
             innerApiRequest.ApprenticeshipId.Should().Be(_request.ApprenticeshipId);
+            innerApiRequest.ApprovedOn.Should().Be(_request.AgreedOn);
             innerApiRequest.EmployerName.Should().Be(_request.EmployerName);
             innerApiRequest.EmployerAccountLegalEntityId.Should().Be(_request.EmployerAccountLegalEntityId);
             innerApiRequest.TrainingProviderId.Should().Be(_request.TrainingProviderId);

--- a/src/SFA.DAS.ApprenticeCommitments/Apis/InnerApi/CreateApprenticeshipRequest.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Apis/InnerApi/CreateApprenticeshipRequest.cs
@@ -14,6 +14,7 @@ namespace SFA.DAS.ApprenticeCommitments.Apis.InnerApi
     {
         public Guid ApprenticeId  { get; set; }
         public long ApprenticeshipId { get; set; }
+        public DateTime ApprovedOn { get; set; }
         public string Email { get; set; }
         public string EmployerName { get; set; }
         public long EmployerAccountLegalEntityId { get; set; }

--- a/src/SFA.DAS.ApprenticeCommitments/Application/Commands/CreateApprenticeship/CreateApprenticeshipCommand.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Commands/CreateApprenticeship/CreateApprenticeshipCommand.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using System;
 
 namespace SFA.DAS.ApprenticeCommitments.Application.Commands.CreateApprenticeship
 {
@@ -6,6 +7,7 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Commands.CreateApprenticeshi
     {
         public long EmployerAccountId { get; set; }
         public long ApprenticeshipId { get; set; }
+        public DateTime AgreedOn { get; set; }
         public string Email { get; set; }
         public string EmployerName { get; set; }
         public long EmployerAccountLegalEntityId { get; set; }

--- a/src/SFA.DAS.ApprenticeCommitments/Application/Commands/CreateApprenticeship/CreateApprenticeshipCommandHandler.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Commands/CreateApprenticeship/CreateApprenticeshipCommandHandler.cs
@@ -55,6 +55,7 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Commands.CreateApprenticeshi
                 CourseLevel = course.Level,
                 PlannedStartDate = apprentice.StartDate,
                 PlannedEndDate = apprentice.EndDate,
+                ApprovedOn = command.AgreedOn,
             });
 
             await _apprenticeLoginService.SendInvitation(new SendInvitationModel


### PR DESCRIPTION
ApprovedOn comes from the [ApprenticeshipCreated](https://github.com/SkillsFundingAgency/das-commitments/blob/master/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Messages/Events/ApprenticeshipCreatedEvent.cs) event, where it is called `AgreedOn`.