### PR TITLE
[TM-36] - Extend LTM Application-Details route

### DIFF
--- a/src/SFA.DAS.LevyTransferMatching.Api.UnitTests/Controllers/OpportunityTests/WhenCallingGetApplicationDetails.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Api.UnitTests/Controllers/OpportunityTests/WhenCallingGetApplicationDetails.cs
@@ -10,6 +10,7 @@ using SFA.DAS.LevyTransferMatching.Application.Queries.Standards;
 using SFA.DAS.Testing.AutoFixture;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
@@ -39,7 +40,7 @@ namespace SFA.DAS.LevyTransferMatching.Api.UnitTests.Controllers.OpportunityTest
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(getStandardsQueryResult);
 
-            var controllerResult = await opportunityController.GetApplicationDetails(opportunityId);
+            var controllerResult = await opportunityController.GetApplicationDetails(opportunityId, default);
             var okObjectResult = controllerResult as OkObjectResult;
             var response = okObjectResult.Value as ApplicationDetailsResponse;
 
@@ -61,7 +62,7 @@ namespace SFA.DAS.LevyTransferMatching.Api.UnitTests.Controllers.OpportunityTest
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync((GetOpportunityResult)null);
 
-            var controllerResult = await opportunityController.GetApplicationDetails(opportunityId);
+            var controllerResult = await opportunityController.GetApplicationDetails(opportunityId, default);
             var notFoundResult = controllerResult as NotFoundResult;
 
             Assert.IsNotNull(controllerResult);

--- a/src/SFA.DAS.LevyTransferMatching.Api/Controllers/OpportunityController.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Api/Controllers/OpportunityController.cs
@@ -51,7 +51,7 @@ namespace SFA.DAS.LevyTransferMatching.Api.Controllers
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
-        public async Task<IActionResult> GetApplicationDetails(int opportunityId)
+        public async Task<IActionResult> GetApplicationDetails(int opportunityId, [FromQuery] string standardId)
         {
             try
             {
@@ -62,7 +62,7 @@ namespace SFA.DAS.LevyTransferMatching.Api.Controllers
                     return NotFound();
                 }
 
-                var standards = await _mediator.Send(new GetStandardsQuery());
+                var standards = await _mediator.Send(new GetStandardsQuery() { StandardId = standardId});
 
                 return Ok(new ApplicationDetailsResponse
                 {

--- a/src/SFA.DAS.LevyTransferMatching.Api/Models/PledgeDto.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Api/Models/PledgeDto.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.LevyTransferMatching.Api.Models
         public long AccountId { get; set; }
 
         public int Amount { get; set; }
-
+        public int RemainingAmount { get; set; }
         public bool IsNamePublic { get; set; }
 
         public string DasAccountName { get; set; }
@@ -30,6 +30,7 @@ namespace SFA.DAS.LevyTransferMatching.Api.Models
                 Id = pledge.Id.Value,
                 AccountId = pledge.AccountId,
                 Amount = pledge.Amount,
+                RemainingAmount = pledge.RemainingAmount,
                 CreatedOn = pledge.CreatedOn,
                 IsNamePublic = pledge.IsNamePublic,
                 DasAccountName = pledge.IsNamePublic ? pledge.DasAccountName : "Opportunity",

--- a/src/SFA.DAS.LevyTransferMatching.UnitTests/Application/Queries/GetStandards/WhenCallingHandle.cs
+++ b/src/SFA.DAS.LevyTransferMatching.UnitTests/Application/Queries/GetStandards/WhenCallingHandle.cs
@@ -1,0 +1,58 @@
+﻿using System.Linq;
+using AutoFixture.NUnit3;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.LevyTransferMatching.Application.Queries.GetOpportunity;
+using SFA.DAS.LevyTransferMatching.Interfaces;
+using SFA.DAS.LevyTransferMatching.Models;
+using SFA.DAS.Testing.AutoFixture;
+using System.Threading;
+using System.Threading.Tasks;
+using SFA.DAS.LevyTransferMatching.Application.Queries.Standards;
+using SFA.DAS.LevyTransferMatching.InnerApi.Responses;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.InnerApi.Requests;
+using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.LevyTransferMatching.UnitTests.Application.Queries.GetStandards
+{
+    public class WhenCallingHandle
+    {
+        [Test, MoqAutoData]
+        public async Task And_No_Id_Specified_Then_All_Standards_Returned(
+            GetStandardsListResponse response,
+            [Frozen] Mock<ICoursesApiClient<CoursesApiConfiguration>> client,
+            GetStandardsQueryHandler getStandardsQueryHandler)
+        {
+            var getStandardsQuery = new GetStandardsQuery();
+
+            client
+                .Setup(x => x.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
+                .ReturnsAsync(response);
+
+            var result = await getStandardsQueryHandler.Handle(getStandardsQuery, CancellationToken.None);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(response.Standards.Count(), result.Standards.Count());
+            client.Verify(x => x.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()), Times.Once);
+        }
+
+        [Test, MoqAutoData]
+        public async Task And_Valid_Id_Specified_Then_Standard_Returned(
+            GetStandardsListItem response,
+            [Frozen] Mock<ICoursesApiClient<CoursesApiConfiguration>> client,
+            GetStandardsQueryHandler getStandardsQueryHandler)
+        {
+            var getStandardsQuery = new GetStandardsQuery() { StandardId = "1"};
+
+            client
+                .Setup(x => x.Get<GetStandardsListItem>(It.IsAny<GetStandardDetailsByIdRequest>()))
+                .ReturnsAsync(response);
+
+            var result = await getStandardsQueryHandler.Handle(getStandardsQuery, CancellationToken.None);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Standards.Count());
+        }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching/Application/Queries/GetOpportunity/GetOpportunityQueryHandler.cs
+++ b/src/SFA.DAS.LevyTransferMatching/Application/Queries/GetOpportunity/GetOpportunityQueryHandler.cs
@@ -24,6 +24,7 @@ namespace SFA.DAS.LevyTransferMatching.Application.Queries.GetOpportunity
                 {
                      AccountId = opportunity.AccountId,
                      Amount = opportunity.Amount,
+                     RemainingAmount = opportunity.RemainingAmount,
                      CreatedOn = opportunity.CreatedOn,
                      DasAccountName = opportunity.DasAccountName,
                      Id = opportunity.Id,

--- a/src/SFA.DAS.LevyTransferMatching/Application/Queries/Standards/GetStandardsQuery.cs
+++ b/src/SFA.DAS.LevyTransferMatching/Application/Queries/Standards/GetStandardsQuery.cs
@@ -4,5 +4,6 @@ namespace SFA.DAS.LevyTransferMatching.Application.Queries.Standards
 {
     public class GetStandardsQuery : IRequest<GetStandardsQueryResult>
     {
+        public string StandardId { get; set; }
     }
 }

--- a/src/SFA.DAS.LevyTransferMatching/Application/Queries/Standards/GetStandardsQueryHandler.cs
+++ b/src/SFA.DAS.LevyTransferMatching/Application/Queries/Standards/GetStandardsQueryHandler.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using SFA.DAS.LevyTransferMatching.InnerApi.Responses;
@@ -20,11 +22,23 @@ namespace SFA.DAS.LevyTransferMatching.Application.Queries.Standards
         }
         public async Task<GetStandardsQueryResult> Handle(GetStandardsQuery request, CancellationToken cancellationToken)
         {
-            var standardsResponse = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
+            var standards = new List<GetStandardsListItem>();
+
+            if (string.IsNullOrEmpty(request.StandardId))
+            {
+                var standardsResponse = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
+                standards = standardsResponse.Standards.ToList();
+            }
+
+            else
+            {
+                var standard = await _coursesApiClient.Get<GetStandardsListItem>(new GetStandardDetailsByIdRequest(request.StandardId));
+                standards.Add(standard);
+            }
 
             return new GetStandardsQueryResult
             {
-                Standards = standardsResponse.Standards
+                Standards = standards
             };
         }        
     }

--- a/src/SFA.DAS.LevyTransferMatching/Models/Pledge.cs
+++ b/src/SFA.DAS.LevyTransferMatching/Models/Pledge.cs
@@ -7,6 +7,7 @@ namespace SFA.DAS.LevyTransferMatching.Models
     {
         public long AccountId { get; set; }
         public int Amount { get; set; }
+        public int RemainingAmount { get; set; }
         public bool IsNamePublic { get; set; }
         public string DasAccountName { get; set; }
         public DateTime CreatedOn { get; set; }


### PR DESCRIPTION
Adds the ability to pass a standard id to the application-details route so we can just return the one standard