### PR TITLE
TM-151 - Issue with DefaultRequestHeader

### DIFF
--- a/src/SFA.DAS.ApprenticeCommitments/Application/Services/ApprenticeLogin/ApprenticeLoginClient.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Services/ApprenticeLogin/ApprenticeLoginClient.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Services.ApprenticeLogin
         {
         }
 
-        protected override Task AddAuthenticationHeader(HttpRequestMessage requestMessage)
+        protected override Task AddAuthenticationHeader(HttpRequestMessage httpRequestMessage)
         {
             return Task.CompletedTask;
         }

--- a/src/SFA.DAS.ApprenticeCommitments/Application/Services/ApprenticeLogin/ApprenticeLoginClient.cs
+++ b/src/SFA.DAS.ApprenticeCommitments/Application/Services/ApprenticeLogin/ApprenticeLoginClient.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.ApprenticeCommitments.Application.Services.ApprenticeLogin
         {
         }
 
-        protected override Task AddAuthenticationHeader()
+        protected override Task AddAuthenticationHeader(HttpRequestMessage requestMessage)
         {
             return Task.CompletedTask;
         }

--- a/src/SFA.DAS.Campaign/ExternalApi/ContentfulApiClient.cs
+++ b/src/SFA.DAS.Campaign/ExternalApi/ContentfulApiClient.cs
@@ -12,9 +12,9 @@ namespace SFA.DAS.Campaign.ExternalApi
         {
         }
         
-        protected override async Task AddAuthenticationHeader(HttpRequestMessage requestMessage)
+        protected override async Task AddAuthenticationHeader(HttpRequestMessage httpRequestMessage)
         {
-            requestMessage.Headers.Add("Authorization", $"Bearer {Configuration.AccessToken}");
+            httpRequestMessage.Headers.Add("Authorization", $"Bearer {Configuration.AccessToken}");
         }
     }
 }

--- a/src/SFA.DAS.Campaign/ExternalApi/ContentfulApiClient.cs
+++ b/src/SFA.DAS.Campaign/ExternalApi/ContentfulApiClient.cs
@@ -12,13 +12,9 @@ namespace SFA.DAS.Campaign.ExternalApi
         {
         }
         
-        protected override async Task AddAuthenticationHeader()
+        protected override async Task AddAuthenticationHeader(HttpRequestMessage requestMessage)
         {
-            HttpClient.DefaultRequestHeaders.Remove("Authorization");
-            HttpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {Configuration.AccessToken}");
-        }
-        protected override void AddVersionHeader(string requestVersion)
-        {
+            requestMessage.Headers.Add("Authorization", $"Bearer {Configuration.AccessToken}");
         }
     }
 }

--- a/src/SFA.DAS.SharedOuterApi/Infrastructure/ApiClient.cs
+++ b/src/SFA.DAS.SharedOuterApi/Infrastructure/ApiClient.cs
@@ -36,14 +36,14 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
       
         public async Task<ApiResponse<TResponse>> PostWithResponseCode<TResponse>(IPostApiRequest request)
         {
-            await AddAuthenticationHeader();
-
-            AddVersionHeader(request.Version);
-
             var stringContent = request.Data != null ? new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json") : null;
 
-            var response = await HttpClient.PostAsync(request.PostUrl, stringContent)
-                .ConfigureAwait(false);
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post, request.PostUrl);
+            requestMessage.AddVersion(request.Version);
+            requestMessage.Content = stringContent;
+            await AddAuthenticationHeader(requestMessage);
+            
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
 
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             
@@ -67,88 +67,88 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
         [Obsolete("Use PostWithResponseCode")]
         public async Task Post<TData>(IPostApiRequest<TData> request)
         {
-            await AddAuthenticationHeader();
-
-            AddVersionHeader(request.Version);
-
             var stringContent = request.Data != null ? new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json") : null;
-
-            var response = await HttpClient.PostAsync(request.PostUrl, stringContent)
-                .ConfigureAwait(false);
+            
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post, request.PostUrl);
+            requestMessage.AddVersion(request.Version);
+            requestMessage.Content = stringContent;
+            await AddAuthenticationHeader(requestMessage);
+            
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
 
             await response.EnsureSuccessStatusCodeIncludeContentInException();
         }
 
         public async Task Delete(IDeleteApiRequest request)
         {
-            await AddAuthenticationHeader();
-            AddVersionHeader(request.Version);
-
-            var response = await HttpClient.DeleteAsync(request.DeleteUrl)
-                .ConfigureAwait(false);
+            var requestMessage = new HttpRequestMessage(HttpMethod.Delete, request.DeleteUrl);
+            requestMessage.AddVersion(request.Version);
+            await AddAuthenticationHeader(requestMessage);
+            
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
+            
             await response.EnsureSuccessStatusCodeIncludeContentInException();
         }
 
+        [Obsolete("Use PatchWithResponseCode")]
         public async Task Patch<TData>(IPatchApiRequest<TData> request)
         {
-            await AddAuthenticationHeader();
-            AddVersionHeader(request.Version);
-
             var stringContent = request.Data != null ? new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json") : null;
-
-            var response = await HttpClient.PatchAsync(request.PatchUrl, stringContent)
-                .ConfigureAwait(false);
+            var requestMessage = new HttpRequestMessage(HttpMethod.Patch, request.PatchUrl);
+            requestMessage.AddVersion(request.Version);
+            requestMessage.Content = stringContent;
+            await AddAuthenticationHeader(requestMessage);
+            
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
+            
             await response.EnsureSuccessStatusCodeIncludeContentInException();
         }
 
         public async Task<ApiResponse<string>> PatchWithResponseCode<TData>(IPatchApiRequest<TData> request)
         {
-            await AddAuthenticationHeader();
-
-            AddVersionHeader(request.Version);
-
             var stringContent = request.Data != null ? new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json") : null;
+            var requestMessage = new HttpRequestMessage(HttpMethod.Patch, request.PatchUrl);
+            requestMessage.AddVersion(request.Version);
+            requestMessage.Content = stringContent;
+            await AddAuthenticationHeader(requestMessage);
 
-            var response = await HttpClient.PatchAsync(request.PatchUrl, stringContent)
-                .ConfigureAwait(false);
-
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             return new ApiResponse<string>(responseContent, response.StatusCode, ""); //TODO - Error content should be correctly set
         }
 
         public async Task Put(IPutApiRequest request)
-
         {
-            await AddAuthenticationHeader();
-
-            AddVersionHeader(request.Version);
-
             var stringContent = request.Data != null ? new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json") : null;
+            var requestMessage = new HttpRequestMessage(HttpMethod.Put, request.PutUrl);
+            requestMessage.AddVersion(request.Version);
+            requestMessage.Content = stringContent;
+            await AddAuthenticationHeader(requestMessage);
 
-            var response = await HttpClient.PutAsync(request.PutUrl, stringContent)
-                .ConfigureAwait(false);
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
             await response.EnsureSuccessStatusCodeIncludeContentInException();
         }
 
         public async Task Put<TData>(IPutApiRequest<TData> request)
         {
-            await AddAuthenticationHeader();
-
-            AddVersionHeader(request.Version);
-
             var stringContent = request.Data != null ? new StringContent(JsonConvert.SerializeObject(request.Data), Encoding.UTF8, "application/json") : null;
-
-            var response = await HttpClient.PutAsync(request.PutUrl, stringContent)
-                .ConfigureAwait(false);
+            var requestMessage = new HttpRequestMessage(HttpMethod.Put, request.PutUrl);
+            requestMessage.AddVersion(request.Version);
+            requestMessage.Content = stringContent;
+            await AddAuthenticationHeader(requestMessage);
+            
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
             await response.EnsureSuccessStatusCodeIncludeContentInException();
         }
 
         public async Task<IEnumerable<TResponse>> GetAll<TResponse>(IGetAllApiRequest request)
         {
-            await AddAuthenticationHeader();
-            AddVersionHeader(request.Version);
-            var response = await HttpClient.GetAsync(request.GetAllUrl).ConfigureAwait(false);
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, request.GetAllUrl);
+            requestMessage.AddVersion(request.Version);
+            await AddAuthenticationHeader(requestMessage);
+            
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -161,19 +161,22 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
 
         public async Task<HttpStatusCode> GetResponseCode(IGetApiRequest request)
         {
-            await AddAuthenticationHeader();
-            AddVersionHeader(request.Version);
-            var response = await HttpClient.GetAsync(request.GetUrl).ConfigureAwait(false);
-
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, request.GetUrl);
+            requestMessage.AddVersion(request.Version);
+            await AddAuthenticationHeader(requestMessage);
+            
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
+            
             return response.StatusCode;
         }
 
         public async Task<PagedResponse<TResponse>> GetPaged<TResponse>(IGetPagedApiRequest request)
         {
-            await AddAuthenticationHeader();
-            AddVersionHeader(request.Version);
-
-            var response = await HttpClient.GetAsync(request.GetPagedUrl).ConfigureAwait(false);
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, request.GetPagedUrl);
+            requestMessage.AddVersion(request.Version);
+            await AddAuthenticationHeader(requestMessage);
+            
+            var response = await HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/SFA.DAS.SharedOuterApi/Infrastructure/CustomerEngagementApiClient.cs
+++ b/src/SFA.DAS.SharedOuterApi/Infrastructure/CustomerEngagementApiClient.cs
@@ -12,14 +12,9 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
         {
         }
 
-        protected override async Task AddAuthenticationHeader()
+        protected override async Task AddAuthenticationHeader(HttpRequestMessage requestMessage)
         {
-            HttpClient.DefaultRequestHeaders.Remove("Ocp-Apim-Subscription-Key");
-            HttpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", Configuration.SubscriptionKey);
-        }
-
-        protected override void AddVersionHeader(string requestVersion)
-        {
+            requestMessage.Headers.Add("Ocp-Apim-Subscription-Key", Configuration.SubscriptionKey);
         }
     }
 }

--- a/src/SFA.DAS.SharedOuterApi/Infrastructure/CustomerEngagementApiClient.cs
+++ b/src/SFA.DAS.SharedOuterApi/Infrastructure/CustomerEngagementApiClient.cs
@@ -12,9 +12,9 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
         {
         }
 
-        protected override async Task AddAuthenticationHeader(HttpRequestMessage requestMessage)
+        protected override async Task AddAuthenticationHeader(HttpRequestMessage httpRequestMessage)
         {
-            requestMessage.Headers.Add("Ocp-Apim-Subscription-Key", Configuration.SubscriptionKey);
+            httpRequestMessage.Headers.Add("Ocp-Apim-Subscription-Key", Configuration.SubscriptionKey);
         }
     }
 }

--- a/src/SFA.DAS.SharedOuterApi/Infrastructure/GetApiClient.cs
+++ b/src/SFA.DAS.SharedOuterApi/Infrastructure/GetApiClient.cs
@@ -81,7 +81,7 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
             return !((int)statusCode >= 200 && (int)statusCode <= 299);
         }
 
-        protected abstract Task AddAuthenticationHeader(HttpRequestMessage requestMessage);
+        protected abstract Task AddAuthenticationHeader(HttpRequestMessage httpRequestMessage);
 
     }
 }

--- a/src/SFA.DAS.SharedOuterApi/Infrastructure/GetApiClient.cs
+++ b/src/SFA.DAS.SharedOuterApi/Infrastructure/GetApiClient.cs
@@ -40,22 +40,22 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
 
         public async Task<HttpStatusCode> GetResponseCode(IGetApiRequest request)
         {
-            await AddAuthenticationHeader();
-
-            AddVersionHeader(request.Version);
-
-            var response = await HttpClient.GetAsync(request.GetUrl).ConfigureAwait(false);
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, request.GetUrl);
+            httpRequestMessage.AddVersion(request.Version);
+            await AddAuthenticationHeader(httpRequestMessage);
+            
+            var response = await HttpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
 
             return response.StatusCode;
         }
 
         public async Task<ApiResponse<TResponse>> GetWithResponseCode<TResponse>(IGetApiRequest request)
         {
-            await AddAuthenticationHeader();
-
-            AddVersionHeader(request.Version);
-
-            var response = await HttpClient.GetAsync(request.GetUrl).ConfigureAwait(false);
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, request.GetUrl);
+            httpRequestMessage.AddVersion(request.Version);
+            await AddAuthenticationHeader(httpRequestMessage);
+            
+            var response = await HttpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
 
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             
@@ -81,8 +81,7 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
             return !((int)statusCode >= 200 && (int)statusCode <= 299);
         }
 
-        protected abstract Task AddAuthenticationHeader();
+        protected abstract Task AddAuthenticationHeader(HttpRequestMessage requestMessage);
 
-        protected abstract void AddVersionHeader(string requestVersion);
     }
 }

--- a/src/SFA.DAS.SharedOuterApi/Infrastructure/HttpRequestMessageExtensions.cs
+++ b/src/SFA.DAS.SharedOuterApi/Infrastructure/HttpRequestMessageExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Net.Http;
+
+namespace SFA.DAS.SharedOuterApi.Infrastructure
+{
+    public static class HttpRequestMessageExtensions
+    {
+        public static void AddVersion(this HttpRequestMessage request, string version)
+        {
+            request.Headers.Add("X-Version", version);
+        }
+    }
+}

--- a/src/SFA.DAS.SharedOuterApi/Infrastructure/HttpRequestMessageExtensions.cs
+++ b/src/SFA.DAS.SharedOuterApi/Infrastructure/HttpRequestMessageExtensions.cs
@@ -4,9 +4,9 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
 {
     public static class HttpRequestMessageExtensions
     {
-        public static void AddVersion(this HttpRequestMessage request, string version)
+        public static void AddVersion(this HttpRequestMessage httpRequestMessage, string version)
         {
-            request.Headers.Add("X-Version", version);
+            httpRequestMessage.Headers.Add("X-Version", version);
         }
     }
 }

--- a/src/SFA.DAS.SharedOuterApi/Infrastructure/InternalApiClient.cs
+++ b/src/SFA.DAS.SharedOuterApi/Infrastructure/InternalApiClient.cs
@@ -21,19 +21,13 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
             _azureClientCredentialHelper = azureClientCredentialHelper;
         }
 
-        protected override async Task AddAuthenticationHeader()
+        protected override async Task AddAuthenticationHeader(HttpRequestMessage request)
         {
             if (!HostingEnvironment.IsDevelopment())
             {
                 var accessToken = await _azureClientCredentialHelper.GetAccessTokenAsync(Configuration.Identifier);
-                HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             }
-        }
-
-        protected override void AddVersionHeader(string requestVersion)
-        {
-            HttpClient.DefaultRequestHeaders.Remove("X-Version");
-            HttpClient.DefaultRequestHeaders.Add("X-Version", requestVersion);
         }
     }
 }

--- a/src/SFA.DAS.SharedOuterApi/Infrastructure/InternalApiClient.cs
+++ b/src/SFA.DAS.SharedOuterApi/Infrastructure/InternalApiClient.cs
@@ -21,12 +21,12 @@ namespace SFA.DAS.SharedOuterApi.Infrastructure
             _azureClientCredentialHelper = azureClientCredentialHelper;
         }
 
-        protected override async Task AddAuthenticationHeader(HttpRequestMessage request)
+        protected override async Task AddAuthenticationHeader(HttpRequestMessage httpRequestMessage)
         {
             if (!HostingEnvironment.IsDevelopment())
             {
                 var accessToken = await _azureClientCredentialHelper.GetAccessTokenAsync(Configuration.Identifier);
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+                httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             }
         }
     }


### PR DESCRIPTION
Change so that the default request header is no longer used for the version or authorization due to the default headers not being thread safe. The version and auth are now added to the request instead