### PR TITLE
[TM-132] Confirmation Page for Declined Funds (Receiver)

### DIFF
--- a/src/SFA.DAS.LevyTransferMatching.Api.UnitTests/Controllers/ApplicationTests/WhenCallingDeclined.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Api.UnitTests/Controllers/ApplicationTests/WhenCallingDeclined.cs
@@ -1,0 +1,54 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.LevyTransferMatching.Api.Controllers;
+using SFA.DAS.LevyTransferMatching.Api.Models.Applications;
+using SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetDeclined;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.LevyTransferMatching.Api.UnitTests.Controllers.ApplicationTests
+{
+    public class WhenCallingDeclined
+    {
+        [Test, MoqAutoData]
+        public async Task And_Result_Exists_Then_Returns_Ok_And_Result(
+            int applicationId,
+            GetDeclinedResult getDeclinedResult,
+            [Frozen] Mock<IMediator> mockMediator,
+            [Greedy] ApplicationsController applicationController)
+        {
+            mockMediator
+                .Setup(x => x.Send(It.Is<GetDeclinedQuery>(y => y.ApplicationId == applicationId), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(getDeclinedResult);
+
+            var controllerResult = await applicationController.Declined(applicationId);
+            var okObjectResult = controllerResult as OkObjectResult;
+            var getDeclinedResponse = okObjectResult.Value as GetDeclinedResponse;
+
+            Assert.IsNotNull(controllerResult);
+            Assert.IsNotNull(okObjectResult);
+            Assert.IsNotNull(getDeclinedResponse);
+        }
+
+        [Test, MoqAutoData]
+        public async Task And_Result_Doesnt_Exist_Then_Returns_NotFound(
+            int applicationId,
+            [Frozen] Mock<IMediator> mockMediator,
+            [Greedy] ApplicationsController applicationController)
+        {
+            mockMediator
+                .Setup(x => x.Send(It.Is<GetDeclinedQuery>(y => y.ApplicationId == applicationId), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((GetDeclinedResult)null);
+
+            var controllerResult = await applicationController.Application(applicationId);
+            var notFoundResult = controllerResult as NotFoundResult;
+
+            Assert.IsNotNull(controllerResult);
+            Assert.IsNotNull(notFoundResult);
+        }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.Api/Controllers/ApplicationsController.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Api/Controllers/ApplicationsController.cs
@@ -9,6 +9,7 @@ using SFA.DAS.LevyTransferMatching.Application.Commands.SetApplicationAcceptance
 using SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetApplications;
 using SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetApplication;
 using SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetAccepted;
+using SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetDeclined;
 
 namespace SFA.DAS.LevyTransferMatching.Api.Controllers
 {
@@ -113,6 +114,34 @@ namespace SFA.DAS.LevyTransferMatching.Api.Controllers
             catch (Exception e)
             {
                 _logger.LogError(e, $"Error attempting to get {nameof(Accepted)} result");
+                return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
+            }
+        }
+
+        [HttpGet]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.NotFound)]
+        [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
+        [Route("/accounts/{accountId}/applications/{applicationId}/declined")]
+        public async Task<IActionResult> Declined(int applicationId)
+        {
+            try
+            {
+                var result = await _mediator.Send(new GetDeclinedQuery()
+                {
+                    ApplicationId = applicationId,
+                });
+
+                if (result != null)
+                {
+                    return Ok((GetDeclinedResponse)result);
+                }
+
+                return NotFound();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Error attempting to get {nameof(Declined)} result");
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }

--- a/src/SFA.DAS.LevyTransferMatching.Api/Models/Applications/GetDeclinedResponse.cs
+++ b/src/SFA.DAS.LevyTransferMatching.Api/Models/Applications/GetDeclinedResponse.cs
@@ -1,0 +1,19 @@
+﻿using SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetDeclined;
+
+namespace SFA.DAS.LevyTransferMatching.Api.Models.Applications
+{
+    public class GetDeclinedResponse
+    {
+        public string EmployerAccountName { get; set; }
+        public int OpportunityId { get; set; }
+
+        public static implicit operator GetDeclinedResponse(GetDeclinedResult result)
+        {
+            return new GetDeclinedResponse()
+            {
+                EmployerAccountName = result.EmployerAccountName,
+                OpportunityId = result.OpportunityId,
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching.UnitTests/Application/Queries/Applications/GetDeclined/WhenCallingHandle.cs
+++ b/src/SFA.DAS.LevyTransferMatching.UnitTests/Application/Queries/Applications/GetDeclined/WhenCallingHandle.cs
@@ -1,0 +1,57 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.NUnit3;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetDeclined;
+using SFA.DAS.LevyTransferMatching.InnerApi.Requests.Applications;
+using SFA.DAS.LevyTransferMatching.InnerApi.Responses;
+using SFA.DAS.LevyTransferMatching.Interfaces;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.LevyTransferMatching.UnitTests.Application.Queries.Applications.GetDeclined
+{
+    public class WhenCallingHandle
+    {
+        private Fixture _fixture;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Test, MoqAutoData]
+        public async Task And_Application_Exists_Response_Returned(
+            GetDeclinedQuery getDeclinedQuery,
+            GetApplicationResponse getApplicationResponse,
+            [Frozen] Mock<ILevyTransferMatchingService> mockLevyTransferMatchingService,
+            GetDeclinedQueryHandler getDeclinedQueryHandler)
+        {
+            mockLevyTransferMatchingService
+                .Setup(x => x.GetApplication(It.Is<GetApplicationRequest>(y => y.GetUrl.Contains(getDeclinedQuery.ApplicationId.ToString()))))
+                .ReturnsAsync(getApplicationResponse);
+
+            var result = await getDeclinedQueryHandler.Handle(getDeclinedQuery, CancellationToken.None);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(getApplicationResponse.PledgeEmployerAccountName, result.EmployerAccountName);
+        }
+
+        [Test, MoqAutoData]
+        public async Task And_Application_Doesnt_Exist_Returns_Null(
+            GetDeclinedQuery getDeclinedQuery,
+            [Frozen] Mock<ILevyTransferMatchingService> mockLevyTransferMatchingService,
+            GetDeclinedQueryHandler getDeclinedQueryHandler)
+        {
+            mockLevyTransferMatchingService
+                .Setup(x => x.GetApplication(It.Is<GetApplicationRequest>(y => y.GetUrl.Contains(getDeclinedQuery.ApplicationId.ToString()))))
+                .ReturnsAsync((GetApplicationResponse)null);
+
+            var result = await getDeclinedQueryHandler.Handle(getDeclinedQuery, CancellationToken.None);
+
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching/Application/Queries/Applications/GetDeclined/GetDeclinedQuery.cs
+++ b/src/SFA.DAS.LevyTransferMatching/Application/Queries/Applications/GetDeclined/GetDeclinedQuery.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetDeclined
+{
+    public class GetDeclinedQuery : IRequest<GetDeclinedResult>
+    {
+        public int ApplicationId { get; set; }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching/Application/Queries/Applications/GetDeclined/GetDeclinedQueryHandler.cs
+++ b/src/SFA.DAS.LevyTransferMatching/Application/Queries/Applications/GetDeclined/GetDeclinedQueryHandler.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using SFA.DAS.LevyTransferMatching.InnerApi.Requests.Applications;
+using SFA.DAS.LevyTransferMatching.Interfaces;
+
+namespace SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetDeclined
+{
+    public class GetDeclinedQueryHandler : IRequestHandler<GetDeclinedQuery, GetDeclinedResult>
+    {
+        private readonly ILevyTransferMatchingService _levyTransferMatchingService;
+
+        public GetDeclinedQueryHandler(ILevyTransferMatchingService levyTransferMatchingService)
+        {
+            _levyTransferMatchingService = levyTransferMatchingService;
+        }
+
+        public async Task<GetDeclinedResult> Handle(GetDeclinedQuery request, CancellationToken cancellationToken)
+        {
+            var application = await _levyTransferMatchingService.GetApplication(new GetApplicationRequest(request.ApplicationId));
+
+            if (application == null)
+            {
+                return null;
+            }
+
+            return new GetDeclinedResult()
+            {
+                EmployerAccountName = application.PledgeEmployerAccountName,
+                OpportunityId = application.PledgeId,
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.LevyTransferMatching/Application/Queries/Applications/GetDeclined/GetDeclinedResult.cs
+++ b/src/SFA.DAS.LevyTransferMatching/Application/Queries/Applications/GetDeclined/GetDeclinedResult.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.LevyTransferMatching.Application.Queries.Applications.GetDeclined
+{
+    public class GetDeclinedResult
+    {
+        public string EmployerAccountName { get; set; }
+        public int OpportunityId { get; set; }
+    }
+}


### PR DESCRIPTION
APIM changes required for the confirmation page when declining accepted funds.

Note: targets `TM-54-Decline-Funding-For-Approved-Applications`.

See also:

* https://github.com/SkillsFundingAgency/das-levy-transfer-matching-web/pull/110