### PR TITLE
FAI-221 - Add mapping for fields from HttpRequestContentException

### DIFF
--- a/src/SFA.DAS.Vacancies.Manage.Api.UnitTests/Controllers/WhenCreatingVacancy.cs
+++ b/src/SFA.DAS.Vacancies.Manage.Api.UnitTests/Controllers/WhenCreatingVacancy.cs
@@ -148,7 +148,7 @@ namespace SFA.DAS.Vacancies.Manage.Api.UnitTests.Controllers
         }
         
         [Test, MoqAutoData]
-        public async Task Then_If_ContentException_Bad_Request_Is_Returned(
+        public async Task Then_If_ContentException_Bad_Request_Is_Returned_And_Error_Keys_Mapped(
             Guid id,
             string errorContent,
             CreateVacancyRequest request,
@@ -161,12 +161,12 @@ namespace SFA.DAS.Vacancies.Manage.Api.UnitTests.Controllers
                 .Setup(mediator => mediator.Send(
                     It.IsAny<CreateVacancyCommand>(),
                     It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new HttpRequestContentException("Error", HttpStatusCode.BadRequest,errorContent));
+                .ThrowsAsync(new HttpRequestContentException("Error", HttpStatusCode.BadRequest,@"{""errors"":[{""field"":""ProgrammeId"",""message"":""Training programme a does not exist.""},{""field"":""employerName"",""message"":""Employer name is not in the correct format.""},{""field"":""employerNameOption"",""message"":""Invalid employer name option.""}]}"));
             
             var controllerResult = await controller.CreateVacancy(accountIdentifier, id, request) as ObjectResult;
 
             controllerResult!.StatusCode.Should().Be((int) HttpStatusCode.BadRequest);
-            controllerResult.Value.Should().Be(errorContent);
+            controllerResult.Value.Should().Be(@"{""errors"":[{""field"":""standardLarsCode"",""message"":""Training programme a does not exist.""},{""field"":""alternativeEmployerName"",""message"":""Employer name is not in the correct format.""},{""field"":""employerNameOption"",""message"":""Invalid employer name option.""}]}");
         }
         
         [Test, MoqAutoData]

--- a/src/SFA.DAS.Vacancies.Manage.Api/Controllers/VacancyController.cs
+++ b/src/SFA.DAS.Vacancies.Manage.Api/Controllers/VacancyController.cs
@@ -95,7 +95,11 @@ namespace SFA.DAS.Vacancies.Manage.Api.Controllers
             }
             catch (HttpRequestContentException e)
             {
-                return StatusCode((int) e.StatusCode, e.ErrorContent);
+                var content = e.ErrorContent
+                    .Replace("ProgrammeId", "standardLarsCode", StringComparison.CurrentCultureIgnoreCase)
+                    .Replace(@"EmployerName""",@"alternativeEmployerName""", StringComparison.CurrentCultureIgnoreCase);
+                
+                return StatusCode((int) e.StatusCode, content);
             }
             catch (SecurityException e)
             {

--- a/src/SFA.DAS.Vacancies.Manage.Api/Models/CreateVacancyRequest.cs
+++ b/src/SFA.DAS.Vacancies.Manage.Api/Models/CreateVacancyRequest.cs
@@ -77,7 +77,7 @@ namespace SFA.DAS.Vacancies.Manage.Api.Models
         /// The LARS code associated with the Standard you wish to create the advert for. This can be found from `GET referencedata/courses`
         /// </summary>
         /// <example>119</example>
-        [JsonProperty("standardLarsCode")]
+        [JsonProperty("standardLarsCode", Required = Required.Always)]
         public string ProgrammeId { get ; set ; }
         /// <summary>
         /// If `EmployerNameOption` is set to `TradingName` then will be used and Trading name in the application updated. If it is set to `Anonymous` then will be used for the anonymous employer name. If it is set to `RegisteredName` then the Account Legal Entity name will be used. Must not exceed 100 characters


### PR DESCRIPTION
Add mapping for standards lars code and the alternative employer name if there is a validation error from the inner api