### PR TITLE
FAI-236 - Set FixedWageYearAmount to null if not Fixed wage

### DIFF
--- a/src/SFA.DAS.Vacancies.Manage.Api.UnitTests/Models/WhenMappingCreateVacancyRequestToMediatorCommand.cs
+++ b/src/SFA.DAS.Vacancies.Manage.Api.UnitTests/Models/WhenMappingCreateVacancyRequestToMediatorCommand.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using SFA.DAS.Vacancies.Manage.Api.Models;
 using SFA.DAS.Vacancies.Manage.InnerApi.Requests;
+using WageType = SFA.DAS.Vacancies.Manage.Api.Models.WageType;
 
 namespace SFA.DAS.Vacancies.Manage.Api.UnitTests.Models
 {
@@ -11,6 +12,7 @@ namespace SFA.DAS.Vacancies.Manage.Api.UnitTests.Models
         [Test, AutoData]
         public void Then_The_Fields_Are_Correctly_Mapped_For_Employer(CreateVacancyRequest source)
         {
+            source.Wage.WageType = WageType.FixedWage;
             var actual = (PostVacancyRequestData) source;
             
             actual.Should().BeEquivalentTo(source, options=> options
@@ -22,6 +24,18 @@ namespace SFA.DAS.Vacancies.Manage.Api.UnitTests.Models
             actual.User.Email.Should().Be(source.SubmitterContactDetails.Email);
             actual.User.Name.Should().Be(source.SubmitterContactDetails.Name);
             
+        }
+
+        [Test]
+        [InlineAutoData(WageType.NationalMinimumWage)]
+        [InlineAutoData(WageType.NationalMinimumWageForApprentices)]
+        public void Then_If_The_Wage_Is_Not_Fixed_Then_Value_Set_To_Null(WageType wageType, CreateVacancyRequest source)
+        {
+            source.Wage.WageType = wageType;
+            
+            var actual = (PostVacancyRequestData) source;
+
+            actual.Wage.FixedWageYearlyAmount.Should().BeNull();
         }
     }
 }

--- a/src/SFA.DAS.Vacancies.Manage.Api/Models/CreateVacancyRequest.cs
+++ b/src/SFA.DAS.Vacancies.Manage.Api/Models/CreateVacancyRequest.cs
@@ -248,7 +248,7 @@ namespace SFA.DAS.Vacancies.Manage.Api.Models
                 WeeklyHours = source.WeeklyHours,
                 Duration = source.Duration,
                 WorkingWeekDescription = source.WorkingWeekDescription,
-                FixedWageYearlyAmount = source.FixedWageYearlyAmount,
+                FixedWageYearlyAmount = source.WageType == WageType.FixedWage ?  source.FixedWageYearlyAmount : null,
                 DurationUnit = (InnerApi.Requests.DurationUnit)durationUnit,
                 WageType = (InnerApi.Requests.WageType)wageType
             };


### PR DESCRIPTION
Fix an issue where the fixed waged was not being correctly set to null for cases where the wage type was not fixed. This was then causing issues in FAA when indexing the data.