### PR TITLE
QF-856 Remove Headers from Apprentice Feedback

### DIFF
--- a/src/ApprenticeFeedback/SFA.DAS.ApprenticeFeedback.Api/web.config
+++ b/src/ApprenticeFeedback/SFA.DAS.ApprenticeFeedback.Api/web.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<system.webServer>
+		<security>
+			<requestFiltering removeServerHeader="true" />
+		</security>
+		<httpProtocol>
+			<customHeaders>
+				<remove name="X-Powered-By" />
+			</customHeaders>
+		</httpProtocol>
+	</system.webServer>
+</configuration>


### PR DESCRIPTION
Remove the 'X-Powered-By' and 'Server' headers from the Apprentice Feedback Outer API to resolve pen test issues.