### PR TITLE
CSP-579 Added GetApprentice endpoint

### DIFF
--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api.UnitTests/Controllers/ApprenticesControllerTests/GetAccountTests.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api.UnitTests/Controllers/ApprenticesControllerTests/GetAccountTests.cs
@@ -7,9 +7,9 @@ using SFA.DAS.ApprenticeAan.Api.Controllers;
 using SFA.DAS.ApprenticeAan.Application.ApprenticeAccount.Queries.GetApprenticeAccount;
 using SFA.DAS.Testing.AutoFixture;
 
-namespace SFA.DAS.ApprenticeAan.Api.UnitTests.Controllers;
+namespace SFA.DAS.ApprenticeAan.Api.UnitTests.Controllers.ApprenticesControllerTests;
 
-public class ApprenticesControllerTests
+public class GetAccountTests
 {
     [Test]
     [MoqAutoData]

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api.UnitTests/Controllers/ApprenticesControllerTests/GetApprenticeTests.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api.UnitTests/Controllers/ApprenticesControllerTests/GetApprenticeTests.cs
@@ -1,0 +1,55 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SFA.DAS.ApprenticeAan.Api.Controllers;
+using SFA.DAS.ApprenticeAan.Application.Apprentices.Queries.GetApprentice;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.ApprenticeAan.Api.UnitTests.Controllers.ApprenticesControllerTests;
+
+public class GetApprenticeTests
+{
+    [Test, MoqAutoData]
+    public async Task GetApprentice_InvokesMediator(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] ApprenticesController sut,
+        Guid apprenticeId,
+        CancellationToken cancellationToken)
+    {
+        await sut.GetApprentice(apprenticeId, cancellationToken);
+
+        mediatorMock.Verify(m => m.Send(It.Is<GetApprenticeQuery>(q => q.ApprenticeId == apprenticeId), cancellationToken));
+    }
+
+    [Test, MoqAutoData]
+    public async Task GetApprentice_RecordNotFound_ReturnsNotFoundResponse(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] ApprenticesController sut,
+        Guid apprenticeId,
+        CancellationToken cancellationToken)
+    {
+        mediatorMock.Setup(m => m.Send(It.Is<GetApprenticeQuery>(q => q.ApprenticeId == apprenticeId), cancellationToken)).ReturnsAsync(() => null);
+
+        var result = await sut.GetApprentice(apprenticeId, cancellationToken);
+
+        result.As<NotFoundResult>().Should().NotBeNull();
+    }
+
+    [Test, MoqAutoData]
+    public async Task GetApprentice_RecordFound_ReturnsOkResponse(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] ApprenticesController sut,
+        GetApprenticeQueryResult expectedResult,
+        Guid apprenticeId,
+        CancellationToken cancellationToken)
+    {
+        mediatorMock.Setup(m => m.Send(It.Is<GetApprenticeQuery>(q => q.ApprenticeId == apprenticeId), cancellationToken)).ReturnsAsync(expectedResult);
+
+        var result = await sut.GetApprentice(apprenticeId, cancellationToken);
+
+        result.As<OkObjectResult>().Should().NotBeNull();
+        result.As<OkObjectResult>().Value.As<GetApprenticeQueryResult?>().Should().Be(expectedResult);
+    }
+}

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api/Controllers/ApprenticesController.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api/Controllers/ApprenticesController.cs
@@ -1,6 +1,7 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.ApprenticeAan.Application.ApprenticeAccount.Queries.GetApprenticeAccount;
+using SFA.DAS.ApprenticeAan.Application.Apprentices.Queries.GetApprentice;
 
 namespace SFA.DAS.ApprenticeAan.Api.Controllers;
 
@@ -16,7 +17,7 @@ public class ApprenticesController : ControllerBase
     }
 
     [HttpGet]
-    [Route("account/{apprenticeId}")]
+    [Route("{apprenticeId}/account")]
     [ProducesResponseType(typeof(GetApprenticeAccountQueryResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetAccount(Guid apprenticeId, CancellationToken cancellationToken)
@@ -25,4 +26,18 @@ public class ApprenticesController : ControllerBase
         if (apprenticeAccountDetails == null) return NotFound();
         return Ok(apprenticeAccountDetails);
     }
+
+    [HttpGet]
+    [Route("{apprenticeId}")]
+    [ProducesResponseType(typeof(GetApprenticeQueryResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetApprentice(Guid apprenticeId, CancellationToken cancellationToken)
+    {
+        var apprentice = await _mediator.Send(new GetApprenticeQuery(apprenticeId), cancellationToken);
+
+        if (apprentice == null) return NotFound();
+
+        return Ok(apprentice);
+    }
+
 }

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application.UnitTests/Apprentices/Queries/GetApprentice/GetApprenticeQueryHandlerTests.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application.UnitTests/Apprentices/Queries/GetApprentice/GetApprenticeQueryHandlerTests.cs
@@ -1,0 +1,22 @@
+﻿using AutoFixture.NUnit3;
+using Moq;
+using SFA.DAS.ApprenticeAan.Api.Configuration;
+using SFA.DAS.ApprenticeAan.Application.Apprentices.Queries.GetApprentice;
+using SFA.DAS.ApprenticeAan.Application.InnerApi.Apprentices;
+using SFA.DAS.ApprenticeAan.Application.Services;
+
+namespace SFA.DAS.ApprenticeAan.Application.UnitTests.Apprentices.Queries.GetApprentice;
+
+public class GetApprenticeQueryHandlerTests
+{
+    [Test, AutoData]
+    public async Task Handle_InvokesApiClient(GetApprenticeQuery query, CancellationToken cancellationToken)
+    {
+        Mock<IAanHubApiClient<AanHubApiConfiguration>> apiClientMock = new();
+        GetApprenticeQueryHandler sut = new(apiClientMock.Object);
+
+        await sut.Handle(query, cancellationToken);
+
+        apiClientMock.Verify(c => c.Get<GetApprenticeQueryResult?>(It.Is<GetApprenticeRequest>(r => r.ApprenticeId == query.ApprenticeId)));
+    }
+}

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application.UnitTests/InnerApi/Apprentices/GetApprenticeRequestTests.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application.UnitTests/InnerApi/Apprentices/GetApprenticeRequestTests.cs
@@ -1,0 +1,16 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using SFA.DAS.ApprenticeAan.Application.InnerApi.Apprentices;
+
+namespace SFA.DAS.ApprenticeAan.Application.UnitTests.InnerApi.Apprentices;
+
+public class GetApprenticeRequestTests
+{
+    [Test, AutoData]
+    public void GetUrl_HasCorrectUrl(Guid apprenticeId)
+    {
+        GetApprenticeRequest sut = new(apprenticeId);
+
+        sut.GetUrl.Should().Be($"apprentices/{apprenticeId}");
+    }
+}

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/Apprentices/Queries/GetApprentice/GetApprenticeQuery.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/Apprentices/Queries/GetApprentice/GetApprenticeQuery.cs
@@ -1,0 +1,5 @@
+﻿using MediatR;
+
+namespace SFA.DAS.ApprenticeAan.Application.Apprentices.Queries.GetApprentice;
+
+public record GetApprenticeQuery(Guid ApprenticeId) : IRequest<GetApprenticeQueryResult?>;

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/Apprentices/Queries/GetApprentice/GetApprenticeQueryHandler.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/Apprentices/Queries/GetApprentice/GetApprenticeQueryHandler.cs
@@ -1,0 +1,22 @@
+﻿using MediatR;
+using SFA.DAS.ApprenticeAan.Api.Configuration;
+using SFA.DAS.ApprenticeAan.Application.InnerApi.Apprentices;
+using SFA.DAS.ApprenticeAan.Application.Services;
+
+namespace SFA.DAS.ApprenticeAan.Application.Apprentices.Queries.GetApprentice;
+
+public class GetApprenticeQueryHandler : IRequestHandler<GetApprenticeQuery, GetApprenticeQueryResult?>
+{
+    private readonly IAanHubApiClient<AanHubApiConfiguration> _apiClient;
+
+    public GetApprenticeQueryHandler(IAanHubApiClient<AanHubApiConfiguration> apiClient)
+    {
+        _apiClient = apiClient;
+    }
+
+    public Task<GetApprenticeQueryResult?> Handle(GetApprenticeQuery request, CancellationToken cancellationToken)
+    {
+        return _apiClient.Get<GetApprenticeQueryResult?>(new GetApprenticeRequest(request.ApprenticeId));
+    }
+}
+

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/Apprentices/Queries/GetApprentice/GetApprenticeQueryResult.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/Apprentices/Queries/GetApprentice/GetApprenticeQueryResult.cs
@@ -1,0 +1,13 @@
+﻿namespace SFA.DAS.ApprenticeAan.Application.Apprentices.Queries.GetApprentice;
+
+public class GetApprenticeQueryResult
+{
+    public Guid MemberId { get; set; }
+    public string FirstName { get; set; } = null!;
+    public string LastName { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public string OrganisationName { get; set; } = null!;
+    public string Status { get; set; } = null!;
+    public int RegionId { get; set; }
+}
+

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/InnerApi/Apprentices/GetApprenticeRequest.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/InnerApi/Apprentices/GetApprenticeRequest.cs
@@ -1,0 +1,11 @@
+﻿using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.ApprenticeAan.Application.InnerApi.Apprentices;
+
+public class GetApprenticeRequest : IGetApiRequest
+{
+    public Guid ApprenticeId { get; }
+    public string GetUrl => $"apprentices/{ApprenticeId}";
+
+    public GetApprenticeRequest(Guid apprenticeId) => ApprenticeId = apprenticeId;
+}


### PR DESCRIPTION
Also the existing account endpoint which had wrong route `apprentices/account/{apprenticeId}` has been corrected as `apprentices/{apprenticeId}/account` to make it consistent.