### PR TITLE
CSP-989 Add get notification endpoint to apprentice API

### DIFF
--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api.UnitTests/Controllers/NotificationsControllerTests.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api.UnitTests/Controllers/NotificationsControllerTests.cs
@@ -1,0 +1,81 @@
+﻿using System.Net;
+using AutoFixture.NUnit3;
+using FluentAssertions.Execution;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SFA.DAS.ApprenticeAan.Api.Controllers;
+using SFA.DAS.ApprenticeAan.Application.Infrastructure;
+using SFA.DAS.ApprenticeAan.Application.InnerApi.Notifications;
+using SFA.DAS.Testing.AutoFixture;
+using RestEase;
+
+namespace SFA.DAS.ApprenticeAan.Api.UnitTests.Controllers;
+public class NotificationsControllerTests
+{
+    [Test, MoqAutoData]
+    public async Task GetNotification_InvokesApiClientAndNullReturned_ReturnsOkWithNullValueResponse(
+    [Frozen] Mock<IAanHubRestApiClient> apiClientMock,
+    [Greedy] NotificationsController sut,
+    GetNotificationResponse notificationsResponse,
+    Guid notificationId,
+    Guid requestedByMemberId)
+    {
+        notificationsResponse.MemberId = requestedByMemberId;
+        apiClientMock.Setup(a => a.GetNotification(notificationId, requestedByMemberId, It.IsAny<CancellationToken>())).ReturnsAsync(new Response<GetNotificationResponse?>(string.Empty, new(HttpStatusCode.NotFound), () => null));
+
+        var actual = await sut.GetNotification(notificationId, requestedByMemberId, It.IsAny<CancellationToken>());
+        var actualObjectResult = actual as ObjectResult;
+
+        using (new AssertionScope())
+        {
+            apiClientMock.Verify(a => a.GetNotification(notificationId, requestedByMemberId, It.IsAny<CancellationToken>()));
+            actualObjectResult.Should().BeOfType<OkObjectResult>();
+            actualObjectResult!.StatusCode.Should().Be(200);
+            actualObjectResult.Value.Should().BeNull();
+        }
+    }
+
+    [Test, MoqAutoData]
+    public async Task GetNotification_InvokesApiClientAndNotificationReturned_ReturnsOkWithValueResponse(
+    [Frozen] Mock<IAanHubRestApiClient> apiClientMock,
+    [Greedy] NotificationsController sut,
+    GetNotificationResponse notificationsResponse,
+    Guid notificationId,
+    Guid requestedByMemberId)
+    {
+        notificationsResponse.MemberId = requestedByMemberId;
+        apiClientMock.Setup(a => a.GetNotification(notificationId, requestedByMemberId, It.IsAny<CancellationToken>())).ReturnsAsync(new Response<GetNotificationResponse?>(string.Empty, new(HttpStatusCode.OK), () => notificationsResponse));
+
+        var actual = await sut.GetNotification(notificationId, requestedByMemberId, It.IsAny<CancellationToken>());
+        var actualObjectResult = actual as ObjectResult;
+
+        using (new AssertionScope())
+        {
+            apiClientMock.Verify(a => a.GetNotification(notificationId, requestedByMemberId, It.IsAny<CancellationToken>()));
+            actualObjectResult.Should().BeOfType<OkObjectResult>();
+            actualObjectResult!.Value.Should().Be(notificationsResponse);
+            actualObjectResult.StatusCode.Should().Be(200);
+        }
+    }
+
+    [Test, MoqAutoData]
+    public async Task GetNotification_InvokesApiClientAndUnexpectedResponseReturned_ReturnsInvalidOperationException(
+    [Frozen] Mock<IAanHubRestApiClient> apiClientMock,
+    [Greedy] NotificationsController sut,
+    GetNotificationResponse notificationsResponse,
+    Guid notificationId,
+    Guid requestedByMemberId)
+    {
+        notificationsResponse.MemberId = requestedByMemberId;
+        apiClientMock.Setup(a => a.GetNotification(notificationId, requestedByMemberId, It.IsAny<CancellationToken>())).ReturnsAsync(new Response<GetNotificationResponse?>(string.Empty, new(HttpStatusCode.Unauthorized), () => null));
+
+        Func<Task> actual = async () => await sut.GetNotification(notificationId, requestedByMemberId, It.IsAny<CancellationToken>());
+
+        using (new AssertionScope())
+        {
+            await actual.Should().ThrowAsync<InvalidOperationException>().WithMessage("Get notification didn't come back with a successful response");
+            apiClientMock.Verify(a => a.GetNotification(notificationId, requestedByMemberId, It.IsAny<CancellationToken>()));
+        }
+    }
+}

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api/Controllers/NotificationsController.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Api/Controllers/NotificationsController.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.ApprenticeAan.Application.Infrastructure;
+using SFA.DAS.ApprenticeAan.Application.Infrastructure.Configuration;
+using SFA.DAS.ApprenticeAan.Application.InnerApi.Notifications;
+using System.Net;
+
+namespace SFA.DAS.ApprenticeAan.Api.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class NotificationsController : Controller
+{
+    private readonly IAanHubRestApiClient _outerApiClient;
+
+    public NotificationsController(IAanHubRestApiClient outerApiClient)
+    {
+        _outerApiClient = outerApiClient;
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(GetNotificationResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetNotification([FromRoute] Guid id, [FromHeader(Name = Constants.ApiHeaders.RequestedByMemberIdHeader)] Guid requestedByMemberId, CancellationToken cancellationToken)
+    {
+        var response = await _outerApiClient.GetNotification(id, requestedByMemberId, cancellationToken);
+        var result = response.ResponseMessage.StatusCode switch
+        {
+            HttpStatusCode.OK => response.GetContent(),
+            HttpStatusCode.NotFound => null,
+            _ => throw new InvalidOperationException("Get notification didn't come back with a successful response")
+        };
+        return Ok(result);
+    }
+}

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/Infrastructure/IAanHubRestApiClient.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/Infrastructure/IAanHubRestApiClient.cs
@@ -4,6 +4,7 @@ using SFA.DAS.ApprenticeAan.Application.CalendarEvents.Queries.GetCalendarEvents
 using SFA.DAS.ApprenticeAan.Application.Entities;
 using SFA.DAS.ApprenticeAan.Application.Infrastructure.Configuration;
 using SFA.DAS.ApprenticeAan.Application.InnerApi.Attendances;
+using SFA.DAS.ApprenticeAan.Application.InnerApi.Notifications;
 using SFA.DAS.ApprenticeAan.Application.Profiles.Queries.GetProfilesByUserType;
 using SFA.DAS.ApprenticeAan.Application.Regions.Queries.GetRegions;
 
@@ -46,4 +47,8 @@ public interface IAanHubRestApiClient
         string FromDate,
         string ToDate,
         CancellationToken cancellationToken);
+
+    [Get("/notifications/{id}")]
+    Task<Response<GetNotificationResponse?>> GetNotification([Path] Guid id, [Header(Constants.ApiHeaders.RequestedByMemberIdHeader)] Guid requestedByMemberId,
+    CancellationToken cancellationToken);
 }

--- a/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/InnerApi/Notifications/GetNotificationResponse.cs
+++ b/src/ApprenticeAan/SFA.DAS.ApprenticeAan.Application/InnerApi/Notifications/GetNotificationResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace SFA.DAS.ApprenticeAan.Application.InnerApi.Notifications;
+
+public class GetNotificationResponse
+{
+    public Guid MemberId { get; set; }
+    public string TemplateName { get; set; } = string.Empty;
+    public DateTime SentTime { get; set; }
+    public string? ReferenceId { get; set; }
+    public long? EmployerAccountId { get; set; }
+}


### PR DESCRIPTION
Add endpoint to get notification by Id to pass through to inner API endpoint.