### PR TITLE
FAI-970 Remove traineeships from API response

### DIFF
--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/GetLiveVacanciesApiResponse.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/GetLiveVacanciesApiResponse.cs
@@ -32,6 +32,7 @@ public class GetLiveVacanciesApiResponse
             {
                 VacancyId = source.VacancyId,
                 VacancyTitle = source.VacancyTitle,
+                NumberOfPositions = source.NumberOfPositions,
                 ApprenticeshipTitle = source.ApprenticeshipTitle,
                 ProgrammeId = source.ProgrammeId,
                 ProgrammeType = source.ProgrammeType,
@@ -51,6 +52,7 @@ public class GetLiveVacanciesApiResponse
 
         public Guid VacancyId { get; set; }
         public string VacancyTitle { get; set; }
+        public int NumberOfPositions { get; set; }
         public string ApprenticeshipTitle { get; set; }
         public string? Description { get; set; }
         public Address? EmployerLocation { get; set; }

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/GetLiveVacanciesQueryResult.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/GetLiveVacanciesQueryResult.cs
@@ -1,6 +1,4 @@
-﻿using SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
-
-namespace SFA.DAS.FindApprenticeshipJobs.Application.Queries;
+﻿namespace SFA.DAS.FindApprenticeshipJobs.Application.Queries;
 public class GetLiveVacanciesQueryResult
 {
     public IEnumerable<LiveVacancy> Vacancies { get; set; } = null!;
@@ -14,6 +12,7 @@ public class GetLiveVacanciesQueryResult
     {
         public Guid VacancyId { get; set; }
         public string VacancyTitle { get; set; }
+        public int NumberOfPositions { get; set; }
         public string ApprenticeshipTitle { get; set; }
         public string? Description { get; set; }
         public Address? EmployerLocation { get; set; }


### PR DESCRIPTION
This PR includes:

- removing any traineeships from the `GetVacancies` API response
- Adding the `NumberOfPositions` property to the API response