### PR TITLE
DASD-11129 - Fix Shared APIM Infrastructure Deployment Pipeline

### DIFF
--- a/deployments/shared-infrastructure.yml
+++ b/deployments/shared-infrastructure.yml
@@ -11,18 +11,13 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/1.0.5
+    ref: refs/tags/2.1.20
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.7
+    ref: refs/tags/5.1.8
     endpoint: SkillsFundingAgency
-  pipelines:
-  - pipeline: das-apim-endpoints-build
-    project: Digital Apprenticeship Service
-    source: das-apim-endpoints (build)
-    branch: master
 
 stages:
 - stage: Deploy_AT

--- a/pipeline-templates/job/shared-arm-deploy.yml
+++ b/pipeline-templates/job/shared-arm-deploy.yml
@@ -14,6 +14,7 @@ jobs:
     runOnce:
       deploy:
         steps:
+        - checkout: self
         - template: azure-pipelines-templates/deploy/step/wait-azure-devops-deployment.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
@@ -25,6 +26,6 @@ jobs:
             Location: $(ResourceGroupLocation)
             ServiceConnection: ${{ parameters.ServiceConnection }}
             SubscriptionId: $(SubscriptionId)
-            TemplatePath: $(Pipeline.Workspace)/das-apim-endpoints-build/ApimEndpointsArtifacts/azure/shared-infrastructure-template.json
-            ParametersPath: $(Pipeline.Workspace)/das-apim-endpoints-build/ApimEndpointsArtifacts/azure/shared-infrastructure-template.parameters.json
-            IsMultiRepoCheckout: false
+            TemplatePath: $(Pipeline.Workspace)/s/das-apim-endpoints/azure/shared-infrastructure-template.json
+            ParametersPath: $(Pipeline.Workspace)/s/das-apim-endpoints/azure/shared-infrastructure-template.parameters.json
+            IsMultiRepoCheckout: true


### PR DESCRIPTION
**Context**

The current `shared-infrastructure.yml` failed to deploy and needed fixing. Subnet and ASP deployments were removed from the main shared infrastructure templates in 2021, but it doesn't look like the dedicated pipeline had been run since to check.

**Proposed changes**

- Update references to external repositories
- Remove reference to removed pipelines
- Ensure the code is checked out as it's not pulled from a different pipeline