### PR TITLE
DASD-11129 - Manage APIM Endpoint ASPs

### DIFF
--- a/azure/shared-infrastructure-template.json
+++ b/azure/shared-infrastructure-template.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "resourceEnvironmentName": {
@@ -12,8 +12,25 @@
             "type": "object",
             "defaultValue": {
                 "tier": "Standard",
-                "size": "2",
-                "instances": 2
+                "size": "1",
+                "instances": 1
+            },
+            "metadata": {
+                "description": "SKU information for the existing ASP."
+            }
+        },
+        "appServicePlanSkus": {
+            "type": "array",
+            "defaultValue": [
+                {
+                    "identifier": 0,
+                    "tier": "Standard",
+                    "size": "1",
+                    "instances": 1
+                }
+            ],
+            "metadata": {
+                "description": "Takes an array of objects: '[{\"identifier\": 0,\"tier\": \"Basic\",\"size\": \"1\",\"instances\": 1}]. Removing the backslash. The identifier helps map the values to the deployed ASP."
             }
         },
         "tags": {
@@ -21,32 +38,125 @@
         },
         "resourceGroupLocation": {
             "type": "string"
+        },
+        "sharedEnvResourceGroup": {
+            "type": "string"
+        },
+        "sharedEnvVirtualNetworkName": {
+            "type": "string"
+        },
+        "sharedEnvVirtualNetworkAddressPrefix": {
+            "type": "string",
+            "defaultValue": "10.0",
+            "metadata": {
+                "description": "Prefix address space of the Vnet"
+            }
+        },
+        "subnetCount": {
+            "type": "int",
+            "defaultValue": 1,
+            "maxValue": 5,
+            "metadata": {
+                "description": "Number of subnets to deploy. Normally one per deployed ASP."
+            }
+        },
+        "subnetAddressSpaceCIDR": {
+            "type": "string",
+            "defaultValue": "/24",
+            "metadata": {
+                "description": "The CIDR notation of the subnet address space"
+            }
+        },
+        "subnetServiceEndpointList": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "subnetDelegations": {
+            "type": "array",
+            "defaultValue": []
+        },
+        "utcValue": {
+            "type": "string",
+            "defaultValue": "[utcNow()]"
         }
     },
     "variables": {
         "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
-        "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
+        "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'), '-', parameters('serviceName')))]",
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
-        "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]"
+        "appServicePlanNamePrefix": "[concat(variables('resourceNamePrefix'), '-asp-')]",
+        "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
+        "subnetNamePrefix": "apimendp-sn",
+        "emptyArray": [],
+        "emptyObject": {},
+        "copy": [
+            {
+                "name": "subnetCopy",
+                "count": "[if(greater(parameters('subnetCount'), 0), parameters('subnetCount'), 1)]",
+                "input": {
+                    "name": "[concat(variables('subnetNamePrefix'), '-', copyIndex('subnetCopy'))]",
+                    "properties": {
+                        "addressPrefix": "[blocks.getNextAddressRange(parameters('sharedEnvVirtualNetworkAddressPrefix'), 25, copyIndex('subnetCopy'), parameters('subnetAddressSpaceCIDR'))]",
+                        "serviceEndpointList": "[parameters('subnetServiceEndpointList')]",
+                        "delegations": "[parameters('subnetDelegations')]",
+                        "networkSecurityGroup": "[variables('emptyObject')]",
+                        "routeTable": "[variables('emptyObject')]"
+                    }
+                }
+            }
+        ],
+        "apimSubnets": "[if(greater(parameters('subnetCount'), 0), variables('subnetCopy'), variables('emptyArray'))]",
+        "subnetConfiguration": "[variables('apimSubnets')]"
     },
+    "functions": [
+        {
+            "namespace": "blocks",
+            "members": {
+                "getNextAddressRange": {
+                    "parameters": [
+                        {
+                            "name": "networkPrefix",
+                            "type": "string"
+                        },
+                        {
+                            "name": "networkStartingAddress",
+                            "type": "int"
+                        },
+                        {
+                            "name": "index",
+                            "type": "int"
+                        },
+                        {
+                            "name": "mask",
+                            "type": "string"
+                        }
+                    ],
+                    "output": {
+                        "type": "string",
+                        "value": "[concat(parameters('networkPrefix'), '.' , add(parameters('networkStartingAddress'), parameters('index')) ,'.0', parameters('mask'))]"
+                    }
+                }
+            }
+        }
+    ],
     "resources": [
         {
-            "apiVersion": "2021-04-01",
-            "name": "[variables('resourceGroupName')]",
             "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2019-05-01",
+            "name": "[variables('resourceGroupName')]",
             "location": "[parameters('resourceGroupLocation')]",
             "tags": "[parameters('tags')]",
             "properties": {}
         },
         {
-            "apiVersion": "2021-04-01",
-            "name": "apim-endpoint-app-service-plan",
+            "apiVersion": "2022-09-01",
+            "name": "[concat('apim-endpoint-app-service-plan-', parameters('utcValue'))]",
             "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[variables('resourceGroupName')]",
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
+                    "uri": "[uri(variables('deploymentUrlBase'),'app-service-plan.json')]",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -64,7 +174,91 @@
                     }
                 }
             }
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2022-09-01",
+            "name": "[concat('apim-endpoint-app-service-plan-', copyIndex(), '-', parameters('utcValue'))]",
+            "resourceGroup": "[variables('resourceGroupName')]",
+            "copy": {
+                "name": "appServicePlanLoop",
+                "count": "[length(parameters('appServicePlanSkus'))]"
+            },
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[uri(variables('deploymentUrlBase'),'app-service-plan.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appServicePlanName": {
+                        "value": "[concat(variables('appServicePlanNamePrefix'), copyIndex())]"
+                    },
+                    "aspSize": {
+                        "value": "[parameters('appServicePlanSkus')[copyIndex()].size]"
+                    },
+                    "aspInstances": {
+                        "value": "[parameters('appServicePlanSkus')[copyIndex()].instances]"
+                    },
+                    "nonASETier": {
+                        "value": "[parameters('appServicePlanSkus')[copyIndex()].tier]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2022-09-01",
+            "name": "[concat(variables('subnetNamePrefix'), copyIndex(), '-', parameters('utcValue'))]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
+            "copy": {
+                "name": "subnetLoop",
+                "count": "[length(variables('subnetConfiguration'))]",
+                "mode": "Serial"
+            },
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[uri(variables('deploymentUrlBase'),'subnet.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "virtualNetworkName": {
+                        "value": "[parameters('sharedEnvVirtualNetworkName')]"
+                    },
+                    "subnetName": {
+                        "value": "[variables('subnetConfiguration')[copyIndex()].name]"
+                    },
+                    "subnetAddressPrefix": {
+                        "value": "[variables('subnetConfiguration')[copyIndex()].properties.addressPrefix]"
+                    },
+                    "serviceEndpointList": {
+                        "value": "[variables('subnetConfiguration')[copyIndex()].properties.serviceEndpointList]"
+                    },
+                    "delegations": {
+                        "value": "[variables('subnetConfiguration')[copyIndex()].properties.delegations]"
+                    },
+                    "networkSecurityGroup": {
+                        "value": "[if(empty(variables('subnetConfiguration')[copyIndex()].properties.networkSecurityGroup), variables('emptyObject'), variables('subnetConfiguration')[copyIndex()].properties.networkSecurityGroup)]"
+                    },
+                    "routeTable": {
+                        "value": "[if(empty(variables('subnetConfiguration')[copyIndex()].properties.routeTable), variables('emptyObject'), variables('subnetConfiguration')[copyIndex()].properties.routeTable)]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[variables('resourceGroupName')]"
+            ]
         }
     ],
-    "outputs": {}
+    "outputs": {
+        "appServicePlanSkus": {
+            "type": "array",
+            "value": "[parameters('appServicePlanSkus')]"
+        },
+        "subnetRangeOverRun": {
+            "type": "bool",
+            "value": "[greater(length(parameters('appServicePlanSkus')), 5)]"
+        }
+    }
 }

--- a/deployments/shared-infrastructure.yml
+++ b/deployments/shared-infrastructure.yml
@@ -11,7 +11,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.1.20
+    ref: refs/tags/2.1.22
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/AdminAan/azure-pipelines.yml
+++ b/src/AdminAan/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/AdminAan
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/AdminAan
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/AparRegister/azure-pipelines.yml
+++ b/src/AparRegister/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/AparRegister
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/AparRegister
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ApimDeveloper/azure-pipelines.yml
+++ b/src/ApimDeveloper/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ApimDeveloper
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ApimDeveloper
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticeAan/azure-pipelines.yml
+++ b/src/ApprenticeAan/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ApprenticeAan
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ApprenticeAan
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticeApp/azure-pipelines.yml
+++ b/src/ApprenticeApp/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ApprenticeApp
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ApprenticeApp
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticeCommitments/azure-pipelines.yml
+++ b/src/ApprenticeCommitments/azure-pipelines.yml
@@ -6,8 +6,11 @@ trigger:
   paths:
     include:
     - azure
-    - pipeline-templates     
+    - pipeline-templates
     - src/ApprenticeCommitments
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -17,8 +20,11 @@ pr:
   paths:
     include:
     - azure
-    - pipeline-templates     
+    - pipeline-templates
     - src/ApprenticeCommitments
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticeFeedback/azure-pipelines.yml
+++ b/src/ApprenticeFeedback/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ApprenticeFeedback
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ApprenticeFeedback
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticePortal/azure-pipelines.yml
+++ b/src/ApprenticePortal/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ApprenticePortal
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ApprenticePortal
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Apprenticeships/azure-pipelines.yml
+++ b/src/Apprenticeships/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Apprenticeships
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Apprenticeships
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Approvals/azure-pipelines.yml
+++ b/src/Approvals/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Approvals
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Approvals
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Assessors/azure-pipelines.yml
+++ b/src/Assessors/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Assessors
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Assessors
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Campaign/azure-pipelines.yml
+++ b/src/Campaign/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Campaign
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Campaign
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EarlyConnect/azure-pipelines.yml
+++ b/src/EarlyConnect/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EarlyConnect
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EarlyConnect
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerAan/azure-pipelines.yml
+++ b/src/EmployerAan/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerAan
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerAan
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerAccounts/azure-pipelines.yml
+++ b/src/EmployerAccounts/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerAccounts
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerAccounts
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerContactForms/azure-pipelines.yml
+++ b/src/EmployerContactForms/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerContactForms
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerContactForms
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerDemand/azure-pipelines.yml
+++ b/src/EmployerDemand/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerDemand
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerDemand
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerFeedback/azure-pipelines.yml
+++ b/src/EmployerFeedback/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerFeedback
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerFeedback
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerFinance/azure-pipelines.yml
+++ b/src/EmployerFinance/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerFinance
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerFinance
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerIncentives/azure-pipelines.yml
+++ b/src/EmployerIncentives/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerIncentives
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerIncentives
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerPR/azure-pipelines.yml
+++ b/src/EmployerPR/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerPR
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerPR
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerProfiles/azure-pipelines.yml
+++ b/src/EmployerProfiles/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerProfiles
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerProfiles
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmployerRequestApprenticeTraining
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmployerRequestApprenticeTraining
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EmploymentCheck/azure-pipelines.yml
+++ b/src/EmploymentCheck/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EmploymentCheck
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,7 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EmploymentCheck
-
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/EpaoRegister/azure-pipelines.yml
+++ b/src/EpaoRegister/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/EpaoRegister
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/EpaoRegister
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/FindAnApprenticeship/azure-pipelines.yml
+++ b/src/FindAnApprenticeship/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/FindAnApprenticeship
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/FindAnApprenticeship
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/FindApprenticeshipJobs/azure-pipelines.yml
+++ b/src/FindApprenticeshipJobs/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/FindApprenticeshipJobs
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/FindApprenticeshipJobs
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/FindApprenticeshipTraining/azure-pipelines.yml
+++ b/src/FindApprenticeshipTraining/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/FindApprenticeshipTraining
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/FindApprenticeshipTraining
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/FindEpao/azure-pipelines.yml
+++ b/src/FindEpao/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/FindEpao
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/FindEpao
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Forecasting/azure-pipelines.yml
+++ b/src/Forecasting/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Forecasting
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,7 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Forecasting
-
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Funding/azure-pipelines.yml
+++ b/src/Funding/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Funding
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Funding
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/LevyTransferMatching/azure-pipelines.yml
+++ b/src/LevyTransferMatching/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/LevyTransferMatching
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/LevyTransferMatching
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ProviderFeedback/azure-pipelines.yml
+++ b/src/ProviderFeedback/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ProviderFeedback
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ProviderFeedback
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ProviderPR/azure-pipelines.yml
+++ b/src/ProviderPR/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ProviderPR
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ProviderPR
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ProviderRelationships/azure-pipelines.yml
+++ b/src/ProviderRelationships/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ProviderRelationships
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,7 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ProviderRelationships
-
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ProviderRequestApprenticeTraining
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ProviderRequestApprenticeTraining
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/PublicSectorReporting/azure-pipelines.yml
+++ b/src/PublicSectorReporting/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/PublicSectorReporting
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/PublicSectorReporting
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Recruit/azure-pipelines.yml
+++ b/src/Recruit/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Recruit
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   branches:
@@ -18,7 +21,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Recruit
-
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/ReferenceDataJobs/azure-pipelines.yml
+++ b/src/ReferenceDataJobs/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/ReferenceDataJobs
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/ReferenceDataJobs
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Reservations/azure-pipelines.yml
+++ b/src/Reservations/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Reservations
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Reservations
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Roatp/azure-pipelines.yml
+++ b/src/Roatp/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Roatp
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   branches:
@@ -18,6 +21,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Roatp
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/RoatpCourseManagement/azure-pipelines.yml
+++ b/src/RoatpCourseManagement/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/RoatpCourseManagement
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/RoatpCourseManagement
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/RoatpOversight/azure-pipelines.yml
+++ b/src/RoatpOversight/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/RoatpOversight
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/RoatpOversight
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/RoatpProviderModeration/azure-pipelines.yml
+++ b/src/RoatpProviderModeration/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/RoatpProviderModeration
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/RoatpProviderModeration
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/TrackProgress/azure-pipelines.yml
+++ b/src/TrackProgress/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/TrackProgress
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   branches:
@@ -18,6 +21,9 @@ pr:
     - azure
     - pipeline-templates
     - src/TrackProgress
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/TrackProgressInternal/azure-pipelines.yml
+++ b/src/TrackProgressInternal/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/TrackProgressInternal
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   branches:
@@ -18,6 +21,9 @@ pr:
     - azure
     - pipeline-templates
     - src/TrackProgressInternal
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/Vacancies/azure-pipelines.yml
+++ b/src/Vacancies/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/Vacancies
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   autoCancel: true
@@ -19,6 +22,9 @@ pr:
     - azure
     - pipeline-templates
     - src/Vacancies
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources

--- a/src/VacanciesManage/azure-pipelines.yml
+++ b/src/VacanciesManage/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
     - azure
     - pipeline-templates
     - src/VacanciesManage
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 pr:
   branches:
@@ -18,6 +21,9 @@ pr:
     - azure
     - pipeline-templates
     - src/VacanciesManage
+    exclude:
+    - azure/shared-infrastructure-template.json
+    - pipeline-templates/job/shared-arm-deploy.yml
 
 variables:
 - group: Release Management Resources


### PR DESCRIPTION
**Context**

We need a way to add additional ASP's for use with APIM endpoints to distribute the traffic load and to provide more resilience and flexibility.

**Proposed Changes**

- Update all endpoint YAML pipelines to exclude shared infrastructure files
- Update shared infra schema version and align other elements to the ARM template toolkit
- Add parameters for new resources
- Add subnet and ASP resource deployments

**Testing**

- Deployed to AT taking on existing `apimendp-sn-0` subnet, new subnet `apimendp-sn-1` and new ASP `das-{ENV}-apimendp-asp-0` and `das-{ENV}-apimendp-asp-0`