### PR TITLE
CSP-1473: PR Employer Outer API: Send Email to Provider on Permission Created/Updated/Removed

### DIFF
--- a/src/EmployerPR/SFA.DAS.EmployerPR.Api.UnitTests/Controllers/PermissionsControllerTests/PostPermissionsTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.Api.UnitTests/Controllers/PermissionsControllerTests/PostPermissionsTests.cs
@@ -30,15 +30,13 @@ public class PostPermissionsTests
         [Frozen] Mock<IMediator> mediatorMock,
         [Greedy] PermissionsController sut,
         PostPermissionsCommand command,
-        PostPermissionsCommandResult postPermissionsCommandResult,
         CancellationToken cancellationToken
     )
     {
-        mediatorMock.Setup(m => m.Send(command, It.IsAny<CancellationToken>())).ReturnsAsync(postPermissionsCommandResult);
+        mediatorMock.Setup(m => m.Send(command, It.IsAny<CancellationToken>())).ReturnsAsync(Unit.Value);
 
         var result = await sut.PostPermissions(command, cancellationToken);
 
-        result.As<OkObjectResult>().Should().NotBeNull();
-        result.As<OkObjectResult>().Value.Should().Be(postPermissionsCommandResult);
+        result.As<NoContentResult>().Should().NotBeNull();
     }
 }

--- a/src/EmployerPR/SFA.DAS.EmployerPR.Api/Controllers/PermissionsController.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.Api/Controllers/PermissionsController.cs
@@ -23,11 +23,10 @@ public class PermissionsController(IMediator _mediator) : ControllerBase
 
     [HttpPost]
     [Produces("application/json")]
-    [ProducesResponseType(typeof(PostPermissionsCommandResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(Unit), StatusCodes.Status204NoContent)]
     public async Task<IActionResult> PostPermissions([FromBody] PostPermissionsCommand command, CancellationToken cancellationToken)
     {
-        var result = await _mediator.Send(command, cancellationToken);
-
-        return Ok(result);
+        await _mediator.Send(command, cancellationToken);
+        return NoContent();
     }
 }

--- a/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Permissions/Commands/PostPermissions/PostPermissionsCommandHandlerTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Permissions/Commands/PostPermissions/PostPermissionsCommandHandlerTests.cs
@@ -1,9 +1,14 @@
 ﻿using AutoFixture.NUnit3;
 using FluentAssertions;
+using MediatR;
 using Moq;
 using NUnit.Framework;
+using SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
 using SFA.DAS.EmployerPR.Application.Commands.PostPermissions;
+using SFA.DAS.EmployerPR.Application.Queries.GetPermissions;
+using SFA.DAS.EmployerPR.Common;
 using SFA.DAS.EmployerPR.Infrastructure;
+using SFA.DAS.SharedOuterApi.Models.ProviderRelationships;
 using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.EmployerPR.UnitTests.Application.Permissions.Commands.PostPermissions;
@@ -12,21 +17,272 @@ public class PostPermissionsCommandHandlerTests
 {
     [Test]
     [MoqAutoData]
-    public async Task Handle_Returns_PostPermissionsCommandResult(
+    public async Task PostPermissionsCommandHandler_Handle_Requires_No_Action(
         [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
         PostPermissionsCommandHandler sut,
-        PostPermissionsCommand command,
-        PostPermissionsCommandResult result
+        PostPermissionsCommandResult result,
+        PostPermissionsCommand command
     )
     {
+        command.Operations = [];
+
         providerRelationshipsApiRestClient.Setup(x =>
-            x.PostPermissions(
-                command,
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
                 CancellationToken.None
             )
-        ).ReturnsAsync(result);
+        ).ReturnsAsync(new GetPermissionsResponse());
 
         var actual = await sut.Handle(command, CancellationToken.None);
-        actual.Should().Be(result);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x => 
+            x.RemovePermissions(
+                It.IsAny<Guid>(), 
+                It.IsAny<long>(), 
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ), 
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task PostPermissionsCommandHandler_Handle_Requires_Permissions_Removed(
+        [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+        PostPermissionsCommandHandler sut,
+        PostPermissionsCommandResult result,
+        PostPermissionsCommand command
+    )
+    {
+        command.Operations = [];
+
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                CancellationToken.None
+            )
+        ).ReturnsAsync(new GetPermissionsResponse()
+        {
+            Operations = [Operation.Recruitment]
+        });
+
+        var actual = await sut.Handle(command, CancellationToken.None);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.RemovePermissions(
+                It.IsAny<Guid>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostNotifications(
+                It.Is<PostNotificationsCommand>(cmd =>
+                    cmd.Notifications.Count() == 1 &&
+                    cmd.Notifications[0].NotificationType == nameof(PermissionEmailTemplateType.PermissionDeleted) &&
+                    cmd.Notifications[0].TemplateName == "provider" &&
+                    cmd.Notifications[0].Ukprn == command.Ukprn &&
+                    cmd.Notifications[0].AccountLegalEntityId == command.AccountLegalEntityId &&
+                    cmd.Notifications[0].PermitApprovals == 0 &&
+                    cmd.Notifications[0].PermitRecruit == 0 &&
+                    cmd.Notifications[0].CreatedBy == command.UserRef.ToString()
+                ),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task PostPermissionsCommandHandler_Handle_Permissions_Created_PermitRecruit(
+        [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+        PostPermissionsCommandHandler sut,
+        PostPermissionsCommandResult result,
+        PostPermissionsCommand command
+    )
+    {
+        command.Operations = [Operation.CreateCohort, Operation.Recruitment];
+
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                CancellationToken.None
+            )
+        ).ReturnsAsync(new GetPermissionsResponse()
+        {
+            Operations = []
+        });
+
+        var actual = await sut.Handle(command, CancellationToken.None);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.RemovePermissions(
+                It.IsAny<Guid>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostNotifications(
+                It.Is<PostNotificationsCommand>(cmd =>
+                    cmd.Notifications.Count() == 1 &&
+                    cmd.Notifications[0].NotificationType == nameof(PermissionEmailTemplateType.PermissionsCreated) &&
+                    cmd.Notifications[0].TemplateName == "provider" &&
+                    cmd.Notifications[0].Ukprn == command.Ukprn &&
+                    cmd.Notifications[0].AccountLegalEntityId == command.AccountLegalEntityId &&
+                    cmd.Notifications[0].PermitApprovals == 1 &&
+                    cmd.Notifications[0].PermitRecruit == 1 &&
+                    cmd.Notifications[0].CreatedBy == command.UserRef.ToString()
+                ),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task PostPermissionsCommandHandler_Handle_Permissions_Created_PermitRecruitWithReview(
+        [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+        PostPermissionsCommandHandler sut,
+        PostPermissionsCommandResult result,
+        PostPermissionsCommand command
+    )
+    {
+        command.Operations = [Operation.CreateCohort, Operation.RecruitmentRequiresReview];
+
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                CancellationToken.None
+            )
+        ).ReturnsAsync(new GetPermissionsResponse()
+        {
+            Operations = []
+        });
+
+        var actual = await sut.Handle(command, CancellationToken.None);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.RemovePermissions(
+                It.IsAny<Guid>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostNotifications(
+                It.Is<PostNotificationsCommand>(cmd =>
+                    cmd.Notifications.Count() == 1 &&
+                    cmd.Notifications[0].NotificationType == nameof(PermissionEmailTemplateType.PermissionsCreated) &&
+                    cmd.Notifications[0].TemplateName == "provider" &&
+                    cmd.Notifications[0].Ukprn == command.Ukprn &&
+                    cmd.Notifications[0].AccountLegalEntityId == command.AccountLegalEntityId &&
+                    cmd.Notifications[0].PermitApprovals == 1 &&
+                    cmd.Notifications[0].PermitRecruit == 2 &&
+                    cmd.Notifications[0].CreatedBy == command.UserRef.ToString()
+                ),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task PostPermissionsCommandHandler_Handle_Permissions_Updated(
+       [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+       PostPermissionsCommandHandler sut,
+       PostPermissionsCommandResult result,
+       PostPermissionsCommand command
+   )
+    {
+        command.Operations = [Operation.Recruitment];
+
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                CancellationToken.None
+            )
+        ).ReturnsAsync(new GetPermissionsResponse()
+        {
+            Operations = [Operation.RecruitmentRequiresReview]
+        });
+
+        var actual = await sut.Handle(command, CancellationToken.None);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.RemovePermissions(
+                It.IsAny<Guid>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostNotifications(
+                It.Is<PostNotificationsCommand>(cmd =>
+                    cmd.Notifications.Count() == 1 &&
+                    cmd.Notifications[0].NotificationType == nameof(PermissionEmailTemplateType.PermissionsUpdated) &&
+                    cmd.Notifications[0].TemplateName == "provider" &&
+                    cmd.Notifications[0].Ukprn == command.Ukprn &&
+                    cmd.Notifications[0].AccountLegalEntityId == command.AccountLegalEntityId &&
+                    cmd.Notifications[0].PermitApprovals == 0 &&
+                    cmd.Notifications[0].PermitRecruit == 1 &&
+                    cmd.Notifications[0].CreatedBy == command.UserRef.ToString()
+                ),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
     }
 }

--- a/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Providers/Queries/GetPermissionsHas/GetPermissionsHasQueryHandlerTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Providers/Queries/GetPermissionsHas/GetPermissionsHasQueryHandlerTests.cs
@@ -21,7 +21,7 @@ public class GetPermissionsQueryHandlerTests
         providerRelationshipsApiRestClient.Setup(x =>
             x.GetPermissions(
                 It.IsAny<long>(),
-                It.IsAny<int>(),
+                It.IsAny<long>(),
                 It.IsAny<CancellationToken>()
             )
         )

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/NotificationModel.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/NotificationModel.cs
@@ -1,0 +1,16 @@
+﻿namespace SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
+
+public class NotificationModel
+{
+    public required string TemplateName { get; set; }
+    public required string NotificationType { get; set; }
+    public long? Ukprn { get; set; }
+    public string? EmailAddress { get; set; }
+    public string? Contact { get; set; }
+    public string? EmployerName { get; set; }
+    public Guid? RequestId { get; set; }
+    public long? AccountLegalEntityId { get; set; }
+    public int? PermitApprovals { get; set; }
+    public int? PermitRecruit { get; set; }
+    public required string CreatedBy { get; set; }
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/PostNotificationsCommand.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/PostNotificationsCommand.cs
@@ -1,0 +1,11 @@
+﻿namespace SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
+
+public class PostNotificationsCommand
+{
+    public PostNotificationsCommand(NotificationModel[] notifications)
+    {
+        Notifications = notifications;
+    }
+
+    public NotificationModel[] Notifications { get; set; } = [];
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommand.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommand.cs
@@ -3,7 +3,7 @@ using SFA.DAS.SharedOuterApi.Models.ProviderRelationships;
 
 namespace SFA.DAS.EmployerPR.Application.Commands.PostPermissions;
 
-public class PostPermissionsCommand : IRequest<PostPermissionsCommandResult>
+public class PostPermissionsCommand : IRequest<Unit>
 {
     public required Guid UserRef { get; set; }
 

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
@@ -76,7 +76,7 @@ public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _
     {
         NotificationModel notification = new NotificationModel()
         {
-            NotificationType = "Provider",
+            NotificationType = nameof(NotificationType.Provider),
             TemplateName = templateType.ToString(),
             Ukprn = command.Ukprn,
             AccountLegalEntityId = command.AccountLegalEntityId,

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
@@ -1,12 +1,120 @@
 ﻿using MediatR;
+using SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
+using SFA.DAS.EmployerPR.Application.Queries.GetPermissions;
+using SFA.DAS.EmployerPR.Common;
 using SFA.DAS.EmployerPR.Infrastructure;
+using SFA.DAS.SharedOuterApi.Models.ProviderRelationships;
 
 namespace SFA.DAS.EmployerPR.Application.Commands.PostPermissions;
 
-public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _providerRelationshipsApiRestClient) : IRequestHandler<PostPermissionsCommand, PostPermissionsCommandResult>
+public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _providerRelationshipsApiRestClient) : IRequestHandler<PostPermissionsCommand, Unit>
 {
-    public async Task<PostPermissionsCommandResult> Handle(PostPermissionsCommand command, CancellationToken cancellationToken)
+    private const int PERMITS_APPROVAL = 1;
+    private const int PERMITS_RECRUITNENT = 1;
+    private const int PERMITS_RECRUITNENT_WITH_REVIEW = 2;
+
+    public async Task<Unit> Handle(PostPermissionsCommand command, CancellationToken cancellationToken)
     {
-        return await _providerRelationshipsApiRestClient.PostPermissions(command, cancellationToken);
+        GetPermissionsResponse permissionsResponse = 
+            await _providerRelationshipsApiRestClient.GetPermissions(
+                command.Ukprn, 
+                command.AccountLegalEntityId, 
+                cancellationToken
+        );
+
+        if (NoUpdatesRequired(command.Operations, permissionsResponse.Operations))
+        {
+            return Unit.Value;
+        }
+
+        PermissionEmailTemplateType templateType = default;
+
+        if (!command.Operations.Any())
+        {
+            await _providerRelationshipsApiRestClient.RemovePermissions(
+                command.UserRef, 
+                command.Ukprn!.Value, 
+                command.AccountLegalEntityId, 
+                cancellationToken
+            );
+
+            templateType = PermissionEmailTemplateType.PermissionDeleted;
+        }
+        else
+        {
+            await _providerRelationshipsApiRestClient.PostPermissions(
+                command,
+                cancellationToken
+            );
+
+            templateType = GetTemplateType(permissionsResponse.Operations);
+        }
+
+        await PostNotification(command, templateType, cancellationToken);
+
+        return Unit.Value;
+    }
+
+    private bool NoUpdatesRequired(List<Operation> requestedPermissions, List<Operation> currentPermissions)
+    {
+        return (!requestedPermissions.Any() && !currentPermissions.Any()) || IdenticalPermissions(requestedPermissions, currentPermissions);
+    }
+
+    private bool IdenticalPermissions(List<Operation> requestedPermissions, List<Operation> currentPermissions)
+    {
+        return currentPermissions.OrderBy(a => (int)a).SequenceEqual(requestedPermissions.OrderBy(a => (int)a));
+    }
+
+    private PermissionEmailTemplateType GetTemplateType(List<Operation> operations)
+    {
+        return operations.Any() ?
+            PermissionEmailTemplateType.PermissionsUpdated : 
+            PermissionEmailTemplateType.PermissionsCreated;
+    }
+
+    private async Task PostNotification(PostPermissionsCommand command, PermissionEmailTemplateType templateType, CancellationToken cancellationToken)
+    {
+        NotificationModel notification = new NotificationModel()
+        {
+            NotificationType = templateType.ToString(),
+            TemplateName = "provider",
+            Ukprn = command.Ukprn,
+            AccountLegalEntityId = command.AccountLegalEntityId,
+            PermitApprovals = SetPermitsApproval(command.Operations),
+            PermitRecruit = SetPermitsRecruit(command.Operations),
+            CreatedBy = command.UserRef.ToString()
+        };
+
+        await _providerRelationshipsApiRestClient.PostNotifications(
+            new PostNotificationsCommand([notification]),
+            cancellationToken
+        );
+    }
+
+    private int SetPermitsApproval(List<Operation> operations)
+    {
+        if(operations.Contains(Operation.CreateCohort))
+        {
+            return PERMITS_APPROVAL;
+        }
+        else
+        {
+            return default;
+        }
+    }
+
+    private int SetPermitsRecruit(List<Operation> operations)
+    {
+        if(operations.Contains(Operation.Recruitment))
+        {
+            return PERMITS_RECRUITNENT;
+        }
+
+        if (operations.Contains(Operation.RecruitmentRequiresReview))
+        {
+            return PERMITS_RECRUITNENT_WITH_REVIEW;
+        }
+
+        return default;
     }
 }

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
@@ -76,8 +76,8 @@ public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _
     {
         NotificationModel notification = new NotificationModel()
         {
-            NotificationType = templateType.ToString(),
-            TemplateName = "provider",
+            NotificationType = "Provider",
+            TemplateName = templateType.ToString(),
             Ukprn = command.Ukprn,
             AccountLegalEntityId = command.AccountLegalEntityId,
             PermitApprovals = SetPermitsApproval(command.Operations),

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Common/NotificationType.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Common/NotificationType.cs
@@ -1,0 +1,6 @@
+﻿namespace SFA.DAS.EmployerPR.Common;
+
+public enum NotificationType
+{
+    Provider
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Common/PermissionEmailTemplateType.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Common/PermissionEmailTemplateType.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.EmployerPR.Common;
+
+public enum PermissionEmailTemplateType
+{
+    PermissionsCreated,
+    PermissionsUpdated,
+    PermissionDeleted
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
@@ -20,7 +20,7 @@ public interface IProviderRelationshipsApiRestClient
     Task<PostPermissionsCommandResult> PostPermissions([Body] PostPermissionsCommand command, CancellationToken cancellationToken);
 
     [Post("notifications")]
-    Task PostNotifications([FromBody] PostNotificationsCommand command, CancellationToken cancellationToken);
+    Task PostNotifications([Body] PostNotificationsCommand command, CancellationToken cancellationToken);
 
     [Delete("permissions")]
     Task RemovePermissions([Query] Guid userRef, [Query] long ukprn, [Query] long accountLegalEntityId, CancellationToken cancellationToken);

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
@@ -1,4 +1,7 @@
-﻿using RestEase;
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using RestEase;
+using SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
 using SFA.DAS.EmployerPR.Application.Commands.PostPermissions;
 using SFA.DAS.EmployerPR.Application.Queries.GetEmployerRelationships;
 using SFA.DAS.EmployerPR.Application.Queries.GetPermissions;
@@ -8,11 +11,17 @@ namespace SFA.DAS.EmployerPR.Infrastructure;
 public interface IProviderRelationshipsApiRestClient
 {
     [Get("permissions")]
-    Task<GetPermissionsResponse> GetPermissions([Query] long? ukprn, [Query] int? AccountLegalEntityId, CancellationToken cancellationToken);
+    Task<GetPermissionsResponse> GetPermissions([Query] long? ukprn, [Query] long? AccountLegalEntityId, CancellationToken cancellationToken);
 
     [Get("relationships/employeraccount/{AccountHashedId}")]
     Task<GetEmployerRelationshipsResponse> GetEmployerRelationships([Path] string AccountHashedId, [Query] long? Ukprn, [Query] string? AccountlegalentityPublicHashedId, CancellationToken cancellationToken);
 
     [Post("permissions")]
     Task<PostPermissionsCommandResult> PostPermissions([Body] PostPermissionsCommand command, CancellationToken cancellationToken);
+
+    [Post("notifications")]
+    Task PostNotifications([FromBody] PostNotificationsCommand command, CancellationToken cancellationToken);
+
+    [Delete("permissions")]
+    Task RemovePermissions([Query] Guid userRef, [Query] long ukprn, [Query] long accountLegalEntityId, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
- Extend the post permissions endpoint to handle notification creation for create, update and removing of permissions.