### PR TITLE
CSP-1473: PR Employer Outer API: Send Email to Provider on Permission Created/Updated/Removed

### DIFF
--- a/src/EmployerPR/SFA.DAS.EmployerPR.Api.UnitTests/Controllers/GetRelationshipsControllerTests/GetRelationshipsTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.Api.UnitTests/Controllers/GetRelationshipsControllerTests/GetRelationshipsTests.cs
@@ -1,0 +1,45 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EmployerPR.Api.Controllers;
+using SFA.DAS.EmployerPR.Application.Queries.GetRelationships;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.EmployerPR.Api.UnitTests.Controllers.GetRelationshipsControllerTests;
+
+public class GetRelationshipsTests
+{
+    [Test, MoqAutoData]
+    public async Task GetRelationships_InvokesQueryHandler(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] RelationshipsController sut,
+        GetRelationshipsQuery query,
+        CancellationToken cancellationToken)
+    {
+        await sut.GetRelationships(query, cancellationToken);
+
+        mediatorMock.Verify(
+            m => m.Send(It.IsAny<GetRelationshipsQuery>(),
+                It.IsAny<CancellationToken>()));
+    }
+
+    [Test, MoqAutoData]
+    public async Task GetRelationships_HandlerReturnsData_ReturnsExpectedResponse(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] RelationshipsController sut,
+        GetRelationshipsResponse queryResponse,
+        GetRelationshipsQuery query,
+        CancellationToken cancellationToken)
+    {
+        mediatorMock.Setup(m => m.Send(It.IsAny<GetRelationshipsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(queryResponse);
+
+        var result = await sut.GetRelationships(query, cancellationToken);
+
+        result.As<OkObjectResult>().Should().NotBeNull();
+        result.As<OkObjectResult>().Value.Should().Be(queryResponse);
+    }
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR.Api.UnitTests/Controllers/PermissionsControllerTests/PostPermissionsTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.Api.UnitTests/Controllers/PermissionsControllerTests/PostPermissionsTests.cs
@@ -30,15 +30,13 @@ public class PostPermissionsTests
         [Frozen] Mock<IMediator> mediatorMock,
         [Greedy] PermissionsController sut,
         PostPermissionsCommand command,
-        PostPermissionsCommandResult postPermissionsCommandResult,
         CancellationToken cancellationToken
     )
     {
-        mediatorMock.Setup(m => m.Send(command, It.IsAny<CancellationToken>())).ReturnsAsync(postPermissionsCommandResult);
+        mediatorMock.Setup(m => m.Send(command, It.IsAny<CancellationToken>())).ReturnsAsync(Unit.Value);
 
         var result = await sut.PostPermissions(command, cancellationToken);
 
-        result.As<OkObjectResult>().Should().NotBeNull();
-        result.As<OkObjectResult>().Value.Should().Be(postPermissionsCommandResult);
+        result.As<NoContentResult>().Should().NotBeNull();
     }
 }

--- a/src/EmployerPR/SFA.DAS.EmployerPR.Api/Controllers/PermissionsController.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.Api/Controllers/PermissionsController.cs
@@ -28,11 +28,10 @@ public class PermissionsController(IMediator _mediator) : ControllerBase
 
     [HttpPost]
     [Produces("application/json")]
-    [ProducesResponseType(typeof(PostPermissionsCommandResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(Unit), StatusCodes.Status204NoContent)]
     public async Task<IActionResult> PostPermissions([FromBody] PostPermissionsCommand command, CancellationToken cancellationToken)
     {
-        var result = await _mediator.Send(command, cancellationToken);
-
-        return Ok(result);
+        await _mediator.Send(command, cancellationToken);
+        return NoContent();
     }
 }

--- a/src/EmployerPR/SFA.DAS.EmployerPR.Api/Controllers/RelationshipsController.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.Api/Controllers/RelationshipsController.cs
@@ -1,0 +1,21 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.EmployerPR.Application.Queries.GetRelationships;
+
+namespace SFA.DAS.EmployerPR.Api.Controllers;
+
+[Route("[controller]")]
+[ApiController]
+public class RelationshipsController(IMediator _mediator) : ControllerBase
+{
+    [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(GetRelationshipsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetRelationships([FromQuery] GetRelationshipsQuery query, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(query, cancellationToken);
+
+        return Ok(result);
+    }
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Permissions/Commands/PostPermissions/PostPermissionsCommandHandlerTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Permissions/Commands/PostPermissions/PostPermissionsCommandHandlerTests.cs
@@ -20,7 +20,7 @@ public class PostPermissionsCommandHandlerTests
 {
     [Test]
     [MoqAutoData]
-    public async Task PostPermissionsCommandHandler_Handle_Requires_No_Action(
+    public async Task Handle_NoRequestedAndExistingOperations_NoAction(
         [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
         PostPermissionsCommandHandler sut,
         PostPermissionsCommandResult result,
@@ -72,7 +72,7 @@ public class PostPermissionsCommandHandlerTests
 
     [Test]
     [MoqAutoData]
-    public void PostPermissionsCommandHandler_Handle_Throws_InvalidOperationException(
+    public void Handle_UnexpectedResponseOnExistingPermission_ThrowsException(
         [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
         PostPermissionsCommandHandler sut,
         PostPermissionsCommandResult result,
@@ -116,7 +116,7 @@ public class PostPermissionsCommandHandlerTests
 
     [Test]
     [MoqAutoData]
-    public async Task PostPermissionsCommandHandler_Handle_Requires_Permissions_Removed(
+    public async Task Handle_NoOperationsRequestedWithExistingPermissions_RemovesExistingPermissions(
         [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
         PostPermissionsCommandHandler sut,
         PostPermissionsCommandResult result,

--- a/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Permissions/Commands/PostPermissions/PostPermissionsCommandHandlerTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Permissions/Commands/PostPermissions/PostPermissionsCommandHandlerTests.cs
@@ -1,10 +1,18 @@
 ﻿using AutoFixture.NUnit3;
 using FluentAssertions;
+using MediatR;
 using Moq;
 using NUnit.Framework;
+using RestEase;
+using SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
 using SFA.DAS.EmployerPR.Application.Commands.PostPermissions;
+using SFA.DAS.EmployerPR.Application.Queries.GetPermissions;
+using SFA.DAS.EmployerPR.Common;
 using SFA.DAS.EmployerPR.Infrastructure;
+using SFA.DAS.SharedOuterApi.Models.ProviderRelationships;
 using SFA.DAS.Testing.AutoFixture;
+using System.Net;
+using System.Text.Json;
 
 namespace SFA.DAS.EmployerPR.UnitTests.Application.Permissions.Commands.PostPermissions;
 
@@ -12,21 +20,369 @@ public class PostPermissionsCommandHandlerTests
 {
     [Test]
     [MoqAutoData]
-    public async Task Handle_Returns_PostPermissionsCommandResult(
+    public async Task PostPermissionsCommandHandler_Handle_Requires_No_Action(
         [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
         PostPermissionsCommandHandler sut,
-        PostPermissionsCommand command,
-        PostPermissionsCommandResult result
+        PostPermissionsCommandResult result,
+        PostPermissionsCommand command
+    )
+    {
+        command.Operations = [];
+
+        var responseObject = new GetPermissionsResponse()
+        {
+            Operations = []
+        };
+
+        var responseString = JsonSerializer.Serialize(responseObject);
+
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                CancellationToken.None
+            )
+        ).ReturnsAsync(
+            new Response<GetPermissionsResponse>(
+                responseString,
+                new(HttpStatusCode.OK),
+                () => JsonSerializer.Deserialize<GetPermissionsResponse>(responseString)!
+            )
+        );
+
+        var actual = await sut.Handle(command, CancellationToken.None);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x => 
+            x.RemovePermissions(
+                It.IsAny<Guid>(), 
+                It.IsAny<long>(), 
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ), 
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public void PostPermissionsCommandHandler_Handle_Throws_InvalidOperationException(
+        [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+        PostPermissionsCommandHandler sut,
+        PostPermissionsCommandResult result,
+        PostPermissionsCommand command
     )
     {
         providerRelationshipsApiRestClient.Setup(x =>
-            x.PostPermissions(
-                command,
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
                 CancellationToken.None
             )
-        ).ReturnsAsync(result);
+        ).ReturnsAsync(
+            new Response<GetPermissionsResponse>(
+                string.Empty,
+                new(HttpStatusCode.BadRequest),
+                () => null!
+            )
+        );
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await sut.Handle(command, CancellationToken.None)
+        );       
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.RemovePermissions(
+                It.IsAny<Guid>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task PostPermissionsCommandHandler_Handle_Requires_Permissions_Removed(
+        [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+        PostPermissionsCommandHandler sut,
+        PostPermissionsCommandResult result,
+        PostPermissionsCommand command
+    )
+    {
+        command.Operations = [];
+
+        var responseObject = new GetPermissionsResponse()
+        {
+            Operations = new List<Operation> { Operation.Recruitment }
+        };
+
+        var responseString = JsonSerializer.Serialize(responseObject);
+
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                CancellationToken.None
+            )
+        ).ReturnsAsync(
+            new Response<GetPermissionsResponse>(
+                responseString, 
+                new(HttpStatusCode.OK),
+                () => JsonSerializer.Deserialize<GetPermissionsResponse>(responseString)!
+            )
+        );
 
         var actual = await sut.Handle(command, CancellationToken.None);
-        actual.Should().Be(result);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.RemovePermissions(
+                It.IsAny<Guid>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostNotifications(
+                It.Is<PostNotificationsCommand>(cmd =>
+                    cmd.Notifications.Count() == 1 &&
+                    cmd.Notifications[0].NotificationType == nameof(NotificationType.Provider) &&
+                    cmd.Notifications[0].TemplateName == nameof(PermissionEmailTemplateType.PermissionDeleted) &&
+                    cmd.Notifications[0].Ukprn == command.Ukprn &&
+                    cmd.Notifications[0].AccountLegalEntityId == command.AccountLegalEntityId &&
+                    cmd.Notifications[0].PermitApprovals == 0 &&
+                    cmd.Notifications[0].PermitRecruit == 0 &&
+                    cmd.Notifications[0].CreatedBy == command.UserRef.ToString()
+                ),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task PostPermissionsCommandHandler_Handle_Permissions_Created_PermitRecruit(
+        [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+        PostPermissionsCommandHandler sut,
+        PostPermissionsCommandResult result,
+        PostPermissionsCommand command
+    )
+    {
+        command.Operations = [Operation.CreateCohort, Operation.Recruitment];
+
+        var responseObject = new GetPermissionsResponse()
+        {
+            Operations = []
+        };
+
+        var responseString = JsonSerializer.Serialize(responseObject);
+
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                CancellationToken.None
+            )
+        ).ReturnsAsync(
+            new Response<GetPermissionsResponse>(
+                responseString,
+                new(HttpStatusCode.OK),
+                () => JsonSerializer.Deserialize<GetPermissionsResponse>(responseString)!
+            )
+        );
+
+        var actual = await sut.Handle(command, CancellationToken.None);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.RemovePermissions(
+                It.IsAny<Guid>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostNotifications(
+                It.Is<PostNotificationsCommand>(cmd =>
+                    cmd.Notifications.Count() == 1 &&
+                    cmd.Notifications[0].NotificationType == nameof(NotificationType.Provider) &&
+                    cmd.Notifications[0].TemplateName == nameof(PermissionEmailTemplateType.PermissionsCreated) &&
+                    cmd.Notifications[0].Ukprn == command.Ukprn &&
+                    cmd.Notifications[0].AccountLegalEntityId == command.AccountLegalEntityId &&
+                    cmd.Notifications[0].PermitApprovals == 1 &&
+                    cmd.Notifications[0].PermitRecruit == 1 &&
+                    cmd.Notifications[0].CreatedBy == command.UserRef.ToString()
+                ),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task PostPermissionsCommandHandler_Handle_Permissions_Created_PermitRecruitWithReview(
+        [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+        PostPermissionsCommandHandler sut,
+        PostPermissionsCommandResult result,
+        PostPermissionsCommand command
+    )
+    {
+        command.Operations = [Operation.CreateCohort, Operation.RecruitmentRequiresReview];
+
+        var responseObject = new GetPermissionsResponse()
+        {
+            Operations = []
+        };
+
+        var responseString = JsonSerializer.Serialize(responseObject);
+
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                CancellationToken.None
+            )
+        ).ReturnsAsync(
+            new Response<GetPermissionsResponse>(
+                responseString,
+                new(HttpStatusCode.OK),
+                () => JsonSerializer.Deserialize<GetPermissionsResponse>(responseString)!
+            )
+        );
+
+        var actual = await sut.Handle(command, CancellationToken.None);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.RemovePermissions(
+                It.IsAny<Guid>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostNotifications(
+                It.Is<PostNotificationsCommand>(cmd =>
+                    cmd.Notifications.Count() == 1 &&
+                    cmd.Notifications[0].NotificationType == nameof(NotificationType.Provider) &&
+                    cmd.Notifications[0].TemplateName == nameof(PermissionEmailTemplateType.PermissionsCreated) &&
+                    cmd.Notifications[0].Ukprn == command.Ukprn &&
+                    cmd.Notifications[0].AccountLegalEntityId == command.AccountLegalEntityId &&
+                    cmd.Notifications[0].PermitApprovals == 1 &&
+                    cmd.Notifications[0].PermitRecruit == 2 &&
+                    cmd.Notifications[0].CreatedBy == command.UserRef.ToString()
+                ),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task PostPermissionsCommandHandler_Handle_Permissions_Updated(
+       [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+       PostPermissionsCommandHandler sut,
+       PostPermissionsCommandResult result,
+       PostPermissionsCommand command
+   )
+    {
+        command.Operations = [Operation.Recruitment];
+
+        var responseObject = new GetPermissionsResponse()
+        {
+            Operations = new List<Operation> { Operation.RecruitmentRequiresReview }
+        };
+
+        var responseString = JsonSerializer.Serialize(responseObject);
+
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetPermissions(
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                CancellationToken.None
+            )
+        ).ReturnsAsync(
+            new Response<GetPermissionsResponse>(
+                responseString,
+                new(HttpStatusCode.OK),
+                () => JsonSerializer.Deserialize<GetPermissionsResponse>(responseString)!
+            )
+        );
+
+        var actual = await sut.Handle(command, CancellationToken.None);
+        actual.Should().Be(Unit.Value);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostPermissions(
+                It.IsAny<PostPermissionsCommand>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.RemovePermissions(
+                It.IsAny<Guid>(),
+                It.IsAny<long>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Never);
+
+        providerRelationshipsApiRestClient.Verify(x =>
+            x.PostNotifications(
+                It.Is<PostNotificationsCommand>(cmd =>
+                    cmd.Notifications.Count() == 1 &&
+                    cmd.Notifications[0].NotificationType == nameof(NotificationType.Provider) &&
+                    cmd.Notifications[0].TemplateName == nameof(PermissionEmailTemplateType.PermissionsUpdated) &&
+                    cmd.Notifications[0].Ukprn == command.Ukprn &&
+                    cmd.Notifications[0].AccountLegalEntityId == command.AccountLegalEntityId &&
+                    cmd.Notifications[0].PermitApprovals == 0 &&
+                    cmd.Notifications[0].PermitRecruit == 1 &&
+                    cmd.Notifications[0].CreatedBy == command.UserRef.ToString()
+                ),
+                It.IsAny<CancellationToken>()
+            ),
+        Times.Once);
     }
 }

--- a/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Providers/Queries/GetPermissionsHas/GetPermissionsHasQueryHandlerTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Providers/Queries/GetPermissionsHas/GetPermissionsHasQueryHandlerTests.cs
@@ -23,7 +23,7 @@ public class GetPermissionsQueryHandlerTests
         providerRelationshipsApiRestClient.Setup(x =>
             x.GetPermissions(
                 It.IsAny<long>(),
-                It.IsAny<int>(),
+                It.IsAny<long>(),
                 It.IsAny<CancellationToken>()
             )
         )
@@ -49,7 +49,7 @@ public class GetPermissionsQueryHandlerTests
         providerRelationshipsApiRestClient.Setup(x =>
                 x.GetPermissions(
                     It.IsAny<long>(),
-                    It.IsAny<int>(),
+                    It.IsAny<long>(),
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -73,7 +73,7 @@ public class GetPermissionsQueryHandlerTests
         providerRelationshipsApiRestClient.Setup(x =>
                 x.GetPermissions(
                     It.IsAny<long>(),
-                    It.IsAny<int>(),
+                    It.IsAny<long>(),
                     It.IsAny<CancellationToken>()
                 )
             )

--- a/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Relationships/Queries/GetRelationships/GetRelationshipsQueryHandlerTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/Relationships/Queries/GetRelationships/GetRelationshipsQueryHandlerTests.cs
@@ -1,0 +1,31 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EmployerPR.Application.Queries.GetRelationships;
+using SFA.DAS.EmployerPR.Infrastructure;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.EmployerPR.UnitTests.Application.Relationships.Queries.GetRelationships;
+public class GetRelationshipsQueryHandlerTests
+{
+    [Test, MoqAutoData]
+    public async Task Handle_ReturnRelationships(
+        [Frozen] Mock<IProviderRelationshipsApiRestClient> providerRelationshipsApiRestClient,
+        GetRelationshipsHandler handler,
+        GetRelationshipsQuery query,
+        GetRelationshipsResponse response
+    )
+    {
+        providerRelationshipsApiRestClient.Setup(x =>
+            x.GetRelationships(
+                query.Ukprn,
+                query.AccountLegalEntityId,
+                CancellationToken.None
+            )
+        ).ReturnsAsync(response);
+
+        var actual = await handler.Handle(query, CancellationToken.None);
+        actual.Should().BeEquivalentTo(response);
+    }
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/NotificationModel.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/NotificationModel.cs
@@ -1,0 +1,15 @@
+﻿namespace SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
+
+public class NotificationModel
+{
+    public required string TemplateName { get; set; }
+    public required string NotificationType { get; set; }
+    public long? Ukprn { get; set; }
+    public string? EmailAddress { get; set; }
+    public string? Contact { get; set; }
+    public Guid? RequestId { get; set; }
+    public long? AccountLegalEntityId { get; set; }
+    public int? PermitApprovals { get; set; }
+    public int? PermitRecruit { get; set; }
+    public required string CreatedBy { get; set; }
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/PostNotificationsCommand.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/PostNotificationsCommand.cs
@@ -7,5 +7,5 @@ public class PostNotificationsCommand
         Notifications = notifications;
     }
 
-    public NotificationModel[] Notifications { get; set; } = [];
+    public NotificationModel[] Notifications { get; set; }
 }

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/PostNotificationsCommand.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostNotifications/PostNotificationsCommand.cs
@@ -1,0 +1,11 @@
+﻿namespace SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
+
+public class PostNotificationsCommand
+{
+    public PostNotificationsCommand(NotificationModel[] notifications)
+    {
+        Notifications = notifications;
+    }
+
+    public NotificationModel[] Notifications { get; set; } = [];
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommand.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommand.cs
@@ -3,7 +3,7 @@ using SFA.DAS.SharedOuterApi.Models.ProviderRelationships;
 
 namespace SFA.DAS.EmployerPR.Application.Commands.PostPermissions;
 
-public class PostPermissionsCommand : IRequest<PostPermissionsCommandResult>
+public class PostPermissionsCommand : IRequest<Unit>
 {
     public required Guid UserRef { get; set; }
 

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
@@ -1,12 +1,142 @@
 ﻿using MediatR;
+using RestEase;
+using SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
+using SFA.DAS.EmployerPR.Application.Queries.GetPermissions;
+using SFA.DAS.EmployerPR.Common;
 using SFA.DAS.EmployerPR.Infrastructure;
+using SFA.DAS.SharedOuterApi.Models.ProviderRelationships;
+using System.Net;
 
 namespace SFA.DAS.EmployerPR.Application.Commands.PostPermissions;
 
-public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _providerRelationshipsApiRestClient) : IRequestHandler<PostPermissionsCommand, PostPermissionsCommandResult>
+public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _providerRelationshipsApiRestClient) : IRequestHandler<PostPermissionsCommand, Unit>
 {
-    public async Task<PostPermissionsCommandResult> Handle(PostPermissionsCommand command, CancellationToken cancellationToken)
+    private const int PERMITS_APPROVAL = 1;
+    private const int PERMITS_RECRUITNENT = 1;
+    private const int PERMITS_RECRUITNENT_WITH_REVIEW = 2;
+
+    public async Task<Unit> Handle(PostPermissionsCommand command, CancellationToken cancellationToken)
     {
-        return await _providerRelationshipsApiRestClient.PostPermissions(command, cancellationToken);
+        Response<GetPermissionsResponse> permissionsResponse = 
+            await _providerRelationshipsApiRestClient.GetPermissions(
+                command.Ukprn, 
+                command.AccountLegalEntityId, 
+                cancellationToken
+        );
+
+        List<Operation> existingOperations = [];
+
+        switch(permissionsResponse.ResponseMessage.StatusCode)
+        {
+            case HttpStatusCode.OK:
+                {
+                    existingOperations = permissionsResponse.GetContent().Operations;
+                }
+                break;
+            case HttpStatusCode.NotFound:
+                {
+                    existingOperations = [];
+                }
+                break;
+            default:
+                {
+                    throw new InvalidOperationException($"Invalid operation occurred trying to retrieve permissions for ukprn {command.Ukprn} and AccountLegalEntityId {command.AccountLegalEntityId}");
+                }
+        }
+
+        if (NoUpdatesRequired(command.Operations, existingOperations))
+        {
+            return Unit.Value;
+        }
+
+        PermissionEmailTemplateType templateType = default;
+
+        if (!command.Operations.Any())
+        {
+            await _providerRelationshipsApiRestClient.RemovePermissions(
+                command.UserRef, 
+                command.Ukprn!.Value, 
+                command.AccountLegalEntityId, 
+                cancellationToken
+            );
+
+            templateType = PermissionEmailTemplateType.PermissionDeleted;
+        }
+        else
+        {
+            await _providerRelationshipsApiRestClient.PostPermissions(
+                command,
+                cancellationToken
+            );
+
+            templateType = GetTemplateType(existingOperations);
+        }
+
+        await PostNotification(command, templateType, cancellationToken);
+
+        return Unit.Value;
+    }
+
+    private bool NoUpdatesRequired(List<Operation> requestedPermissions, List<Operation> currentPermissions)
+    {
+        return (!requestedPermissions.Any() && !currentPermissions.Any()) || IdenticalPermissions(requestedPermissions, currentPermissions);
+    }
+
+    private bool IdenticalPermissions(List<Operation> requestedPermissions, List<Operation> currentPermissions)
+    {
+        return currentPermissions.OrderBy(a => (int)a).SequenceEqual(requestedPermissions.OrderBy(a => (int)a));
+    }
+
+    private PermissionEmailTemplateType GetTemplateType(List<Operation> operations)
+    {
+        return operations.Any() ?
+            PermissionEmailTemplateType.PermissionsUpdated : 
+            PermissionEmailTemplateType.PermissionsCreated;
+    }
+
+    private async Task PostNotification(PostPermissionsCommand command, PermissionEmailTemplateType templateType, CancellationToken cancellationToken)
+    {
+        NotificationModel notification = new NotificationModel()
+        {
+            NotificationType = nameof(NotificationType.Provider),
+            TemplateName = templateType.ToString(),
+            Ukprn = command.Ukprn,
+            AccountLegalEntityId = command.AccountLegalEntityId,
+            PermitApprovals = SetPermitsApproval(command.Operations),
+            PermitRecruit = SetPermitsRecruit(command.Operations),
+            CreatedBy = command.UserRef.ToString()
+        };
+
+        await _providerRelationshipsApiRestClient.PostNotifications(
+            new PostNotificationsCommand([notification]),
+            cancellationToken
+        );
+    }
+
+    private int SetPermitsApproval(List<Operation> operations)
+    {
+        if(operations.Contains(Operation.CreateCohort))
+        {
+            return PERMITS_APPROVAL;
+        }
+        else
+        {
+            return default;
+        }
+    }
+
+    private int SetPermitsRecruit(List<Operation> operations)
+    {
+        if(operations.Contains(Operation.Recruitment))
+        {
+            return PERMITS_RECRUITNENT;
+        }
+
+        if (operations.Contains(Operation.RecruitmentRequiresReview))
+        {
+            return PERMITS_RECRUITNENT_WITH_REVIEW;
+        }
+
+        return default;
     }
 }

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
@@ -51,7 +51,7 @@ public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _
 
         PermissionEmailTemplateType templateType = default;
 
-        if (!command.Operations.Any())
+        if (command.Operations.Count == 0)
         {
             await _providerRelationshipsApiRestClient.RemovePermissions(
                 command.UserRef, 
@@ -79,19 +79,19 @@ public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _
 
     private bool NoUpdatesRequired(List<Operation> requestedPermissions, List<Operation> currentPermissions)
     {
-        return (!requestedPermissions.Any() && !currentPermissions.Any()) || IdenticalPermissions(requestedPermissions, currentPermissions);
+        return (requestedPermissions.Count == 0 && !currentPermissions.Any()) || IdenticalPermissions(requestedPermissions, currentPermissions);
     }
 
-    private bool IdenticalPermissions(List<Operation> requestedPermissions, List<Operation> currentPermissions)
+    private static bool IdenticalPermissions(List<Operation> requestedPermissions, List<Operation> currentPermissions)
     {
         return currentPermissions.OrderBy(a => (int)a).SequenceEqual(requestedPermissions.OrderBy(a => (int)a));
     }
 
-    private PermissionEmailTemplateType GetTemplateType(List<Operation> operations)
+    private static PermissionEmailTemplateType GetTemplateType(List<Operation> operations)
     {
-        return operations.Any() ?
-            PermissionEmailTemplateType.PermissionsUpdated : 
-            PermissionEmailTemplateType.PermissionsCreated;
+        return operations.Count == 0 ?
+            PermissionEmailTemplateType.PermissionsCreated :
+            PermissionEmailTemplateType.PermissionsUpdated;
     }
 
     private async Task PostNotification(PostPermissionsCommand command, PermissionEmailTemplateType templateType, CancellationToken cancellationToken)
@@ -113,7 +113,7 @@ public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _
         );
     }
 
-    private int SetPermitsApproval(List<Operation> operations)
+    private static int SetPermitsApproval(List<Operation> operations)
     {
         if(operations.Contains(Operation.CreateCohort))
         {
@@ -125,7 +125,7 @@ public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _
         }
     }
 
-    private int SetPermitsRecruit(List<Operation> operations)
+    private static int SetPermitsRecruit(List<Operation> operations)
     {
         if(operations.Contains(Operation.Recruitment))
         {

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
@@ -40,7 +40,7 @@ public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _
                 break;
             default:
                 {
-                    throw new InvalidOperationException($"Invalid operation occurred trying to retrieve permissions for ukprn {command.Ukprn} and AccountLegalEntityId {command.AccountLegalEntityId}");
+                    throw new InvalidOperationException($"Unexpected response code {permissionsResponse.ResponseMessage.StatusCode} when trying to retrieve permissions for ukprn {command.Ukprn} and AccountLegalEntityId {command.AccountLegalEntityId}");
                 }
         }
 
@@ -79,17 +79,17 @@ public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _
 
     private static bool NoUpdatesRequired(List<Operation> requestedPermissions, List<Operation> currentPermissions)
     {
-        return (requestedPermissions.Count == 0 && currentPermissions.Count == 0) || IdenticalPermissions(requestedPermissions, currentPermissions);
+        return (requestedPermissions.Count == 0 && currentPermissions.Count == 0) || HasIdenticalPermissions(requestedPermissions, currentPermissions);
     }
 
-    private static bool IdenticalPermissions(List<Operation> requestedPermissions, List<Operation> currentPermissions)
+    private static bool HasIdenticalPermissions(List<Operation> requestedPermissions, List<Operation> currentPermissions)
     {
         return currentPermissions.OrderBy(a => (int)a).SequenceEqual(requestedPermissions.OrderBy(a => (int)a));
     }
 
-    private static PermissionEmailTemplateType GetTemplateType(List<Operation> operations)
+    private static PermissionEmailTemplateType GetTemplateType(List<Operation> existingOperations)
     {
-        return operations.Count == 0 ?
+        return existingOperations.Count == 0 ?
             PermissionEmailTemplateType.PermissionsCreated :
             PermissionEmailTemplateType.PermissionsUpdated;
     }

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Commands/PostPermissions/PostPermissionsCommandHandler.cs
@@ -77,9 +77,9 @@ public class PostPermissionsCommandHandler(IProviderRelationshipsApiRestClient _
         return Unit.Value;
     }
 
-    private bool NoUpdatesRequired(List<Operation> requestedPermissions, List<Operation> currentPermissions)
+    private static bool NoUpdatesRequired(List<Operation> requestedPermissions, List<Operation> currentPermissions)
     {
-        return (requestedPermissions.Count == 0 && !currentPermissions.Any()) || IdenticalPermissions(requestedPermissions, currentPermissions);
+        return (requestedPermissions.Count == 0 && currentPermissions.Count == 0) || IdenticalPermissions(requestedPermissions, currentPermissions);
     }
 
     private static bool IdenticalPermissions(List<Operation> requestedPermissions, List<Operation> currentPermissions)

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/GetRelationshipsHandler.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/GetRelationshipsHandler.cs
@@ -1,0 +1,14 @@
+﻿using MediatR;
+using SFA.DAS.EmployerPR.Infrastructure;
+
+namespace SFA.DAS.EmployerPR.Application.Queries.GetRelationships;
+public class GetRelationshipsHandler(IProviderRelationshipsApiRestClient _providerRelationshipsApiRestClient) : IRequestHandler<GetRelationshipsQuery, GetRelationshipsResponse>
+{
+    public async Task<GetRelationshipsResponse> Handle(GetRelationshipsQuery query, CancellationToken cancellationToken)
+    {
+        var response =
+            await _providerRelationshipsApiRestClient.GetRelationships(query.Ukprn, query.AccountLegalEntityId, cancellationToken);
+
+        return response;
+    }
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/GetRelationshipsQuery.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/GetRelationshipsQuery.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace SFA.DAS.EmployerPR.Application.Queries.GetRelationships;
+
+public class GetRelationshipsQuery : IRequest<GetRelationshipsResponse>
+{
+    public long? Ukprn { get; set; }
+    public int? AccountLegalEntityId { get; set; }
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/GetRelationshipsResponse.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/GetRelationshipsResponse.cs
@@ -1,0 +1,31 @@
+﻿using SFA.DAS.SharedOuterApi.Models.ProviderRelationships;
+
+namespace SFA.DAS.EmployerPR.Application.Queries.GetRelationships;
+public class GetRelationshipsResponse
+{
+    public long AccountLegalEntityId { get; set; }
+
+    public string AccountLegalEntityPublicHashedId { get; set; } = null!;
+
+    public string AccountLegalEntityName { get; set; } = null!;
+
+    public long AccountId { get; set; }
+
+    public long Ukprn { get; set; }
+
+    public string ProviderName { get; set; } = null!;
+
+    public Operation[] Operations { get; set; } = [];
+
+    public PermissionAction? LastAction { get; set; }
+
+    public DateTime? LastActionTime { get; set; }
+
+    public string? LastRequestType { get; set; }
+
+    public DateTime? LastRequestTime { get; set; }
+
+    public RequestStatus? LastRequestStatus { get; set; }
+
+    public Operation[]? LastRequestOperations { get; set; }
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/PermissionAction.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/PermissionAction.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.EmployerPR.Application.Queries.GetRelationships;
+public enum PermissionAction : short
+{
+    ApprovalsRelationship,
+    RecruitRelationship,
+    PermissionCreated,
+    PermissionUpdated,
+    PermissionDeleted
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/RequestStatus.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetRelationships/RequestStatus.cs
@@ -1,0 +1,10 @@
+﻿namespace SFA.DAS.EmployerPR.Application.Queries.GetRelationships;
+public enum RequestStatus : short
+{
+    New,
+    Sent,
+    Accepted,
+    Declined,
+    Expired,
+    Deleted
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Common/NotificationType.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Common/NotificationType.cs
@@ -1,0 +1,6 @@
+﻿namespace SFA.DAS.EmployerPR.Common;
+
+public enum NotificationType
+{
+    Provider
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Common/PermissionEmailTemplateType.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Common/PermissionEmailTemplateType.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.EmployerPR.Common;
+
+public enum PermissionEmailTemplateType
+{
+    PermissionsCreated,
+    PermissionsUpdated,
+    PermissionDeleted
+}

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
@@ -3,6 +3,7 @@ using SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
 using SFA.DAS.EmployerPR.Application.Commands.PostPermissions;
 using SFA.DAS.EmployerPR.Application.Queries.GetEmployerRelationships;
 using SFA.DAS.EmployerPR.Application.Queries.GetPermissions;
+using SFA.DAS.EmployerPR.Application.Queries.GetRelationships;
 
 namespace SFA.DAS.EmployerPR.Infrastructure;
 
@@ -11,6 +12,9 @@ public interface IProviderRelationshipsApiRestClient
     [Get("permissions")]
     [AllowAnyStatusCode]
     Task<Response<GetPermissionsResponse>> GetPermissions([Query] long? ukprn, [Query] long? AccountLegalEntityId, CancellationToken cancellationToken);
+
+    [Get("relationships")]
+    Task<GetRelationshipsResponse> GetRelationships([Query] long? ukprn, [Query] int? accountLegalEntityId, CancellationToken cancellationToken);
 
     [Get("relationships/employeraccount/{AccountHashedId}")]
     Task<GetEmployerRelationshipsResponse> GetEmployerRelationships([Path] string AccountHashedId, [Query] long? Ukprn, [Query] string? AccountlegalentityPublicHashedId, CancellationToken cancellationToken);

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
@@ -1,4 +1,5 @@
 ﻿using RestEase;
+using SFA.DAS.EmployerPR.Application.Commands.PostNotifications;
 using SFA.DAS.EmployerPR.Application.Commands.PostPermissions;
 using SFA.DAS.EmployerPR.Application.Queries.GetEmployerRelationships;
 using SFA.DAS.EmployerPR.Application.Queries.GetPermissions;
@@ -9,11 +10,17 @@ public interface IProviderRelationshipsApiRestClient
 {
     [Get("permissions")]
     [AllowAnyStatusCode]
-    Task<Response<GetPermissionsResponse>> GetPermissions([Query] long? ukprn, [Query] int? AccountLegalEntityId, CancellationToken cancellationToken);
+    Task<Response<GetPermissionsResponse>> GetPermissions([Query] long? ukprn, [Query] long? AccountLegalEntityId, CancellationToken cancellationToken);
 
     [Get("relationships/employeraccount/{AccountHashedId}")]
     Task<GetEmployerRelationshipsResponse> GetEmployerRelationships([Path] string AccountHashedId, [Query] long? Ukprn, [Query] string? AccountlegalentityPublicHashedId, CancellationToken cancellationToken);
 
     [Post("permissions")]
     Task<PostPermissionsCommandResult> PostPermissions([Body] PostPermissionsCommand command, CancellationToken cancellationToken);
+
+    [Post("notifications")]
+    Task PostNotifications([Body] PostNotificationsCommand command, CancellationToken cancellationToken);
+
+    [Delete("permissions")]
+    Task RemovePermissions([Query] Guid userRef, [Query] long ukprn, [Query] long accountLegalEntityId, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
- Extension of the post permissions endpoint to send out specific notification based on whether or not permissions are being updated, deleted or added.