### PR TITLE
updated triggers across all pipelines

### DIFF
--- a/src/AdminAan/azure-pipelines.yml
+++ b/src/AdminAan/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/AdminAan
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/AdminAan
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/AparRegister/azure-pipelines.yml
+++ b/src/AparRegister/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/AparRegister
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/AparRegister
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ApimDeveloper/azure-pipelines.yml
+++ b/src/ApimDeveloper/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApimDeveloper
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApimDeveloper
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticeAan/azure-pipelines.yml
+++ b/src/ApprenticeAan/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticeAan
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticeAan
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticeApp/azure-pipelines.yml
+++ b/src/ApprenticeApp/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticeApp
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticeApp
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticeCommitments/azure-pipelines.yml
+++ b/src/ApprenticeCommitments/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticeCommitments
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticeCommitments
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticeFeedback/azure-pipelines.yml
+++ b/src/ApprenticeFeedback/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticeFeedback
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticeFeedback
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ApprenticePortal/azure-pipelines.yml
+++ b/src/ApprenticePortal/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticePortal
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ApprenticePortal
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/Apprenticeships/azure-pipelines.yml
+++ b/src/Apprenticeships/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Apprenticeships
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Apprenticeships
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/Assessors/azure-pipelines.yml
+++ b/src/Assessors/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Assessors
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Assessors
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/Campaign/azure-pipelines.yml
+++ b/src/Campaign/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Campaign
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Campaign
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EarlyConnect/azure-pipelines.yml
+++ b/src/EarlyConnect/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EarlyConnect
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EarlyConnect
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerAan/azure-pipelines.yml
+++ b/src/EmployerAan/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerAan
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerAan
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerAccounts/azure-pipelines.yml
+++ b/src/EmployerAccounts/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerAccounts
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerAccounts
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerContactForms/azure-pipelines.yml
+++ b/src/EmployerContactForms/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerContactForms
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerContactForms
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerDemand/azure-pipelines.yml
+++ b/src/EmployerDemand/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerDemand
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerDemand
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerFeedback/azure-pipelines.yml
+++ b/src/EmployerFeedback/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerFeedback
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerFeedback
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerIncentives/azure-pipelines.yml
+++ b/src/EmployerIncentives/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerIncentives
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerIncentives
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerPR/azure-pipelines.yml
+++ b/src/EmployerPR/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerPR
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerPR
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerProfiles/azure-pipelines.yml
+++ b/src/EmployerProfiles/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerProfiles
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerProfiles
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerRequestApprenticeTraining
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmployerRequestApprenticeTraining
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EmploymentCheck/azure-pipelines.yml
+++ b/src/EmploymentCheck/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmploymentCheck
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EmploymentCheck
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/EpaoRegister/azure-pipelines.yml
+++ b/src/EpaoRegister/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EpaoRegister
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/EpaoRegister
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/FindApprenticeshipJobs/azure-pipelines.yml
+++ b/src/FindApprenticeshipJobs/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/FindApprenticeshipJobs
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/FindApprenticeshipJobs
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/FindApprenticeshipTraining/azure-pipelines.yml
+++ b/src/FindApprenticeshipTraining/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/FindApprenticeshipTraining
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/FindApprenticeshipTraining
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/FindEpao/azure-pipelines.yml
+++ b/src/FindEpao/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/FindEpao
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/FindEpao
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/Forecasting/azure-pipelines.yml
+++ b/src/Forecasting/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Forecasting
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Forecasting
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/Funding/azure-pipelines.yml
+++ b/src/Funding/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Funding
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Funding
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ProviderFeedback/azure-pipelines.yml
+++ b/src/ProviderFeedback/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ProviderFeedback
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ProviderFeedback
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ProviderPR/azure-pipelines.yml
+++ b/src/ProviderPR/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ProviderPR
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ProviderPR
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ProviderRelationships/azure-pipelines.yml
+++ b/src/ProviderRelationships/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ProviderRelationships
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ProviderRelationships
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ProviderRequestApprenticeTraining
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ProviderRequestApprenticeTraining
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/PublicSectorReporting/azure-pipelines.yml
+++ b/src/PublicSectorReporting/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/PublicSectorReporting
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/PublicSectorReporting
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/Recruit/azure-pipelines.yml
+++ b/src/Recruit/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Recruit
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   branches:
@@ -18,12 +17,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Recruit
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/ReferenceDataJobs/azure-pipelines.yml
+++ b/src/ReferenceDataJobs/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ReferenceDataJobs
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/ReferenceDataJobs
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/Reservations/azure-pipelines.yml
+++ b/src/Reservations/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Reservations
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Reservations
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/Roatp/azure-pipelines.yml
+++ b/src/Roatp/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Roatp
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   branches:
@@ -18,12 +17,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Roatp
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/RoatpCourseManagement/azure-pipelines.yml
+++ b/src/RoatpCourseManagement/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/RoatpCourseManagement
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/RoatpCourseManagement
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/RoatpOversight/azure-pipelines.yml
+++ b/src/RoatpOversight/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/RoatpOversight
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/RoatpOversight
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/RoatpProviderModeration/azure-pipelines.yml
+++ b/src/RoatpProviderModeration/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/RoatpProviderModeration
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/RoatpProviderModeration
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/TrackProgress/azure-pipelines.yml
+++ b/src/TrackProgress/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/TrackProgress
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   branches:
@@ -18,12 +17,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/TrackProgress
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/TrackProgressInternal/azure-pipelines.yml
+++ b/src/TrackProgressInternal/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/TrackProgressInternal
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   branches:
@@ -18,12 +17,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/TrackProgressInternal
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/Vacancies/azure-pipelines.yml
+++ b/src/Vacancies/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Vacancies
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   autoCancel: true
@@ -19,12 +18,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/Vacancies
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources

--- a/src/VacanciesManage/azure-pipelines.yml
+++ b/src/VacanciesManage/azure-pipelines.yml
@@ -5,12 +5,11 @@ trigger:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/VacanciesManage
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 pr:
   branches:
@@ -18,12 +17,11 @@ pr:
       - "master"
   paths:
     include:
-    - azure
-    - pipeline-templates
     - src/VacanciesManage
     exclude:
-    - azure/shared-infrastructure-template.json
-    - pipeline-templates/job/shared-arm-deploy.yml
+    - azure
+    - pipeline-templates
+    - deployments
 
 variables:
 - group: Release Management Resources


### PR DESCRIPTION
Updated the pipeline triggers so that any DevOps changes to the following folders doesn't cause a bulk trigger of pipeline runs:
- azure
- pipeline-templates
- deployments

Excluding the following API's so we still get some testing against APIM endpoints on global DevOps changes:
- Approvals
- EmployerFinance
- FindAnApprenticeship
- LevyTransferMatching

