### PR TITLE
CSP-1651: GetEmployerRelationships - Update to accept AccountId

### DIFF
--- a/src/EmployerPR/SFA.DAS.EmployerPR.Api.UnitTests/Controllers/EmployerRelationshipsControllerTest/GetEmployerRelationshipsTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.Api.UnitTests/Controllers/EmployerRelationshipsControllerTest/GetEmployerRelationshipsTests.cs
@@ -17,18 +17,18 @@ public class GetEmployerRelationshipsTests
     public async Task GetEmployerRelationships_InvokesQueryHandler(
         [Frozen] Mock<IMediator> mediatorMock,
         [Greedy] EmployerRelationshipsController sut,
-        string accountHashedId,
+        long accountId,
         long? ukprn,
         string accountlegalentityPublicHashedId,
         CancellationToken cancellationToken
     )
     {
-        await sut.GetEmployerRelationships(accountHashedId, ukprn, accountlegalentityPublicHashedId, cancellationToken);
+        await sut.GetEmployerRelationships(accountId, ukprn, accountlegalentityPublicHashedId, cancellationToken);
 
         mediatorMock.Verify(
             m => m.Send(
                 It.Is<GetEmployerRelationshipsQuery>(x => 
-                    x.AccountHashedId == accountHashedId &&
+                    x.AccountId == accountId &&
                     x.Ukprn == ukprn &&
                     x.AccountlegalentityPublicHashedId == accountlegalentityPublicHashedId
                 ),
@@ -41,7 +41,7 @@ public class GetEmployerRelationshipsTests
     public async Task GetEmployerRelationships_HandlerReturnsData_ReturnsOkResponse(
         [Frozen] Mock<IMediator> mediatorMock,
         [Greedy] EmployerRelationshipsController sut,
-        string accountHashedId,
+        long accountId,
         long? ukprn,
         string accountlegalentityPublicHashedId,
         GetEmployerRelationshipsQueryResult queryResult,
@@ -50,7 +50,7 @@ public class GetEmployerRelationshipsTests
         mediatorMock.Setup(m =>
             m.Send(
                 It.Is<GetEmployerRelationshipsQuery>(x => 
-                    x.AccountHashedId == accountHashedId &&
+                    x.AccountId == accountId &&
                     x.Ukprn == ukprn && 
                     x.AccountlegalentityPublicHashedId == accountlegalentityPublicHashedId
                 ),
@@ -59,7 +59,7 @@ public class GetEmployerRelationshipsTests
         )
         .ReturnsAsync(queryResult);
 
-        var result = await sut.GetEmployerRelationships(accountHashedId, ukprn, accountlegalentityPublicHashedId, cancellationToken);
+        var result = await sut.GetEmployerRelationships(accountId, ukprn, accountlegalentityPublicHashedId, cancellationToken);
 
         result.As<OkObjectResult>().Should().NotBeNull();
         result.As<OkObjectResult>().Value.Should().Be(queryResult);

--- a/src/EmployerPR/SFA.DAS.EmployerPR.Api/Controllers/EmployerRelationshipsController.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.Api/Controllers/EmployerRelationshipsController.cs
@@ -8,12 +8,12 @@ namespace SFA.DAS.EmployerPR.Api.Controllers;
 [Route("relationships")]
 public class EmployerRelationshipsController(IMediator _mediator) : ControllerBase
 {
-    [HttpGet("employeraccount/{accountHashedId}")]
     [Produces("application/json")]
+    [HttpGet("employeraccount/{accountId:long}")]
     [ProducesResponseType(typeof(GetEmployerRelationshipsQueryResult), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetEmployerRelationships(string accountHashedId, [FromQuery] long? ukprn, [FromQuery] string? accountlegalentityPublicHashedId, CancellationToken cancellationToken)
+    public async Task<IActionResult> GetEmployerRelationships([FromRoute] long accountId, [FromQuery] long? ukprn, [FromQuery] string? accountlegalentityPublicHashedId, CancellationToken cancellationToken)
     {
-        GetEmployerRelationshipsQuery query = new(accountHashedId, ukprn, accountlegalentityPublicHashedId);
+        GetEmployerRelationshipsQuery query = new(accountId, ukprn, accountlegalentityPublicHashedId);
 
         var result = await _mediator.Send(query, cancellationToken);
 

--- a/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/EmployerRelationships/Queries/GetEmployerRelationships/GetEmployerRelationshipsQueryHandlerTests.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR.UnitTests/Application/EmployerRelationships/Queries/GetEmployerRelationships/GetEmployerRelationshipsQueryHandlerTests.cs
@@ -21,7 +21,7 @@ public class GetEmployerRelationshipsQueryHandlerTests
     {
         providerRelationshipsApiRestClient.Setup(x =>
             x.GetEmployerRelationships(
-                query.AccountHashedId, 
+                query.AccountId, 
                 query.Ukprn, 
                 query.AccountlegalentityPublicHashedId,
                 CancellationToken.None

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetEmployerRelationships/GetEmployerRelationshipsQuery.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetEmployerRelationships/GetEmployerRelationshipsQuery.cs
@@ -4,15 +4,15 @@ namespace SFA.DAS.EmployerPR.Application.Queries.GetEmployerRelationships;
 
 public class GetEmployerRelationshipsQuery : IRequest<GetEmployerRelationshipsQueryResult>
 {
-    public string AccountHashedId { get; set; }
+    public long AccountId { get; set; }
 
     public long? Ukprn { get; set; }
 
     public string? AccountlegalentityPublicHashedId { get; set; }
 
-    public GetEmployerRelationshipsQuery(string accountHashedId, long? ukprn = null, string? accountlegalentityPublicHashedId = null)
+    public GetEmployerRelationshipsQuery(long accountId, long? ukprn = null, string? accountlegalentityPublicHashedId = null)
     {
-        AccountHashedId = accountHashedId;
+        AccountId = accountId;
         Ukprn = ukprn;
         AccountlegalentityPublicHashedId = accountlegalentityPublicHashedId;
     }

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetEmployerRelationships/GetEmployerRelationshipsQueryHandler.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Application/Queries/GetEmployerRelationships/GetEmployerRelationshipsQueryHandler.cs
@@ -9,7 +9,7 @@ public class GetEmployerRelationshipsQueryHandler(IProviderRelationshipsApiRestC
     {
         var response =
             await _providerRelationshipsApiRestClient.GetEmployerRelationships(
-                query.AccountHashedId, 
+                query.AccountId, 
                 query.Ukprn, 
                 query.AccountlegalentityPublicHashedId, 
                 cancellationToken

--- a/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
+++ b/src/EmployerPR/SFA.DAS.EmployerPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
@@ -17,8 +17,8 @@ public interface IProviderRelationshipsApiRestClient
     [Get("relationships")]
     Task<GetRelationshipsResponse> GetRelationships([Query] long? ukprn, [Query] int? accountLegalEntityId, CancellationToken cancellationToken);
 
-    [Get("relationships/employeraccount/{AccountHashedId}")]
-    Task<GetEmployerRelationshipsResponse> GetEmployerRelationships([Path] string AccountHashedId, [Query] long? Ukprn, [Query] string? AccountlegalentityPublicHashedId, CancellationToken cancellationToken);
+    [Get("relationships/employeraccount/{accountId}")]
+    Task<GetEmployerRelationshipsResponse> GetEmployerRelationships([Path] long accountId, [Query] long? Ukprn, [Query] string? AccountlegalentityPublicHashedId, CancellationToken cancellationToken);
 
     [Post("permissions")]
     Task<PostPermissionsCommandResult> PostPermissions([Body] PostPermissionsCommand command, CancellationToken cancellationToken);


### PR DESCRIPTION
- Updated the GetEmployerRelationships endpoint to work off AccountId instead of AccountHashedId.