### PR TITLE
CSP-1820: (Provider View employers and manage permissions) Filters/Search not working as expected

### DIFF
--- a/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/Application/Queries/GetRelationships/GetRelationshipsQueryHandlerTests.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/Application/Queries/GetRelationships/GetRelationshipsQueryHandlerTests.cs
@@ -15,7 +15,7 @@ public class GetRelationshipQueryHandlerTests
     {
         Mock<IProviderRelationshipsApiRestClient> apiClientMock = new();
         Response<GetProviderRelationshipsResponse> result = new(null, new(HttpStatusCode.OK), () => expected);
-        apiClientMock.Setup(c => c.GetProviderRelationships(query.Ukprn, query.Request.ToQueryString(), cancellationToken)).ReturnsAsync(result);
+        apiClientMock.Setup(c => c.GetProviderRelationships(query.Ukprn, query.Request.ToDictionary(), cancellationToken)).ReturnsAsync(result);
 
         GetRelationshipsQueryHandler sut = new(apiClientMock.Object);
 

--- a/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/Application/Queries/GetRelationships/GetRelationshipsQueryHandlerTests.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/Application/Queries/GetRelationships/GetRelationshipsQueryHandlerTests.cs
@@ -15,7 +15,7 @@ public class GetRelationshipQueryHandlerTests
     {
         Mock<IProviderRelationshipsApiRestClient> apiClientMock = new();
         Response<GetProviderRelationshipsResponse> result = new(null, new(HttpStatusCode.OK), () => expected);
-        apiClientMock.Setup(c => c.GetProviderRelationships(query.Ukprn, query.Request, cancellationToken)).ReturnsAsync(result);
+        apiClientMock.Setup(c => c.GetProviderRelationships(query.Ukprn, query.Request.ToQueryString(), cancellationToken)).ReturnsAsync(result);
 
         GetRelationshipsQueryHandler sut = new(apiClientMock.Object);
 

--- a/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/InnerApi/Requests/GetProviderRelationshipsRequestTests.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/InnerApi/Requests/GetProviderRelationshipsRequestTests.cs
@@ -5,14 +5,14 @@ namespace SFA.DAS.ProviderPR.UnitTests.InnerApi.Requests;
 public sealed class GetProviderRelationshipsRequestTests
 {
     [Test]
-    public void ToQuery_AddsSearchTerm_WhenSearchTermIsNotNullOrWhiteSpace()
+    public void ToDictionary_AddsSearchTerm_WhenSearchTermIsNotNullOrWhiteSpace()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             SearchTerm = "SeachTerm"
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.Multiple(() =>
         {
@@ -22,14 +22,14 @@ public sealed class GetProviderRelationshipsRequestTests
     }
 
     [Test]
-    public void ToQuery_AddsHasCreateCohortPermission_WhenHasCreateCohortPermissionIsTrue()
+    public void ToDictionary_AddsHasCreateCohortPermission_WhenHasCreateCohortPermissionIsTrue()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasCreateCohortPermission = true
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.Multiple(() =>
         {
@@ -39,27 +39,27 @@ public sealed class GetProviderRelationshipsRequestTests
     }
 
     [Test]
-    public void ToQuery_DoesNotAddsHasCreateCohortPermission_WhenHasCreateCohortPermissionIsFalse()
+    public void ToDictionary_DoesNotAddsHasCreateCohortPermission_WhenHasCreateCohortPermissionIsFalse()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasCreateCohortPermission = false
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasCreateCohortPermission)), Is.False);
     }
 
     [Test]
-    public void ToQuery_DoesNotAddsHasCreateCohortPermission_WhenHasCreateCohortPermissionIsNull()
+    public void ToDictionary_DoesNotAddsHasCreateCohortPermission_WhenHasCreateCohortPermissionIsNull()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasCreateCohortPermission = null
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasCreateCohortPermission)), Is.False);
     }
@@ -72,7 +72,7 @@ public sealed class GetProviderRelationshipsRequestTests
             HasRecruitmentPermission = true
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.Multiple(() =>
         {
@@ -82,27 +82,27 @@ public sealed class GetProviderRelationshipsRequestTests
     }
 
     [Test]
-    public void ToQuery_DoesNotAddHasRecruitmentPermission_WhenHasRecruitmentPermissionIsFalse()
+    public void ToDictionary_DoesNotAddHasRecruitmentPermission_WhenHasRecruitmentPermissionIsFalse()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasRecruitmentPermission = false
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasRecruitmentPermission)), Is.False);
     }
 
     [Test]
-    public void ToQuery_AddsHasRecruitmentWithReviewPermission_WhenHasRecruitmentWithReviewPermissionIsTrue()
+    public void ToDictionary_AddsHasRecruitmentWithReviewPermission_WhenHasRecruitmentWithReviewPermissionIsTrue()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasRecruitmentWithReviewPermission = true
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.Multiple(() =>
         {
@@ -112,27 +112,27 @@ public sealed class GetProviderRelationshipsRequestTests
     }
 
     [Test]
-    public void ToQuery_DoesNotAddHasRecruitmentWithReviewPermission_WhenHasRecruitmentWithReviewPermissionIsFalse()
+    public void ToDictionary_DoesNotAddHasRecruitmentWithReviewPermission_WhenHasRecruitmentWithReviewPermissionIsFalse()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasRecruitmentWithReviewPermission = false
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasRecruitmentWithReviewPermission)), Is.False);
     }
 
     [Test]
-    public void ToQuery_AddsHasNoRecruitmentPermission_WhenHasNoRecruitmentPermissionIsTrue()
+    public void ToDictionary_AddsHasNoRecruitmentPermission_WhenHasNoRecruitmentPermissionIsTrue()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasNoRecruitmentPermission = true
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.Multiple(() =>
         {
@@ -142,27 +142,27 @@ public sealed class GetProviderRelationshipsRequestTests
     }
 
     [Test]
-    public void ToQuery_DoesNotAddHasNoRecruitmentPermission_WhenHasNoRecruitmentPermissionIsFalse()
+    public void ToDictionary_DoesNotAddHasNoRecruitmentPermission_WhenHasNoRecruitmentPermissionIsFalse()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasNoRecruitmentPermission = false
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasNoRecruitmentPermission)), Is.False);
     }
 
     [Test]
-    public void ToQuery_AddsHasPendingRequest_WhenHasHasPendingRequestIsTrue()
+    public void ToDictionary_AddsHasPendingRequest_WhenHasHasPendingRequestIsTrue()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasPendingRequest = true
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.Multiple(() =>
         {
@@ -172,40 +172,40 @@ public sealed class GetProviderRelationshipsRequestTests
     }
 
     [Test]
-    public void ToQuery_DoesNotAddHasPendingRequest_WhenHasPendingRequestIsFalse()
+    public void ToDictionary_DoesNotAddHasPendingRequest_WhenHasPendingRequestIsFalse()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasPendingRequest = false
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasPendingRequest)), Is.False);
     }
 
     [Test]
-    public void ToQuery_DoesNotAddHasPendingRequest_WhenHasPendingRequestIsNull()
+    public void ToDictionary_DoesNotAddHasPendingRequest_WhenHasPendingRequestIsNull()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             HasPendingRequest = null
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasPendingRequest)), Is.False);
     }
 
     [Test]
-    public void ToQuery_AddsPageSize_WhenPageSizeIsMoreThanZero()
+    public void ToDictionary_AddsPageSize_WhenPageSizeIsMoreThanZero()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             PageSize = 10
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.Multiple(() =>
         {
@@ -215,40 +215,40 @@ public sealed class GetProviderRelationshipsRequestTests
     }
 
     [Test]
-    public void ToQuery_DoesNotAddPageSize_WhenPageSizeIsZero()
+    public void ToDictionary_DoesNotAddPageSize_WhenPageSizeIsZero()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             PageSize = 0
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageSize)), Is.False);
     }
 
     [Test]
-    public void ToQuery_DoesNotAddPageSize_WhenPageSizeIsNull()
+    public void ToDictionary_DoesNotAddPageSize_WhenPageSizeIsNull()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             PageSize = null
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageSize)), Is.False);
     }
 
     [Test]
-    public void ToQuery_AddsPageNumber_WhenPageNumberIsMoreThanZero()
+    public void ToDictionary_AddsPageNumber_WhenPageNumberIsMoreThanZero()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             PageNumber = 3
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.Multiple(() =>
         {
@@ -258,27 +258,27 @@ public sealed class GetProviderRelationshipsRequestTests
     }
 
     [Test]
-    public void ToQuery_DoesNotAddPageNumber_WhenPageNumberIsZero()
+    public void ToDictionary_DoesNotAddPageNumber_WhenPageNumberIsZero()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             PageNumber = 0
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageNumber)), Is.False);
     }
 
     [Test]
-    public void ToQuery_DoesNotAddPageNumber_WhenPageNumberIsNull()
+    public void ToDictionary_DoesNotAddPageNumber_WhenPageNumberIsNull()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {
             PageNumber = null
         };
 
-        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToDictionary();
 
         Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageNumber)), Is.False);
     }

--- a/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/InnerApi/Requests/GetProviderRelationshipsRequestTests.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/InnerApi/Requests/GetProviderRelationshipsRequestTests.cs
@@ -65,7 +65,7 @@ public sealed class GetProviderRelationshipsRequestTests
     }
 
     [Test]
-    public void ToQuery_AddsHasRecruitmentPermission_WhenHasRecruitmentPermissionIsTrue()
+    public void ToDictionary_AddsHasRecruitmentPermission_WhenHasRecruitmentPermissionIsTrue()
     {
         GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
         {

--- a/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/InnerApi/Requests/GetProviderRelationshipsRequestTests.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR.UnitTests/InnerApi/Requests/GetProviderRelationshipsRequestTests.cs
@@ -1,0 +1,285 @@
+﻿using SFA.DAS.ProviderPR.InnerApi.Requests;
+
+namespace SFA.DAS.ProviderPR.UnitTests.InnerApi.Requests;
+
+public sealed class GetProviderRelationshipsRequestTests
+{
+    [Test]
+    public void ToQuery_AddsSearchTerm_WhenSearchTermIsNotNullOrWhiteSpace()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            SearchTerm = "SeachTerm"
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.SearchTerm)), Is.True);
+            Assert.That(sut[nameof(GetProviderRelationshipsRequest.SearchTerm)], Is.EqualTo(providerRelationshipsRequest.SearchTerm));
+        });
+    }
+
+    [Test]
+    public void ToQuery_AddsHasCreateCohortPermission_WhenHasCreateCohortPermissionIsTrue()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasCreateCohortPermission = true
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasCreateCohortPermission)), Is.True);
+            Assert.That(sut[nameof(GetProviderRelationshipsRequest.HasCreateCohortPermission)], Is.EqualTo("True"));
+        });
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddsHasCreateCohortPermission_WhenHasCreateCohortPermissionIsFalse()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasCreateCohortPermission = false
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasCreateCohortPermission)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddsHasCreateCohortPermission_WhenHasCreateCohortPermissionIsNull()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasCreateCohortPermission = null
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasCreateCohortPermission)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_AddsHasRecruitmentPermission_WhenHasRecruitmentPermissionIsTrue()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasRecruitmentPermission = true
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasRecruitmentPermission)), Is.True);
+            Assert.That(sut[nameof(GetProviderRelationshipsRequest.HasRecruitmentPermission)], Is.EqualTo("True"));
+        });
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddHasRecruitmentPermission_WhenHasRecruitmentPermissionIsFalse()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasRecruitmentPermission = false
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasRecruitmentPermission)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_AddsHasRecruitmentWithReviewPermission_WhenHasRecruitmentWithReviewPermissionIsTrue()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasRecruitmentWithReviewPermission = true
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasRecruitmentWithReviewPermission)), Is.True);
+            Assert.That(sut[nameof(GetProviderRelationshipsRequest.HasRecruitmentWithReviewPermission)], Is.EqualTo("True"));
+        });
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddHasRecruitmentWithReviewPermission_WhenHasRecruitmentWithReviewPermissionIsFalse()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasRecruitmentWithReviewPermission = false
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasRecruitmentWithReviewPermission)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_AddsHasNoRecruitmentPermission_WhenHasNoRecruitmentPermissionIsTrue()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasNoRecruitmentPermission = true
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasNoRecruitmentPermission)), Is.True);
+            Assert.That(sut[nameof(GetProviderRelationshipsRequest.HasNoRecruitmentPermission)], Is.EqualTo("True"));
+        });
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddHasNoRecruitmentPermission_WhenHasNoRecruitmentPermissionIsFalse()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasNoRecruitmentPermission = false
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasNoRecruitmentPermission)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_AddsHasPendingRequest_WhenHasHasPendingRequestIsTrue()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasPendingRequest = true
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasPendingRequest)), Is.True);
+            Assert.That(sut[nameof(GetProviderRelationshipsRequest.HasPendingRequest)], Is.EqualTo("True"));
+        });
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddHasPendingRequest_WhenHasPendingRequestIsFalse()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasPendingRequest = false
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasPendingRequest)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddHasPendingRequest_WhenHasPendingRequestIsNull()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            HasPendingRequest = null
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.HasPendingRequest)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_AddsPageSize_WhenPageSizeIsMoreThanZero()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            PageSize = 10
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageSize)), Is.True);
+            Assert.That(sut[nameof(GetProviderRelationshipsRequest.PageSize)], Is.EqualTo("10"));
+        });
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddPageSize_WhenPageSizeIsZero()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            PageSize = 0
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageSize)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddPageSize_WhenPageSizeIsNull()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            PageSize = null
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageSize)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_AddsPageNumber_WhenPageNumberIsMoreThanZero()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            PageNumber = 3
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageNumber)), Is.True);
+            Assert.That(sut[nameof(GetProviderRelationshipsRequest.PageNumber)], Is.EqualTo("3"));
+        });
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddPageNumber_WhenPageNumberIsZero()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            PageNumber = 0
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageNumber)), Is.False);
+    }
+
+    [Test]
+    public void ToQuery_DoesNotAddPageNumber_WhenPageNumberIsNull()
+    {
+        GetProviderRelationshipsRequest providerRelationshipsRequest = new GetProviderRelationshipsRequest()
+        {
+            PageNumber = null
+        };
+
+        Dictionary<string, string> sut = providerRelationshipsRequest.ToQueryString();
+
+        Assert.That(sut.ContainsKey(nameof(GetProviderRelationshipsRequest.PageNumber)), Is.False);
+    }
+}

--- a/src/ProviderPR/SFA.DAS.ProviderPR/Application/Relationships/Queries/GetRelationships/GetRelationshipsQueryHandler.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR/Application/Relationships/Queries/GetRelationships/GetRelationshipsQueryHandler.cs
@@ -9,7 +9,7 @@ public class GetRelationshipsQueryHandler(IProviderRelationshipsApiRestClient _p
     public async Task<GetProviderRelationshipsResponse> Handle(GetRelationshipsQuery request, CancellationToken cancellationToken)
     {
         Response<GetProviderRelationshipsResponse> result =
-            await _providerRelationshipsApiRestClient.GetProviderRelationships(request.Ukprn, request.Request, cancellationToken);
+            await _providerRelationshipsApiRestClient.GetProviderRelationships(request.Ukprn, request.Request.ToQueryString(), cancellationToken);
 
         return result.GetContent();
     }

--- a/src/ProviderPR/SFA.DAS.ProviderPR/Application/Relationships/Queries/GetRelationships/GetRelationshipsQueryHandler.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR/Application/Relationships/Queries/GetRelationships/GetRelationshipsQueryHandler.cs
@@ -9,7 +9,7 @@ public class GetRelationshipsQueryHandler(IProviderRelationshipsApiRestClient _p
     public async Task<GetProviderRelationshipsResponse> Handle(GetRelationshipsQuery request, CancellationToken cancellationToken)
     {
         Response<GetProviderRelationshipsResponse> result =
-            await _providerRelationshipsApiRestClient.GetProviderRelationships(request.Ukprn, request.Request.ToQueryString(), cancellationToken);
+            await _providerRelationshipsApiRestClient.GetProviderRelationships(request.Ukprn, request.Request.ToDictionary(), cancellationToken);
 
         return result.GetContent();
     }

--- a/src/ProviderPR/SFA.DAS.ProviderPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR/Infrastructure/IProviderRelationshipsApiRestClient.cs
@@ -1,4 +1,5 @@
-﻿using RestEase;
+﻿using Microsoft.AspNetCore.Mvc;
+using RestEase;
 using SFA.DAS.ProviderPR.Application.Requests.Commands.AccountInvitation;
 using SFA.DAS.ProviderPR.Application.Requests.Commands.AddAccount;
 using SFA.DAS.ProviderPR.Application.Requests.Commands.CreatePermissions;
@@ -15,7 +16,7 @@ public interface IProviderRelationshipsApiRestClient
     Task<HttpResponseMessage> GetHealth(CancellationToken cancellationToken);
 
     [Get("providers/{ukprn}/relationships")]
-    Task<Response<GetProviderRelationshipsResponse>> GetProviderRelationships([Path] long ukprn, [Query] GetProviderRelationshipsRequest request, CancellationToken cancellationToken);
+    Task<Response<GetProviderRelationshipsResponse>> GetProviderRelationships([Path] long ukprn, [QueryMap] IDictionary<string, string> request, CancellationToken cancellationToken);
 
     [Post("requests/addaccount")]
     Task<AddAccountRequestCommandResult> CreateAddAccountRequest([Body] AddAccountRequestCommand command, CancellationToken cancellationToken);

--- a/src/ProviderPR/SFA.DAS.ProviderPR/InnerApi/Requests/GetProviderRelationshipsRequest.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR/InnerApi/Requests/GetProviderRelationshipsRequest.cs
@@ -11,7 +11,7 @@ public class GetProviderRelationshipsRequest
     public int? PageSize { get; set; }
     public int? PageNumber { get; set; }
 
-    public Dictionary<string, string> ToQueryString()
+    public Dictionary<string, string> ToDictionary()
     {
         Dictionary<string, string> result = new();
 

--- a/src/ProviderPR/SFA.DAS.ProviderPR/InnerApi/Requests/GetProviderRelationshipsRequest.cs
+++ b/src/ProviderPR/SFA.DAS.ProviderPR/InnerApi/Requests/GetProviderRelationshipsRequest.cs
@@ -10,4 +10,51 @@ public class GetProviderRelationshipsRequest
     public bool? HasPendingRequest { get; set; }
     public int? PageSize { get; set; }
     public int? PageNumber { get; set; }
+
+    public Dictionary<string, string> ToQueryString()
+    {
+        Dictionary<string, string> result = new();
+
+        if (!string.IsNullOrWhiteSpace(SearchTerm))
+        {
+            result.Add(nameof(SearchTerm), SearchTerm.Trim());
+        }
+
+        if (HasCreateCohortPermission.HasValue && HasCreateCohortPermission.Value)
+        {
+            result.Add(nameof(HasCreateCohortPermission), true.ToString());
+        }
+
+        if (HasRecruitmentPermission)
+        {
+            result.Add(nameof(HasRecruitmentPermission), HasRecruitmentPermission.ToString());
+        }
+
+        if (HasRecruitmentWithReviewPermission)
+        {
+            result.Add(nameof(HasRecruitmentWithReviewPermission), HasRecruitmentWithReviewPermission.ToString());
+        }
+
+        if (HasNoRecruitmentPermission)
+        {
+            result.Add(nameof(HasNoRecruitmentPermission), HasNoRecruitmentPermission.ToString());
+        }
+
+        if (HasPendingRequest.HasValue && HasPendingRequest.Value)
+        {
+            result.Add(nameof(HasPendingRequest), true.ToString());
+        }
+
+        if (PageSize.HasValue && PageSize.Value > 0)
+        {
+            result.Add(nameof(PageSize), PageSize.Value.ToString());
+        }
+
+        if (PageNumber.HasValue && PageNumber.Value > 0)
+        {
+            result.Add(nameof(PageNumber), PageNumber.Value.ToString());
+        }
+
+        return result;
+    }
 }

--- a/src/Shared/SFA.DAS.SharedOuterApi.Provider.DfeSignIn.Auth/Controllers/ProviderAccountsController.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.Provider.DfeSignIn.Auth/Controllers/ProviderAccountsController.cs
@@ -26,12 +26,12 @@ namespace SFA.DAS.SharedOuterApi.Provider.DfeSignIn.Auth.Controllers
         {
             try
             {
-                var result = await _mediator.Send(new GetRoatpV2ProviderQuery
-                {
-                    Ukprn = ukprn
-                });
+                //var result = await _mediator.Send(new GetRoatpV2ProviderQuery
+                //{
+                //    Ukprn = ukprn
+                //});
 
-                return Ok(new ProviderAccountResponse { CanAccessService = result });
+                return Ok(new ProviderAccountResponse { CanAccessService = true });
 
             }
             catch (Exception ex)

--- a/src/Shared/SFA.DAS.SharedOuterApi.Provider.DfeSignIn.Auth/Controllers/ProviderAccountsController.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.Provider.DfeSignIn.Auth/Controllers/ProviderAccountsController.cs
@@ -26,12 +26,12 @@ namespace SFA.DAS.SharedOuterApi.Provider.DfeSignIn.Auth.Controllers
         {
             try
             {
-                //var result = await _mediator.Send(new GetRoatpV2ProviderQuery
-                //{
-                //    Ukprn = ukprn
-                //});
+                var result = await _mediator.Send(new GetRoatpV2ProviderQuery
+                {
+                    Ukprn = ukprn
+                });
 
-                return Ok(new ProviderAccountResponse { CanAccessService = true });
+                return Ok(new ProviderAccountResponse { CanAccessService = result });
 
             }
             catch (Exception ex)


### PR DESCRIPTION
- Updated provider relationships endpoint to use dictionary of filter values when passing filter values to the inner API.