### PR TITLE
Hot Fix: Added GetAwaiter() for StartNServiceBus container Registration

### DIFF
--- a/src/ApimDeveloper/SFA.DAS.ApimDeveloper.Api/Startup.cs
+++ b/src/ApimDeveloper/SFA.DAS.ApimDeveloper.Api/Startup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -128,7 +129,7 @@ namespace SFA.DAS.ApimDeveloper.Api
         
         public void ConfigureContainer(UpdateableServiceProvider serviceProvider)
         {
-            serviceProvider.StartNServiceBus(_configuration, EndpointName).GetAwaiter().GetResult();
+            Task.FromResult(serviceProvider.StartNServiceBus(_configuration, EndpointName)).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Apprenticeships/SFA.DAS.Apprenticeships.Api/Startup.cs
+++ b/src/Apprenticeships/SFA.DAS.Apprenticeships.Api/Startup.cs
@@ -108,6 +108,6 @@ public class Startup
 
     public void ConfigureContainer(UpdateableServiceProvider serviceProvider)
     {
-        serviceProvider.StartNServiceBus(_configuration, EndpointName).GetAwaiter().GetResult();
+        Task.FromResult(serviceProvider.StartNServiceBus(_configuration, EndpointName)).GetAwaiter().GetResult();
     }
 }

--- a/src/EmployerDemand/SFA.DAS.EmployerDemand.Api/Startup.cs
+++ b/src/EmployerDemand/SFA.DAS.EmployerDemand.Api/Startup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -136,7 +137,7 @@ namespace SFA.DAS.EmployerDemand.Api
         
         public void ConfigureContainer(UpdateableServiceProvider serviceProvider)
         {
-            serviceProvider.StartNServiceBus(_configuration, EndpointName).GetAwaiter().GetResult();
+            Task.FromResult(serviceProvider.StartNServiceBus(_configuration, EndpointName)).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/EmployerRequestApprenticeTraining/SFA.DAS.EmployerRequestApprenticeTraining.Api/Startup.cs
+++ b/src/EmployerRequestApprenticeTraining/SFA.DAS.EmployerRequestApprenticeTraining.Api/Startup.cs
@@ -16,6 +16,7 @@ using SFA.DAS.SharedOuterApi.Employer.GovUK.Auth.Application.Queries.EmployerAcc
 using SFA.DAS.SharedOuterApi.Infrastructure.HealthCheck;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.EmployerRequestApprenticeTraining.Api
 {
@@ -161,7 +162,7 @@ namespace SFA.DAS.EmployerRequestApprenticeTraining.Api
 
         public void ConfigureContainer(UpdateableServiceProvider serviceProvider)
         {
-            serviceProvider.StartNServiceBus(_configuration, EndpointName).GetAwaiter().GetResult();
+            Task.FromResult(serviceProvider.StartNServiceBus(_configuration, EndpointName)).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Startup.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.AspNetCore.Routing;
@@ -152,7 +153,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api
         
         public void ConfigureContainer(UpdateableServiceProvider serviceProvider)
         {
-            serviceProvider.StartNServiceBus(_configuration, EndpointName).GetAwaiter().GetResult();
+            Task.FromResult(serviceProvider.StartNServiceBus(_configuration, EndpointName)).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Startup.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Startup.cs
@@ -153,7 +153,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api
         
         public void ConfigureContainer(UpdateableServiceProvider serviceProvider)
         {
-            Task.FromResult(serviceProvider.StartNServiceBus(_configuration, EndpointName)).GetAwaiter().GetResult();
+            serviceProvider.StartNServiceBus(_configuration, EndpointName);
         }
     }
 }

--- a/src/LevyTransferMatching/SFA.DAS.LevyTransferMatching.Api/Startup.cs
+++ b/src/LevyTransferMatching/SFA.DAS.LevyTransferMatching.Api/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -145,7 +146,7 @@ namespace SFA.DAS.LevyTransferMatching.Api
 
         public void ConfigureContainer(UpdateableServiceProvider serviceProvider)
         {
-            serviceProvider.StartNServiceBus(_configuration, EndpointName).GetAwaiter().GetResult();
+            Task.FromResult(serviceProvider.StartNServiceBus(_configuration, EndpointName)).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/ProviderRequestApprenticeTraining/SFA.DAS.ProviderRequestApprenticeTraining.Api/Startup.cs
+++ b/src/ProviderRequestApprenticeTraining/SFA.DAS.ProviderRequestApprenticeTraining.Api/Startup.cs
@@ -16,6 +16,7 @@ using SFA.DAS.SharedOuterApi.Infrastructure.HealthCheck;
 using SFA.DAS.SharedOuterApi.Provider.DfeSignIn.Auth.Application.Queries.ProviderAccounts;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.ProviderRequestApprenticeTraining.Api
 {
@@ -159,7 +160,7 @@ namespace SFA.DAS.ProviderRequestApprenticeTraining.Api
 
         public void ConfigureContainer(UpdateableServiceProvider serviceProvider)
         {
-            serviceProvider.StartNServiceBus(_configuration, EndpointName).GetAwaiter().GetResult();
+            Task.FromResult(serviceProvider.StartNServiceBus(_configuration, EndpointName)).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Recruit/SFA.DAS.Recruit.Api/Program.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/Program.cs
@@ -12,7 +12,7 @@ builder.Host.UseServiceProviderFactory(new NServiceBusServiceProviderFactory());
 var configuration = builder.Configuration.BuildSharedConfiguration();
 builder.Host.ConfigureContainer<UpdateableServiceProvider>(containerBuilder =>
 {
-    Task.FromResult(containerBuilder.StartNServiceBus(configuration, "SFA.DAS.APIMRecruit")).GetAwaiter().GetResult();
+    Task.FromResult(containerBuilder.StartNServiceBus(configuration, "SFA.DAS.APIMRecruit"));
 });
 Startup.ConfigureServices(builder.Services, builder.Environment, configuration);
 

--- a/src/Recruit/SFA.DAS.Recruit.Api/Program.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/Program.cs
@@ -12,7 +12,7 @@ builder.Host.UseServiceProviderFactory(new NServiceBusServiceProviderFactory());
 var configuration = builder.Configuration.BuildSharedConfiguration();
 builder.Host.ConfigureContainer<UpdateableServiceProvider>(containerBuilder =>
 {
-    Task.FromResult(containerBuilder.StartNServiceBus(configuration, "SFA.DAS.APIMRecruit"));
+    Task.FromResult(containerBuilder.StartNServiceBus(configuration, "SFA.DAS.APIMRecruit")).GetAwaiter().GetResult();
 });
 Startup.ConfigureServices(builder.Services, builder.Environment, configuration);
 


### PR DESCRIPTION
Bug:
'UpdateableServiceProvider' does not contain a definition for 'GetAwaiter' and no accessible extension method 'GetAwaiter' accepting a first argument of type 'UpdateableServiceProvider' could be found (are you missing a using directive or an assembly reference?)

Solution:
Added GetAwaiter() for StartNServiceBus container Registration