### PR TITLE
added conditional for shared app insights deployment

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -61,6 +61,18 @@
         },
         "logAnalyticsWorkspaceName": {
             "type": "string"
+        },
+        "applicationInsightsConnectionString": {
+            "type": "securestring",
+            "defaultValue": ""
+        },
+        "applicationInsightsResourceId": {
+            "type": "string",
+            "defaultValue": ""
+        },
+        "alertActionGroupResourceId": {
+            "type": "string",
+            "defaultValue": ""
         }
     },
     "variables": {
@@ -143,44 +155,44 @@
                     },
                     "appServiceAppSettings": {
                         "value": {
-                          "array": [
-                            {
-                              "name": "Environment",
-                              "value": "[parameters('environmentName')]"
-                            },
-                            {
-                              "name": "ConfigNames",
-                              "value": "[parameters('configNames')]"
-                            },
-                            {
-                              "name": "LoggingRedisConnectionString",
-                              "value": "[parameters('loggingRedisConnectionString')]"
-                            },
-                            {
-                              "name": "LoggingRedisKey",
-                              "value": "[parameters('loggingRedisKey')]"
-                            },
-                            {
-                              "name": "EnvironmentName",
-                              "value": "[parameters('environmentName')]"
-                            },
-                            {
-                                "name": "ResourceEnvironmentName",
-                                "value": "[parameters('resourceEnvironmentName')]"
-                            },
-                            {
-                              "name": "ConfigurationStorageConnectionString",
-                              "value": "[parameters('configurationStorageConnectionString')]"
-                            },
-                            {
-                              "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
-                              "value": "[reference(concat('api-application-insights-', parameters('appServiceName'))).outputs.ConnectionString.value]"
-                            },
-                            {
-                              "name": "WEBSITE_LOAD_USER_PROFILE",
-                              "value": "1"
-                            }
-                          ]
+                            "array": [
+                                {
+                                    "name": "Environment",
+                                    "value": "[parameters('environmentName')]"
+                                },
+                                {
+                                    "name": "ConfigNames",
+                                    "value": "[parameters('configNames')]"
+                                },
+                                {
+                                    "name": "LoggingRedisConnectionString",
+                                    "value": "[parameters('loggingRedisConnectionString')]"
+                                },
+                                {
+                                    "name": "LoggingRedisKey",
+                                    "value": "[parameters('loggingRedisKey')]"
+                                },
+                                {
+                                    "name": "EnvironmentName",
+                                    "value": "[parameters('environmentName')]"
+                                },
+                                {
+                                    "name": "ResourceEnvironmentName",
+                                    "value": "[parameters('resourceEnvironmentName')]"
+                                },
+                                {
+                                    "name": "ConfigurationStorageConnectionString",
+                                    "value": "[parameters('configurationStorageConnectionString')]"
+                                },
+                                {
+                                    "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                                    "value": "[if(greater(length(parameters('applicationInsightsConnectionString')), 0), parameters('applicationInsightsConnectionString'), reference(concat('api-application-insights-', parameters('appServiceName'))).outputs.ConnectionString.value)]"
+                                },
+                                {
+                                    "name": "WEBSITE_LOAD_USER_PROFILE",
+                                    "value": "1"
+                                }
+                            ]
                         }
                     },
                     "customHostName": {
@@ -242,6 +254,31 @@
                     },
                     "resourceName": {
                         "value": "[parameters('sharedServiceBusName')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2021-04-01",
+            "name": "[concat('application-insights-', parameters('appServiceName'), '-alert-')]",
+            "type": "Microsoft.Resources/deployments",
+            "condition": "[greater(length(parameters('applicationInsightsResourceId')), 0)]",
+            "resourceGroup": "[variables('resourceGroupName')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'application-insights-failed-requests-alert.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "serviceName": {
+                        "value": "[parameters('appServiceName')]"
+                    },
+                    "applicationInsightsResourceId": {
+                        "value": "[parameters('applicationInsightsResourceId')]"
+                    },
+                    "alertActionGroupResourceId": {
+                        "value": "[parameters('alertActionGroupResourceId')]"
                     }
                 }
             }

--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -18,6 +18,7 @@ parameters:
   ApplicationIdentifierUri:
   SandboxEnabled: $False
   AddXForwardedAuthorization: $False
+  useProductAppInsights:
 
 jobs:
 - deployment: DeployInfrastructure
@@ -41,17 +42,38 @@ jobs:
             EnvironmentId: $(Environment.Id)
             PipelineName: $(Build.DefinitionName)
             RunId: $(Build.BuildId)
-        - template: azure-pipelines-templates/deploy/step/arm-deploy.yml@das-platform-building-blocks
-          parameters:
-            Location: $(ResourceGroupLocation)
-            ServiceConnection: ${{ parameters.ServiceConnection }}
-            SubscriptionId: $(SubscriptionId)
-            TemplatePath: $(Pipeline.Workspace)/ApimEndpointsArtifacts/azure/template.json
-            ParametersPath: $(Pipeline.Workspace)/ApimEndpointsArtifacts/azure/template.parameters.json
-            IsMultiRepoCheckout: true
-            TemplateSecrets:
-              LoggingRedisConnectionString: $(LoggingRedisConnectionString)
-              ConfigurationStorageConnectionString: $(ConfigurationStorageConnectionString)
+        - ${{ if eq(parameters.useProductAppInsights, 'True') }}:
+          - template: azure-pipelines-templates/deploy/step/get-product-app-insights.yml@das-platform-building-blocks
+            parameters:
+              ServiceConnection: ${{ parameters.ServiceConnection }}
+              AppInsightsResourceGroup: $(SharedEnvResourceGroup)
+              AppInsightsName: $(ProductAppInsightsName)
+              IsMultiRepoCheckout: true
+        - ${{ if ne(parameters.useProductAppInsights, 'True') }}:
+          - template: azure-pipelines-templates/deploy/step/arm-deploy.yml@das-platform-building-blocks
+            parameters:
+              Location: $(ResourceGroupLocation)
+              ServiceConnection: ${{ parameters.ServiceConnection }}
+              SubscriptionId: $(SubscriptionId)
+              TemplatePath: $(Pipeline.Workspace)/ApimEndpointsArtifacts/azure/template.json
+              ParametersPath: $(Pipeline.Workspace)/ApimEndpointsArtifacts/azure/template.parameters.json
+              IsMultiRepoCheckout: true
+              TemplateSecrets:
+                LoggingRedisConnectionString: $(LoggingRedisConnectionString)
+                ConfigurationStorageConnectionString: $(ConfigurationStorageConnectionString)
+        - ${{ if eq(parameters.useProductAppInsights, 'True') }}:
+          - template: azure-pipelines-templates/deploy/step/arm-deploy.yml@das-platform-building-blocks
+            parameters:
+              Location: $(ResourceGroupLocation)
+              ServiceConnection: ${{ parameters.ServiceConnection }}
+              SubscriptionId: $(SubscriptionId)
+              TemplatePath: $(Pipeline.Workspace)/ApimEndpointsArtifacts/azure/template.json
+              ParametersPath: $(Pipeline.Workspace)/ApimEndpointsArtifacts/azure/template.parameters.json
+              IsMultiRepoCheckout: true
+              TemplateSecrets:
+                LoggingRedisConnectionString: $(LoggingRedisConnectionString)
+                ConfigurationStorageConnectionString: $(ConfigurationStorageConnectionString)
+                applicationInsightsConnectionString: $(applicationInsightsConnectionString)
         - template: azure-pipelines-templates/deploy/step/generate-config.yml@das-platform-building-blocks
           parameters:
             EnvironmentName: $(EnvironmentName)

--- a/pipeline-templates/stage/outerapi-pipeline.yml
+++ b/pipeline-templates/stage/outerapi-pipeline.yml
@@ -88,6 +88,7 @@ stages:
       ApplicationIdentifierUri: $(${{ parameters.OuterApiName }}OuterApiIdentifierUri)
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
+      useProductAppInsights: ${{ parameters.useProductAppInsights }}
 
 - stage: Deploy_TEST2
   dependsOn: Build
@@ -118,6 +119,7 @@ stages:
       ApplicationIdentifierUri: $(${{ parameters.OuterApiName }}OuterApiIdentifierUri)
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
+      useProductAppInsights: ${{ parameters.useProductAppInsights }}
 
 - stage: Deploy_PP
   dependsOn: Build
@@ -148,6 +150,8 @@ stages:
       ApplicationIdentifierUri: $(${{ parameters.OuterApiName }}OuterApiIdentifierUri)
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
+      useProductAppInsights: ${{ parameters.useProductAppInsights }}
+
 
 - stage: Deploy_PROD
   dependsOn: Build
@@ -177,6 +181,7 @@ stages:
       ApplicationIdentifierUri: $(${{ parameters.OuterApiName }}OuterApiIdentifierUri)
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
+      useProductAppInsights: ${{ parameters.useProductAppInsights }}
 
 - stage: Deploy_MO
   dependsOn: Build
@@ -206,6 +211,7 @@ stages:
       ApplicationIdentifierUri: $(${{ parameters.OuterApiName }}OuterApiIdentifierUri)
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
+      useProductAppInsights: ${{ parameters.useProductAppInsights }}
 
 - stage: Deploy_DEMO
   dependsOn: Build
@@ -236,3 +242,4 @@ stages:
       ApplicationIdentifierUri: $(${{ parameters.OuterApiName }}OuterApiIdentifierUri)
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
+      useProductAppInsights: ${{ parameters.useProductAppInsights }}

--- a/pipeline-templates/stage/outerapi-pipeline.yml
+++ b/pipeline-templates/stage/outerapi-pipeline.yml
@@ -7,6 +7,7 @@ parameters:
   AdditionalProjectPathToInclude: ''
   AdditionalTestProjectPathToInclude: ''
   ConfigurationSecrets: {}
+  useProductAppInsights: ''
 
 stages:
 - stage: Build
@@ -56,6 +57,7 @@ stages:
       ApplicationIdentifierUri: $(${{ parameters.OuterApiName }}OuterApiIdentifierUri)
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
+      useProductAppInsights: ${{ parameters.useProductAppInsights }}
 
 - stage: Deploy_TEST
   dependsOn: Build

--- a/src/AdminAan/azure-pipelines.yml
+++ b/src/AdminAan/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/AparRegister/azure-pipelines.yml
+++ b/src/AparRegister/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApimDeveloper/azure-pipelines.yml
+++ b/src/ApimDeveloper/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeAan/azure-pipelines.yml
+++ b/src/ApprenticeAan/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeApp/azure-pipelines.yml
+++ b/src/ApprenticeApp/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeCommitments/azure-pipelines.yml
+++ b/src/ApprenticeCommitments/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeFeedback/azure-pipelines.yml
+++ b/src/ApprenticeFeedback/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticePortal/azure-pipelines.yml
+++ b/src/ApprenticePortal/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Apprenticeships/azure-pipelines.yml
+++ b/src/Apprenticeships/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Approvals/azure-pipelines.yml
+++ b/src/Approvals/azure-pipelines.yml
@@ -33,12 +33,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Assessors/azure-pipelines.yml
+++ b/src/Assessors/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Campaign/azure-pipelines.yml
+++ b/src/Campaign/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EarlyConnect/azure-pipelines.yml
+++ b/src/EarlyConnect/azure-pipelines.yml
@@ -36,12 +36,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Earnings/azure-pipelines.yml
+++ b/src/Earnings/azure-pipelines.yml
@@ -69,12 +69,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerAan/azure-pipelines.yml
+++ b/src/EmployerAan/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerAccounts/azure-pipelines.yml
+++ b/src/EmployerAccounts/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerContactForms/azure-pipelines.yml
+++ b/src/EmployerContactForms/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerDemand/azure-pipelines.yml
+++ b/src/EmployerDemand/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerFeedback/azure-pipelines.yml
+++ b/src/EmployerFeedback/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerFinance/azure-pipelines.yml
+++ b/src/EmployerFinance/azure-pipelines.yml
@@ -33,12 +33,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerIncentives/azure-pipelines.yml
+++ b/src/EmployerIncentives/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerPR/azure-pipelines.yml
+++ b/src/EmployerPR/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerProfiles/azure-pipelines.yml
+++ b/src/EmployerProfiles/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmploymentCheck/azure-pipelines.yml
+++ b/src/EmploymentCheck/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EpaoRegister/azure-pipelines.yml
+++ b/src/EpaoRegister/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindAnApprenticeship/azure-pipelines.yml
+++ b/src/FindAnApprenticeship/azure-pipelines.yml
@@ -34,12 +34,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindApprenticeshipJobs/azure-pipelines.yml
+++ b/src/FindApprenticeshipJobs/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindApprenticeshipTraining/azure-pipelines.yml
+++ b/src/FindApprenticeshipTraining/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindEpao/azure-pipelines.yml
+++ b/src/FindEpao/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Forecasting/azure-pipelines.yml
+++ b/src/Forecasting/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Funding/azure-pipelines.yml
+++ b/src/Funding/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/LevyTransferMatching/azure-pipelines.yml
+++ b/src/LevyTransferMatching/azure-pipelines.yml
@@ -33,12 +33,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderFeedback/azure-pipelines.yml
+++ b/src/ProviderFeedback/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderPR/azure-pipelines.yml
+++ b/src/ProviderPR/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/PublicSectorReporting/azure-pipelines.yml
+++ b/src/PublicSectorReporting/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Recruit/azure-pipelines.yml
+++ b/src/Recruit/azure-pipelines.yml
@@ -34,12 +34,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ReferenceDataJobs/azure-pipelines.yml
+++ b/src/ReferenceDataJobs/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Reservations/azure-pipelines.yml
+++ b/src/Reservations/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Roatp/azure-pipelines.yml
+++ b/src/Roatp/azure-pipelines.yml
@@ -34,12 +34,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpCourseManagement/azure-pipelines.yml
+++ b/src/RoatpCourseManagement/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpOversight/azure-pipelines.yml
+++ b/src/RoatpOversight/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpProviderModeration/azure-pipelines.yml
+++ b/src/RoatpProviderModeration/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Shared/azure-pipelines.yml
+++ b/src/Shared/azure-pipelines.yml
@@ -27,7 +27,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
 steps:
   - template: azure-pipelines-templates/build/step/app-build.yml@das-platform-building-blocks

--- a/src/TrackProgress/azure-pipelines.yml
+++ b/src/TrackProgress/azure-pipelines.yml
@@ -34,12 +34,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/TrackProgressInternal/azure-pipelines.yml
+++ b/src/TrackProgressInternal/azure-pipelines.yml
@@ -34,12 +34,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Vacancies/azure-pipelines.yml
+++ b/src/Vacancies/azure-pipelines.yml
@@ -35,12 +35,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/VacanciesManage/azure-pipelines.yml
+++ b/src/VacanciesManage/azure-pipelines.yml
@@ -34,12 +34,12 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.2.0
+    ref: refs/tags/2.2.13
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.14
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config


### PR DESCRIPTION
By default these changes should not affect existing pipelines. These changes optionally allow outer API's to point there telemetry to a shared application insights.

- Added conditional ARM template deployment for if outer API should use the shared application insights. In order to run the get product application insights task and put it into the pipeline you need to add:
  1. set useProductAppInsights = 'True' on service pipeline
  2. add ProductShortName variable on service pipeline.
  
**Once all services are using there product's shared application insights, we need to remove this conditional.**

- Bumped version of platform building blocks and platform automation. This is needed as even though it's not used by default, the YAML still needs a valid template path to parse the pipeline.



