### PR TITLE
FAI-2238 Withdraw Application Email failing to send if the Vacancy is Closed

### DIFF
--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Commands/Apply/WhenHandlingSubmitApplicationCommand.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Commands/Apply/WhenHandlingSubmitApplicationCommand.cs
@@ -1,7 +1,3 @@
-using AutoFixture.NUnit3;
-using FluentAssertions;
-using Moq;
-using NUnit.Framework;
 using SFA.DAS.FindAnApprenticeship.Application.Commands.Apply.SubmitApplication;
 using SFA.DAS.FindAnApprenticeship.Domain.Models;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
@@ -14,7 +10,6 @@ using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Infrastructure;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
-using SFA.DAS.Testing.AutoFixture;
 using System.Net;
 
 namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Commands.Apply;
@@ -26,6 +21,8 @@ public class WhenHandlingSubmitApplicationCommand
         string vacancyReference,
         SubmitApplicationCommand request,
         GetApplicationApiResponse applicationApiResponse,
+        GetApprenticeshipVacancyItemResponse vacancyResponse,
+        [Frozen] Mock<IVacancyService> vacancyService,
         [Frozen] Mock<IMetrics> metricsService,
         [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
         [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
@@ -52,6 +49,8 @@ public class WhenHandlingSubmitApplicationCommand
                     c.PostUrl.Contains(request.CandidateId.ToString())
                     && ((PostSubmitApplicationRequestData)c.Data).VacancyReference == vacancyReference
                 ), false)).ReturnsAsync(new ApiResponse<NullResponse>(new NullResponse(), HttpStatusCode.NoContent, ""));
+
+        vacancyService.Setup(x => x.GetVacancy(applicationApiResponse.VacancyReference)).ReturnsAsync(vacancyResponse);
 
         candidateApiClient.Setup(x => x.PatchWithResponseCode(It.Is<PatchApplicationApiRequest>(c =>
             c.PatchUrl.Contains(request.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
@@ -218,6 +217,47 @@ public class WhenHandlingSubmitApplicationCommand
         
         var actual = await handler.Handle(request, CancellationToken.None);
         
+        recruitApiClient
+            .Verify(x => x.PostWithResponseCode<NullResponse>(
+                It.IsAny<PostSubmitApplicationRequest>(), true), Times.Never);
+        candidateApiClient.Verify(x => x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>()), Times.Never);
+        actual.Should().BeFalse();
+        notificationService.Verify(x => x.Send(
+            It.IsAny<SendEmailCommand>()), Times.Never());
+        metricsService.Verify(x => x.IncreaseVacancySubmitted(It.IsAny<string>(), 1), Times.Never);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Vacancy_Is_Not_Found_Application_Is_Not_Submitted_Email_Not_Sent(
+        GetApplicationApiResponse applicationApiResponse,
+        SubmitApplicationCommand request,
+        [Frozen] Mock<IVacancyService> vacancyService,
+        [Frozen] Mock<IMetrics> metricsService,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+        [Frozen] Mock<INotificationService> notificationService,
+        SubmitApplicationCommandHandler handler)
+    {
+        candidateApiClient
+            .Setup(x => x.Get<GetApplicationApiResponse>(
+                It.Is<GetApplicationApiRequest>(c =>
+                    c.GetUrl.Contains(request.CandidateId.ToString()) && c.GetUrl.Contains(request.ApplicationId.ToString()))))
+            .ReturnsAsync(applicationApiResponse);
+        candidateApiClient.Setup(x => x.PatchWithResponseCode(It.Is<PatchApplicationApiRequest>(c =>
+            c.PatchUrl.Contains(request.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+            c.PatchUrl.Contains(request.CandidateId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+            c.Data.Operations[0].path == "/Status" &&
+            (ApplicationStatus)c.Data.Operations[0].value == ApplicationStatus.Submitted
+        ))).ReturnsAsync(new ApiResponse<string>("", HttpStatusCode.Accepted, ""));
+        recruitApiClient
+            .Setup(x => x.PostWithResponseCode<NullResponse>(
+                It.Is<PostSubmitApplicationRequest>(c =>
+                    c.PostUrl.Contains(request.CandidateId.ToString())
+                ), false)).ReturnsAsync(new ApiResponse<NullResponse>(new NullResponse(), HttpStatusCode.NoContent, ""));
+
+        vacancyService.Setup(x => x.GetVacancy(applicationApiResponse.VacancyReference)).ReturnsAsync((GetApprenticeshipVacancyItemResponse)null!);
+        var actual = await handler.Handle(request, CancellationToken.None);
+
         recruitApiClient
             .Verify(x => x.PostWithResponseCode<NullResponse>(
                 It.IsAny<PostSubmitApplicationRequest>(), true), Times.Never);

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Commands/Apply/WhenHandlingWithdrawApplicationCommand.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Commands/Apply/WhenHandlingWithdrawApplicationCommand.cs
@@ -8,6 +8,7 @@ using SFA.DAS.FindAnApprenticeship.Domain.Models;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
 using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Requests;
+using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Responses;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.Notifications.Messages.Commands;
@@ -182,5 +183,76 @@ public class WhenHandlingWithdrawApplicationCommand
         candidateApiClient.Verify(x => x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>()), Times.Never());
         notificationService.Verify(x => x.Send(
             It.IsAny<SendEmailCommand>()), Times.Never());
+    }
+
+    [Test]
+    [MoqInlineAutoData("address1", "address2", "address3", "address4", "address4")]
+    [MoqInlineAutoData("address1", "address2", "address3", null, "address3")]
+    [MoqInlineAutoData("address1", "address2", null, null, "address2")]
+    [MoqInlineAutoData("address1", null, null, null, "address1")]
+    public async Task Then_The_Vacancy_Is_Closed_Application_Status_Updated_And_Email_Sent(
+        string address1,
+        string address2,
+        string address3,
+        string address4,
+        string expectedAddress,
+        long vacancyRef,
+        WithdrawApplicationCommand request,
+        GetApplicationApiResponse applicationApiResponse,
+        EmailEnvironmentHelper emailEnvironmentHelper,
+        GetClosedVacancyResponse closedVacancyResponse,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+        [Frozen] Mock<INotificationService> notificationService,
+        [Frozen] Mock<IVacancyService> vacancyService,
+        WithdrawApplicationCommandHandler handler)
+    {
+        closedVacancyResponse.EmployerLocation.AddressLine1 = address1;
+        closedVacancyResponse.EmployerLocation.AddressLine2 = address2;
+        closedVacancyResponse.EmployerLocation.AddressLine3 = address3;
+        closedVacancyResponse.EmployerLocation.AddressLine4 = address4;
+        applicationApiResponse.VacancyReference = $"VAC{vacancyRef}";
+        applicationApiResponse.Status = ApplicationStatus.Submitted;
+        var expectedGetApplicationRequest =
+            new GetApplicationApiRequest(request.CandidateId, request.ApplicationId, true);
+        candidateApiClient
+            .Setup(x => x.Get<GetApplicationApiResponse>(
+                It.Is<GetApplicationApiRequest>(c =>
+                    c.GetUrl == expectedGetApplicationRequest.GetUrl
+                )))
+            .ReturnsAsync(applicationApiResponse);
+        candidateApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>())).ReturnsAsync(new ApiResponse<string>("", HttpStatusCode.Accepted, ""));
+        recruitApiClient
+            .Setup(x => x.PostWithResponseCode<NullResponse>(
+                It.IsAny<PostWithdrawApplicationRequest>(), false)).ReturnsAsync(new ApiResponse<NullResponse>(new NullResponse(), HttpStatusCode.NoContent, ""));
+        
+        vacancyService.Setup(x => x.GetVacancy(applicationApiResponse.VacancyReference)).ReturnsAsync((GetApprenticeshipVacancyItemResponse)null!);
+        vacancyService.Setup(x => x.GetClosedVacancy(applicationApiResponse.VacancyReference)).ReturnsAsync(closedVacancyResponse);
+
+        var actual = await handler.Handle(request, CancellationToken.None);
+
+        actual.Should().BeTrue();
+        candidateApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchApplicationApiRequest>(c =>
+            c.PatchUrl.Contains(request.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+            c.PatchUrl.Contains(request.CandidateId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+            c.Data.Operations[0].path == "/Status" &&
+            (ApplicationStatus)c.Data.Operations[0].value == ApplicationStatus.Withdrawn
+        )), Times.Once);
+        recruitApiClient
+            .Verify(x => x.PostWithResponseCode<NullResponse>(
+                It.Is<PostWithdrawApplicationRequest>(c =>
+                    c.PostUrl.Contains(request.CandidateId.ToString())
+                    && c.PostUrl.Contains(vacancyRef.ToString())
+                ), false), Times.Once);
+        notificationService.Verify(x => x.Send(
+            It.Is<SendEmailCommand>(c =>
+                c.RecipientsAddress == applicationApiResponse.Candidate.Email
+                && c.TemplateId == emailEnvironmentHelper.WithdrawApplicationEmailTemplateId
+                && c.Tokens["firstName"] == applicationApiResponse.Candidate.FirstName
+                && c.Tokens["vacancy"] == closedVacancyResponse.Title
+                && c.Tokens["employer"] == closedVacancyResponse.EmployerName
+                && c.Tokens["location"] == $"{expectedAddress}, {closedVacancyResponse.EmployerLocation.Postcode}"
+            )
+        ), Times.Once);
     }
 }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Commands/WhenHandlingDeleteCandidateCommand.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Commands/WhenHandlingDeleteCandidateCommand.cs
@@ -13,6 +13,7 @@ using SFA.DAS.SharedOuterApi.Infrastructure;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
 using System.Net;
+using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Responses;
 
 namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Commands
 {
@@ -230,6 +231,109 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Commands
             candidateApiClient.Verify(x => x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>()), Times.Never());
             notificationService.Verify(x => x.Send(
                 It.IsAny<SendEmailCommand>()), Times.Never());
+        }
+
+        [Test]
+        [MoqInlineAutoData("address1", "address2", "address3", "address4", "address4")]
+        [MoqInlineAutoData("address1", "address2", "address3", null, "address3")]
+        [MoqInlineAutoData("address1", "address2", null, null, "address2")]
+        [MoqInlineAutoData("address1", null, null, null, "address1")]
+        public async Task Then_ClosedVacancy_The_Application_Is_Withdrawn_From_Recruit_Status_Updated_And_Email_Sent_AccountDeleted(
+               string address1,
+               string address2,
+               string address3,
+               string address4,
+               string expectedAddress,
+               long vacancyRef,
+               DeleteCandidateCommand command,
+               GetApplicationsApiResponse applicationsApiResponse,
+               GetCandidateApiResponse candidateApiResponse,
+               EmailEnvironmentHelper emailEnvironmentHelper,
+               GetClosedVacancyResponse closedVacancyResponse,
+               [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+               [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+               [Frozen] Mock<INotificationService> notificationService,
+               [Frozen] Mock<IVacancyService> vacancyService,
+               [Frozen] Mock<IFindApprenticeshipApiClient<FindApprenticeshipApiConfiguration>> findApprenticeshipApiClient,
+               DeleteCandidateCommandHandler handler)
+        {
+            foreach (var application in applicationsApiResponse.Applications)
+            {
+                application.VacancyReference = $"VAC{vacancyRef}";
+                application.Status = ApplicationStatus.Submitted.ToString();
+                application.CandidateId = command.CandidateId;
+            }
+            closedVacancyResponse.EmployerLocation.AddressLine1 = address1;
+            closedVacancyResponse.EmployerLocation.AddressLine2 = address2;
+            closedVacancyResponse.EmployerLocation.AddressLine3 = address3;
+            closedVacancyResponse.EmployerLocation.AddressLine4 = address4;
+
+            var expectedGetApplicationsRequest =
+                new GetApplicationsApiRequest(command.CandidateId);
+            candidateApiClient
+                .Setup(x => x.Get<GetApplicationsApiResponse>(
+                    It.Is<GetApplicationsApiRequest>(c =>
+                        c.GetUrl == expectedGetApplicationsRequest.GetUrl
+                    )))
+                .ReturnsAsync(applicationsApiResponse);
+
+
+            var expectedGetCandidateRequest =
+                new GetCandidateApiRequest(command.CandidateId.ToString());
+            candidateApiClient
+                .Setup(x => x.Get<GetCandidateApiResponse>(
+                    It.Is<GetCandidateApiRequest>(c =>
+                        c.GetUrl == expectedGetCandidateRequest.GetUrl
+                    )))
+                .ReturnsAsync(candidateApiResponse);
+
+            candidateApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>())).ReturnsAsync(new ApiResponse<string>("", HttpStatusCode.Accepted, ""));
+            recruitApiClient
+                .Setup(x => x.PostWithResponseCode<NullResponse>(
+                    It.IsAny<PostWithdrawApplicationRequest>(), false)).ReturnsAsync(new ApiResponse<NullResponse>(new NullResponse(), HttpStatusCode.NoContent, ""));
+            
+            vacancyService.Setup(x => x.GetVacancy($"VAC{vacancyRef}")).ReturnsAsync((GetApprenticeshipVacancyItemResponse)null!);
+            vacancyService.Setup(x => x.GetClosedVacancy($"VAC{vacancyRef}")).ReturnsAsync(closedVacancyResponse);
+
+            var actual = await handler.Handle(command, CancellationToken.None);
+
+            actual.Should().Be(Unit.Value);
+
+            foreach (var application in applicationsApiResponse.Applications)
+            {
+                candidateApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchApplicationApiRequest>(c =>
+                    c.PatchUrl.Contains(application.Id.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+                    c.PatchUrl.Contains(command.CandidateId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+                    c.Data.Operations[0].path == "/Status" &&
+                    (ApplicationStatus)c.Data.Operations[0].value == ApplicationStatus.Withdrawn
+                )), Times.AtLeastOnce);
+
+                recruitApiClient
+                    .Verify(x => x.PostWithResponseCode<NullResponse>(
+                        It.Is<PostWithdrawApplicationRequest>(c =>
+                            c.PostUrl.Contains(command.CandidateId.ToString())
+                            && c.PostUrl.Contains(vacancyRef.ToString())
+                        ), false), Times.Exactly(applicationsApiResponse.Applications.Count));
+
+                notificationService.Verify(x => x.Send(
+                    It.Is<SendEmailCommand>(c =>
+                        c.RecipientsAddress == candidateApiResponse.Email
+                        && c.TemplateId == emailEnvironmentHelper.WithdrawApplicationEmailTemplateId
+                        && c.Tokens["firstName"] == candidateApiResponse.FirstName
+                        && c.Tokens["vacancy"] == closedVacancyResponse.Title
+                        && c.Tokens["employer"] == closedVacancyResponse.EmployerName
+                        && c.Tokens["location"] == $"{expectedAddress}, {closedVacancyResponse.EmployerLocation.Postcode}"
+                    )
+                ), Times.Exactly(applicationsApiResponse.Applications.Count));
+            }
+
+            var expectedDeleteSavedSearchesApiRequest = new DeleteSavedSearchesApiRequest(command.CandidateId);
+            findApprenticeshipApiClient.Verify(client => client.Delete(It.Is<DeleteSavedSearchesApiRequest>(r => r.DeleteUrl == expectedDeleteSavedSearchesApiRequest.DeleteUrl)), Times.Once);
+
+            var expectedDeleteAccountApiRequest =
+                new DeleteAccountApiRequest(command.CandidateId);
+            candidateApiClient
+                .Verify(client => client.Delete(It.Is<DeleteAccountApiRequest>(r => r.DeleteUrl == expectedDeleteAccountApiRequest.DeleteUrl)), Times.Once);
         }
     }
 }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/WhenHandlingWithdrawApplicationQuery.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/WhenHandlingWithdrawApplicationQuery.cs
@@ -1,16 +1,12 @@
-using AutoFixture.NUnit3;
-using FluentAssertions;
-using Moq;
-using NUnit.Framework;
 using SFA.DAS.FindAnApprenticeship.Application.Queries.WithdrawApplication;
 using SFA.DAS.FindAnApprenticeship.Domain.Models;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
+using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Responses;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Interfaces;
-using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries;
 
@@ -78,5 +74,34 @@ public class WhenHandlingWithdrawApplicationQuery
         var actual = await handler.Handle(query, CancellationToken.None);
 
         actual.Should().BeEquivalentTo(new WithdrawApplicationQueryResult());
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_Vacancy_Is_Closed_The_Query_Is_Handled_And_Withdraw_Application_Details_Returned(
+        WithdrawApplicationQuery query,
+        GetApplicationApiResponse getApplicationApiResponse,
+        GetClosedVacancyResponse vacancyResponse,
+        [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+        [Frozen] Mock<IVacancyService> vacancyService,
+        WithdrawApplicationQueryHandler handler)
+    {
+        getApplicationApiResponse.Status = ApplicationStatus.Submitted;
+        candidateApiClient.Setup(x => x.Get<GetApplicationApiResponse>(
+                It.Is<GetApplicationApiRequest>(x =>
+                    x.GetUrl.Contains(query.ApplicationId.ToString())
+                    && x.GetUrl.Contains(query.CandidateId.ToString()))))
+            .ReturnsAsync(getApplicationApiResponse);
+
+        vacancyService.Setup(x => x.GetVacancy(getApplicationApiResponse.VacancyReference)).ReturnsAsync((GetApprenticeshipVacancyItemResponse)null!);
+        vacancyService.Setup(x => x.GetClosedVacancy(getApplicationApiResponse.VacancyReference)).ReturnsAsync(vacancyResponse);
+
+        var actual = await handler.Handle(query, CancellationToken.None);
+
+        actual.ApplicationId.Should().Be(getApplicationApiResponse.Id);
+        actual.ClosingDate.Should().Be(vacancyResponse.ClosingDate);
+        actual.ClosedDate.Should().Be(vacancyResponse.ClosedDate);
+        actual.EmployerName.Should().Be(vacancyResponse.EmployerName);
+        actual.SubmittedDate.Should().Be(getApplicationApiResponse.SubmittedDate);
+        actual.AdvertTitle.Should().Be(vacancyResponse.Title);
     }
 }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Services/VacancyService/WhenGettingAClosedVacancy.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Services/VacancyService/WhenGettingAClosedVacancy.cs
@@ -1,0 +1,34 @@
+﻿using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Requests;
+using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Responses;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.FindAnApprenticeship.UnitTests.Services.VacancyService
+{
+    [TestFixture]
+    public class WhenGettingAClosedVacancy
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_ClosedVacancy_Is_Returned_From_Recruit(
+            long vacancyReference,
+            GetClosedVacancyResponse closedVacancyResponse,
+            [Frozen] Mock<IFindApprenticeshipApiClient<FindApprenticeshipApiConfiguration>> apiClient,
+            [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+            FindAnApprenticeship.Services.VacancyService service)
+        {
+            // Arrange
+            var expectedRecruitApiRequest = new GetClosedVacancyRequest(vacancyReference.ToString());
+            recruitApiClient.Setup(x =>
+                    x.Get<GetClosedVacancyResponse>(
+                        It.Is<GetClosedVacancyRequest>(closedVacancyRequest => closedVacancyRequest.GetUrl == expectedRecruitApiRequest.GetUrl)))
+                .ReturnsAsync(closedVacancyResponse);
+
+            // Act
+            var result = await service.GetClosedVacancy($"VAC{vacancyReference}");
+
+            // Assert
+            result.Should().BeOfType<GetClosedVacancyResponse>();
+            result.Should().BeEquivalentTo(closedVacancyResponse);
+        }
+    }
+}

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Services/VacancyService/WhenGettingAVacancy.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Services/VacancyService/WhenGettingAVacancy.cs
@@ -1,14 +1,9 @@
-﻿using AutoFixture.NUnit3;
-using FluentAssertions;
-using Moq;
-using NUnit.Framework;
-using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Requests;
+﻿using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Responses;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Interfaces;
-using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.FindAnApprenticeship.UnitTests.Services.VacancyService
 {
@@ -37,37 +32,6 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Services.VacancyService
             // Assert
             result.Should().BeOfType<GetApprenticeshipVacancyItemResponse>();
             result.Should().BeEquivalentTo(apiResponse);
-        }
-
-        [Test, MoqAutoData]
-        public async Task Then_The_Vacancy_Is_Returned_From_Recruit_If_Not_Found_In_FindApprenticeshipApi(
-            long vacancyReference,
-            GetClosedVacancyResponse closedVacancyResponse,
-            [Frozen] Mock<IFindApprenticeshipApiClient<FindApprenticeshipApiConfiguration>> apiClient,
-            [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
-            FindAnApprenticeship.Services.VacancyService service)
-        {
-            // Arrange
-            var expectedRequest = new GetVacancyRequest(vacancyReference.ToString());
-
-            apiClient
-                .Setup(client =>
-                    client.Get<GetApprenticeshipVacancyItemResponse>(
-                        It.IsAny<GetVacancyRequest>()))
-                .ReturnsAsync((GetApprenticeshipVacancyItemResponse)null);
-
-            var expectedRecruitApiRequest = new GetClosedVacancyRequest(vacancyReference.ToString());
-            recruitApiClient.Setup(x =>
-                    x.Get<GetClosedVacancyResponse>(
-                        It.Is<GetClosedVacancyRequest>(x => x.GetUrl == expectedRecruitApiRequest.GetUrl)))
-                .ReturnsAsync(closedVacancyResponse);
-
-            // Act
-            var result = await service.GetVacancy($"VAC{vacancyReference}");
-
-            // Assert
-            result.Should().BeOfType<GetClosedVacancyResponse>();
-            result.Should().BeEquivalentTo(closedVacancyResponse);
         }
     }
 }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Apply/SubmitApplication/SubmitApplicationCommandHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Apply/SubmitApplication/SubmitApplicationCommandHandler.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.JsonPatch;
 using SFA.DAS.FindAnApprenticeship.Domain.EmailTemplates;
@@ -15,6 +11,9 @@ using SFA.DAS.Notifications.Messages.Commands;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Infrastructure;
 using SFA.DAS.SharedOuterApi.Interfaces;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Commands.Apply.SubmitApplication;
 
@@ -46,7 +45,11 @@ public class SubmitApplicationCommandHandler(
             return false;
         }
 
-        var vacancy = await vacancyService.GetVacancy(application.VacancyReference) as GetApprenticeshipVacancyItemResponse;
+        if (await vacancyService.GetVacancy(application.VacancyReference) is not GetApprenticeshipVacancyItemResponse vacancy)
+        {
+            return false;
+        }
+
         var email = new SubmitApplicationEmail(
             helper.SubmitApplicationEmailTemplateId,
             application.Candidate.Email,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Apply/WithdrawApplication/WithdrawApplicationCommandHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Apply/WithdrawApplication/WithdrawApplicationCommandHandler.cs
@@ -9,6 +9,7 @@ using SFA.DAS.FindAnApprenticeship.Domain.Models;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
 using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Requests;
+using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Responses;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.Notifications.Messages.Commands;
@@ -27,42 +28,61 @@ public class WithdrawApplicationCommandHandler(
 {
     public async Task<bool> Handle(WithdrawApplicationCommand request, CancellationToken cancellationToken)
     {
-        var application =
-            await candidateApiClient.Get<GetApplicationApiResponse>(
-                new GetApplicationApiRequest(request.CandidateId, request.ApplicationId, true));
+        var application = await candidateApiClient.Get<GetApplicationApiResponse>(
+            new GetApplicationApiRequest(request.CandidateId, request.ApplicationId, true));
 
         if (application is not { Status: ApplicationStatus.Submitted })
         {
             return false;
         }
+
         var response = await recruitApiClient.PostWithResponseCode<NullResponse>(
-            new PostWithdrawApplicationRequest(request.CandidateId, Convert.ToInt64(application.VacancyReference.Replace("VAC",""))), false);
+            new PostWithdrawApplicationRequest(request.CandidateId, Convert.ToInt64(application.VacancyReference.Replace("VAC", ""))), false);
 
         if (response.StatusCode != HttpStatusCode.NoContent)
         {
             return false;
         }
-        
+
         var jsonPatchDocument = new JsonPatchDocument<Domain.Models.Application>();
-        
         jsonPatchDocument.Replace(x => x.Status, ApplicationStatus.Withdrawn);
 
-        var vacancy = await vacancyService.GetVacancy(application.VacancyReference) as GetApprenticeshipVacancyItemResponse;
-        
         var patchRequest = new PatchApplicationApiRequest(request.ApplicationId, request.CandidateId, jsonPatchDocument);
-        var email = new WithdrawApplicationEmail(
+
+        var vacancy = await vacancyService.GetVacancy(application.VacancyReference);
+        var withDrawnApplicationEmail = vacancy is GetApprenticeshipVacancyItemResponse apprenticeshipVacancy
+            ? GetWithdrawApplicationEmail(application, apprenticeshipVacancy)
+            : GetWithdrawApplicationEmail(application, await vacancyService.GetClosedVacancy(application.VacancyReference) as GetClosedVacancyResponse);
+
+        await Task.WhenAll(
+            candidateApiClient.PatchWithResponseCode(patchRequest),
+            notificationService.Send(new SendEmailCommand(withDrawnApplicationEmail.TemplateId, withDrawnApplicationEmail.RecipientAddress, withDrawnApplicationEmail.Tokens))
+        );
+
+        return true;
+    }
+
+    private WithdrawApplicationEmail GetWithdrawApplicationEmail(GetApplicationApiResponse application, GetClosedVacancyResponse vacancyResponse)
+    {
+        return new WithdrawApplicationEmail(
             emailEnvironmentHelper.WithdrawApplicationEmailTemplateId,
             application.Candidate.Email,
             application.Candidate.FirstName,
-            vacancy?.Title, vacancy?.EmployerName,
-            vacancy?.Address.AddressLine4 ?? vacancy?.Address.AddressLine3 ?? vacancy?.Address.AddressLine2 ?? vacancy?.Address.AddressLine1 ?? "Unknown",
-            vacancy?.Address.Postcode);
-        
-        await Task.WhenAll(
-            candidateApiClient.PatchWithResponseCode(patchRequest)
-            , notificationService.Send(new SendEmailCommand(email.TemplateId, email.RecipientAddress, email.Tokens))
-            );
-        
-        return true;
+            vacancyResponse.Title,
+            vacancyResponse.EmployerName,
+            vacancyResponse.EmployerLocation.AddressLine4 ?? vacancyResponse.EmployerLocation.AddressLine3 ?? vacancyResponse.EmployerLocation.AddressLine2 ?? vacancyResponse.EmployerLocation.AddressLine1 ?? "Unknown",
+            vacancyResponse.EmployerLocation.Postcode);
+    }
+
+    private WithdrawApplicationEmail GetWithdrawApplicationEmail(GetApplicationApiResponse application, GetApprenticeshipVacancyItemResponse vacancyResponse)
+    {
+        return new WithdrawApplicationEmail(
+            emailEnvironmentHelper.WithdrawApplicationEmailTemplateId,
+            application.Candidate.Email,
+            application.Candidate.FirstName,
+            vacancyResponse.Title,
+            vacancyResponse.EmployerName,
+            vacancyResponse.Address.AddressLine4 ?? vacancyResponse.Address.AddressLine3 ?? vacancyResponse.Address.AddressLine2 ?? vacancyResponse.Address.AddressLine1 ?? "Unknown",
+            vacancyResponse.Address.Postcode);
     }
 }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/WithdrawApplication/WithdrawApplicationQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/WithdrawApplication/WithdrawApplicationQueryHandler.cs
@@ -1,15 +1,13 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using MediatR;
 using SFA.DAS.FindAnApprenticeship.Domain.Models;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
-using SFA.DAS.FindAnApprenticeship.InnerApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Responses;
+using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Interfaces;
-using SFA.DAS.FindAnApprenticeship.Services;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Queries.WithdrawApplication;
 
@@ -25,7 +23,8 @@ public class WithdrawApplicationQueryHandler(
             return new WithdrawApplicationQueryResult();
         }
 
-        var vacancy = await vacancyService.GetVacancy(application.VacancyReference);
+        var vacancy = await vacancyService.GetVacancy(application.VacancyReference) as GetApprenticeshipVacancyItemResponse ??
+                      await vacancyService.GetClosedVacancy(application.VacancyReference);
 
         return new WithdrawApplicationQueryResult
         {

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Services/IVacancyService.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Services/IVacancyService.cs
@@ -6,5 +6,6 @@ namespace SFA.DAS.FindAnApprenticeship.Services;
 public interface IVacancyService
 {
     public Task<IVacancy> GetVacancy(string vacancyReference);
+    public Task<IVacancy> GetClosedVacancy(string vacancyReference);
     public Task<List<IVacancy>> GetVacancies(List<string> vacancyReferences);
 }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Services/VacancyService.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Services/VacancyService.cs
@@ -16,13 +16,12 @@ namespace SFA.DAS.FindAnApprenticeship.Services
     {
         public async Task<IVacancy> GetVacancy(string vacancyReference)
         {
-            var result = await findApprenticeshipApiClient.Get<GetApprenticeshipVacancyItemResponse>(new GetVacancyRequest(vacancyReference));
+            return await findApprenticeshipApiClient.Get<GetApprenticeshipVacancyItemResponse>(new GetVacancyRequest(vacancyReference));
+        }
 
-            if (result != null) return result;
-
-            var closedVacancy = await recruitApiClient.Get<GetClosedVacancyResponse>(new GetClosedVacancyRequest(vacancyReference.Replace("VAC","")));
-
-            return closedVacancy;
+        public async Task<IVacancy> GetClosedVacancy(string vacancyReference)
+        {
+            return await recruitApiClient.Get<GetClosedVacancyResponse>(new GetClosedVacancyRequest(vacancyReference.Replace("VAC", "")));
         }
 
         public async Task<List<IVacancy>> GetVacancies(List<string> vacancyReferences)
@@ -34,7 +33,7 @@ namespace SFA.DAS.FindAnApprenticeship.Services
 
             var vacancies = await findApprenticeshipApiClient.PostWithResponseCode<PostGetVacanciesByReferenceApiResponse>(vacanciesRequest);
 
-            var result = vacancies.Body.ApprenticeshipVacancies.Select(x => (IVacancy)x).ToList();
+            var result = vacancies.Body.ApprenticeshipVacancies.Select(IVacancy (x) => x).ToList();
 
             var notFoundVacancies = vacancyReferences.Where(x => result.All(y => y.VacancyReference != $"VAC{x}")).ToList();
 


### PR DESCRIPTION
Bug: https://skillsfundingagency.atlassian.net/browse/FAI-2238

1. In case of closed vacancy, the response object could not be cast into GetApprenticeshipVacancyItemResponse
This results in a vacancy item response as NULL. If the email tokens are empty, then the email will not be sent.
 
2.  Vacancy service => Separation of Concerns rule violation split this implementation as separate methods GetVacancy from FAA Api & Closed Vacancy from RAA Api