### PR TITLE
Added functionality to allow Outer API's to be deployed to ASP of choice

### DIFF
--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -29,6 +29,7 @@ jobs:
     clean: all
   variables:
     AppServiceName: ${{ parameters.AppServiceName }}
+    AppServicePlanName: ${{ parameters.AppServicePlanName }}
     CustomHostName: ${{ parameters.CustomHostName }}
     AppServiceKeyVaultCertificateName: ${{ parameters.AppServiceKeyVaultCertificateName }}
     ConfigNames: ${{ parameters.ConfigNames }}

--- a/pipeline-templates/stage/outerapi-pipeline.yml
+++ b/pipeline-templates/stage/outerapi-pipeline.yml
@@ -48,6 +48,7 @@ stages:
       DeploymentName: Deploy_${{ parameters.OuterApiName }}
       AADGroupObjectIdArray: $(AdminAADGroupObjectId),$(DevAADGroupObjectId)
       AppServiceName: $(${{ parameters.OuterApiName }}OuterApiAppServiceName)
+      AppServicePlanName: $(${{ parameters.OuterApiName }}OuterApiAppServicePlanName)
       CustomHostName: $(${{ parameters.OuterApiName }}OuterApiCustomHostname)
       AppServiceKeyVaultCertificateName: $(${{ parameters.OuterApiName }}OuterApiKeyVaultCertificateName)
       ConfigNames: $(${{ parameters.OuterApiName }}OuterApiConfigNames)


### PR DESCRIPTION
This change introduces the AppServicePlanName variable to better distribute the Outer APIs across their respective App Service Plans. The change ensures that each API is deployed within its designated plan, improving resource allocation, scalability, and maintainability