### PR TITLE
FAI-2264 Added logic to check the Application count before calling Inner Api

### DIFF
--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplications/GetApplicationsQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplications/GetApplicationsQueryHandler.cs
@@ -30,7 +30,7 @@ public class GetApplicationsQueryHandler(
             || (request.Status == ApplicationStatus.Draft && x.Status == ApplicationStatus.Expired.ToString())
             ).ToList();
 
-        if (totalApplicationCount == 0)
+        if (totalApplicationCount == 0 || applicationList.Count == 0)
         {
             return new GetApplicationsQueryResult();
         }


### PR DESCRIPTION
- Introduced a new test in `WhenHandlingGetIndexQuery.cs` to verify that an empty API response results in zero applications.
- Removed unnecessary import statement and initialized `applicationApiResponse.Applications` as an empty array.
- Updated the condition in `GetApplicationsQueryHandler.cs` to return an empty result if either the total application count or the application list is empty.