### PR TITLE
FAI-2232 Refactor OtherAddresses to support null values

### DIFF
--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/GetSavedVacancies/GetSavedVacanciesQuery.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/GetSavedVacancies/GetSavedVacanciesQuery.cs
@@ -35,7 +35,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.GetSavedVacancies
             public string ExternalVacancyUrl { get; set; }
             public string ApplicationStatus { get; set; }
             public Address Address { get; set; }
-            public List<Address> OtherAddresses { get; set; } = [];
+            public List<Address>? OtherAddresses { get; set; } = [];
             public string? EmploymentLocationInformation { get; set; }
             public AvailableWhere? EmployerLocationOption { get; set; }
         }
@@ -57,7 +57,6 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.GetSavedVacancies
             if (savedVacancyList.Count == 0) { return new GetSavedVacanciesQueryResult(); }
 
             var vacancyReferences = savedVacancyList.Select(x => $"{x.VacancyReference}").ToList();
-
             var vacancies = await vacancyService.GetVacancies(vacancyReferences);
 
             var result = new GetSavedVacanciesQueryResult();
@@ -83,7 +82,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.GetSavedVacancies
                     ClosingDate = vacancy.ClosedDate ?? vacancy.ClosingDate,
                     CreatedDate = application.CreatedOn,
                     Address = vacancy.Address,
-                    OtherAddresses = vacancy.OtherAddresses,
+                    OtherAddresses = vacancy.OtherAddresses?.ToList(),
                     EmployerLocationOption = vacancy.EmployerLocationOption,
                     EmploymentLocationInformation = vacancy.EmploymentLocationInformation,
                     IsExternalVacancy = vacancy.IsExternalVacancy,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/Responses/GetVacanciesByReferenceApiResponse.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/Responses/GetVacanciesByReferenceApiResponse.cs
@@ -41,14 +41,11 @@ namespace SFA.DAS.FindAnApprenticeship.InnerApi.Responses
             {
                 get
                 {
-
                     if (EmployerLocationOption is not AvailableWhere.MultipleLocations)
                     {
                         return null;
                     }
-
                     return _otherAddresses
-                        .Skip(1)
                         .DistinctBy(x => x.ToSingleLineAddress())
                         .ToList();
                 }


### PR DESCRIPTION
Updated the `OtherAddresses` property in `GetSavedVacanciesQuery` to be nullable, allowing for more flexible handling. Modified the vacancy retrieval method to safely handle null values for `OtherAddresses`.

Additionally, enhanced the `GetVacanciesByReferenceApiResponse` class to return null for `OtherAddresses` when the `EmployerLocationOption` is not set to `AvailableWhere.MultipleLocations`.