### PR TITLE
FAI-2326 Preserve additional questions ordering

### DIFF
--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/Apply/WhenHandlingGetIndexQuery.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/Apply/WhenHandlingGetIndexQuery.cs
@@ -1,9 +1,4 @@
-﻿using AutoFixture.NUnit3;
-using FluentAssertions;
-using FluentAssertions.Execution;
-using Moq;
-using NUnit.Framework;
-using SFA.DAS.FindAnApprenticeship.Application.Queries.Apply.Index;
+﻿using SFA.DAS.FindAnApprenticeship.Application.Queries.Apply.Index;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Requests;
@@ -11,7 +6,6 @@ using SFA.DAS.FindAnApprenticeship.InnerApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Interfaces;
-using SFA.DAS.Testing.AutoFixture;
 
 namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Apply
 {
@@ -30,6 +24,8 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Apply
             [Frozen] Mock<IVacancyService> vacancyService,
             GetIndexQueryHandler handler)
         {
+            var additionalQuestions = applicationApiResponse.AdditionalQuestions.OrderBy(ord => ord.QuestionOrder).ToList();
+
             var expectedGetApplicationRequest = new GetApplicationApiRequest(query.CandidateId, query.ApplicationId, false);
             var expectedGetPreviousApplicationRequest = new GetApplicationApiRequest(query.CandidateId, applicationApiResponse.PreviousAnswersSourceId!.Value, false);
             candidateApiClient
@@ -54,8 +50,8 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Apply
             result.EmployerName.Should().Be(vacancyApiResponse.EmployerName);
             result.ClosingDate.Should().Be(vacancyApiResponse.ClosingDate);
             result.IsDisabilityConfident.Should().Be(vacancyApiResponse.IsDisabilityConfident);
-            result.ApplicationQuestions.AdditionalQuestion1Label.Should().Be(applicationApiResponse.AdditionalQuestions[0].QuestionText);
-            result.ApplicationQuestions.AdditionalQuestion2Label.Should().Be((applicationApiResponse.AdditionalQuestions[1].QuestionText));
+            result.ApplicationQuestions.AdditionalQuestion1Label.Should().Be(additionalQuestions[0].QuestionText);
+            result.ApplicationQuestions.AdditionalQuestion2Label.Should().Be(additionalQuestions[1].QuestionText);
 
             result.EducationHistory.Qualifications.Should().Be(applicationApiResponse.QualificationsStatus);
             result.EducationHistory.TrainingCourses.Should().Be(applicationApiResponse.TrainingCoursesStatus);
@@ -63,8 +59,8 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Apply
             result.WorkHistory.Jobs.Should().Be(applicationApiResponse.JobsStatus);
             result.ApplicationQuestions.AdditionalQuestion1.Should().Be(applicationApiResponse.AdditionalQuestion1Status);
             result.ApplicationQuestions.AdditionalQuestion2.Should().Be(applicationApiResponse.AdditionalQuestion2Status);
-            result.ApplicationQuestions.AdditionalQuestion1Id.Should().Be(applicationApiResponse.AdditionalQuestions[0].Id);
-            result.ApplicationQuestions.AdditionalQuestion2Id.Should().Be(applicationApiResponse.AdditionalQuestions[1].Id);
+            result.ApplicationQuestions.AdditionalQuestion1Id.Should().Be(additionalQuestions[0].Id);
+            result.ApplicationQuestions.AdditionalQuestion2Id.Should().Be(additionalQuestions[1].Id);
             result.InterviewAdjustments.RequestAdjustments.Should().Be(applicationApiResponse.InterviewAdjustmentsStatus);
             result.DisabilityConfidence.InterviewUnderDisabilityConfident.Should().Be(applicationApiResponse.DisabilityConfidenceStatus);
             result.PreviousApplication.EmployerName.Should().Be(previousVacancyApiResponse.EmployerName);
@@ -82,6 +78,9 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Apply
             [Frozen] Mock<IVacancyService> vacancyService,
             GetIndexQueryHandler handler)
         {
+
+            var additionalQuestions = applicationApiResponse.AdditionalQuestions.OrderBy(ord => ord.QuestionOrder).ToList();
+
             var expectedGetApplicationRequest = new GetApplicationApiRequest(query.CandidateId, query.ApplicationId, false);
             var expectedGetPreviousApplicationRequest = new GetApplicationApiRequest(query.CandidateId, applicationApiResponse.PreviousAnswersSourceId!.Value, false);
             candidateApiClient
@@ -107,8 +106,8 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Apply
             result.EmployerName.Should().Be(vacancyApiResponse.EmployerName);
             result.ClosingDate.Should().Be(vacancyApiResponse.ClosingDate);
             result.IsDisabilityConfident.Should().Be(vacancyApiResponse.IsDisabilityConfident);
-            result.ApplicationQuestions.AdditionalQuestion1Label.Should().Be(applicationApiResponse.AdditionalQuestions[0].QuestionText);
-            result.ApplicationQuestions.AdditionalQuestion2Label.Should().Be((applicationApiResponse.AdditionalQuestions[1].QuestionText));
+            result.ApplicationQuestions.AdditionalQuestion1Label.Should().Be(additionalQuestions[0].QuestionText);
+            result.ApplicationQuestions.AdditionalQuestion2Label.Should().Be(additionalQuestions[1].QuestionText);
 
             result.EducationHistory.Qualifications.Should().Be(applicationApiResponse.QualificationsStatus);
             result.EducationHistory.TrainingCourses.Should().Be(applicationApiResponse.TrainingCoursesStatus);
@@ -116,8 +115,8 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Apply
             result.WorkHistory.Jobs.Should().Be(applicationApiResponse.JobsStatus);
             result.ApplicationQuestions.AdditionalQuestion1.Should().Be(applicationApiResponse.AdditionalQuestion1Status);
             result.ApplicationQuestions.AdditionalQuestion2.Should().Be(applicationApiResponse.AdditionalQuestion2Status);
-            result.ApplicationQuestions.AdditionalQuestion1Id.Should().Be(applicationApiResponse.AdditionalQuestions[0].Id);
-            result.ApplicationQuestions.AdditionalQuestion2Id.Should().Be(applicationApiResponse.AdditionalQuestions[1].Id);
+            result.ApplicationQuestions.AdditionalQuestion1Id.Should().Be(additionalQuestions[0].Id);
+            result.ApplicationQuestions.AdditionalQuestion2Id.Should().Be(additionalQuestions[1].Id);
             result.InterviewAdjustments.RequestAdjustments.Should().Be(applicationApiResponse.InterviewAdjustmentsStatus);
             result.DisabilityConfidence.InterviewUnderDisabilityConfident.Should().Be(applicationApiResponse.DisabilityConfidenceStatus);
             result.PreviousApplication.Should().BeNull();

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Vacancies/ApplyCommandHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Vacancies/ApplyCommandHandler.cs
@@ -24,11 +24,11 @@ public class ApplyCommandHandler(
             await findApprenticeshipApiClient.Get<GetApprenticeshipVacancyItemResponse>(
                 new GetVacancyRequest(request.VacancyReference));
 
-        var additionalQuestions = new List<string>();
-        if (result.AdditionalQuestion1 != null) { additionalQuestions.Add(result.AdditionalQuestion1); }
-        if (result.AdditionalQuestion2 != null) { additionalQuestions.Add(result.AdditionalQuestion2); }
+        var additionalQuestions = new List<KeyValuePair<int, string>>();
+        if (result.AdditionalQuestion1 != null) { additionalQuestions.Add(new KeyValuePair<int, string>(1, result.AdditionalQuestion1)); }
+        if (result.AdditionalQuestion2 != null) { additionalQuestions.Add(new KeyValuePair<int, string>(2, result.AdditionalQuestion2)); }
 
-        PutApplicationApiRequest.PutApplicationApiRequestData putApplicationApiRequestData = new PutApplicationApiRequest.PutApplicationApiRequestData
+        var putApplicationApiRequestData = new PutApplicationApiRequest.PutApplicationApiRequestData
         {
             CandidateId = request.CandidateId,
             AdditionalQuestions = additionalQuestions,
@@ -36,10 +36,9 @@ public class ApplyCommandHandler(
             IsAdditionalQuestion2Complete = string.IsNullOrEmpty(result.AdditionalQuestion2) ? (short)4 : (short)0,
             IsDisabilityConfidenceComplete = result.IsDisabilityConfident ? (short)0 : (short)4
         };
-        var putData = putApplicationApiRequestData;
         var vacancyReference =
             request.VacancyReference.Replace("VAC", "", StringComparison.CurrentCultureIgnoreCase);
-        var putRequest = new PutApplicationApiRequest(vacancyReference, putData);
+        var putRequest = new PutApplicationApiRequest(vacancyReference, putApplicationApiRequestData);
 
         var applicationResult =
             await candidateApiClient.PutWithResponseCode<PutApplicationApiResponse>(putRequest);

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplication/GetApplicationViewQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplication/GetApplicationViewQueryHandler.cs
@@ -36,14 +36,16 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.Applications.GetAppli
 
             if (vacancy == null) { return null; }
 
-            var additionalQuestions = application.AdditionalQuestions.ToList();
+            var additionalQuestions = application
+                .AdditionalQuestions
+                .OrderBy(ord => ord.QuestionOrder)
+                .ToList();
 
             var candidate = application.Candidate;
             var address = application.Candidate.Address;
             var trainingCourses = application.TrainingCourses;
             var jobs = application.WorkHistory?.Where(c => c.WorkHistoryType == WorkHistoryType.Job);
             var volunteeringExperiences = application.WorkHistory?.Where(c => c.WorkHistoryType == WorkHistoryType.WorkExperience);
-            var otherDetails = application.AboutYou;
 
             GetApplicationViewQueryResult.ApplicationQuestionsSection.Question additionalQuestion1 = null;
             GetApplicationViewQueryResult.ApplicationQuestionsSection.Question additionalQuestion2 = null;

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Apply/GetApplication/GetApplicationQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Apply/GetApplication/GetApplicationQueryHandler.cs
@@ -29,7 +29,10 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.Apply.GetApplication
             
             if (application == null) return null;
 
-            var additionalQuestions = application.AdditionalQuestions.ToList();
+            var additionalQuestions = application
+                .AdditionalQuestions
+                .OrderBy(ord => ord.QuestionOrder)
+                .ToList();
 
             var candidate = application.Candidate;
             var address = application.Candidate.Address;

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Apply/Index/GetIndexQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Apply/Index/GetIndexQueryHandler.cs
@@ -51,7 +51,10 @@ public class GetIndexQueryHandler : IRequestHandler<GetIndexQuery,GetIndexQueryR
             }
         }
 
-        var additionalQuestions = application.AdditionalQuestions.ToList();
+        var additionalQuestions = application
+            .AdditionalQuestions
+            .OrderBy(ord => ord.QuestionOrder)
+            .ToList();
 
         return new GetIndexQueryResult
         {

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/CandidateApi/Requests/PutApplicationApiRequest.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/CandidateApi/Requests/PutApplicationApiRequest.cs
@@ -20,7 +20,7 @@ namespace SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests
         public class PutApplicationApiRequestData
         {
             public Guid CandidateId { get; set; }
-            public IEnumerable<string> AdditionalQuestions { get; set; }
+            public List<KeyValuePair<int, string>> AdditionalQuestions { get; set; }
             public short IsAdditionalQuestion1Complete { get; set; }
             public short IsAdditionalQuestion2Complete { get; set; }
             public short IsDisabilityConfidenceComplete { get; set; }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/CandidateApi/Responses/GetApplicationApiResponse.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/CandidateApi/Responses/GetApplicationApiResponse.cs
@@ -45,5 +45,6 @@ namespace SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses
         public required Guid Id { get; init; }
         public required string QuestionText { get; init; }
         public string Answer { get; set; }
+        public short? QuestionOrder { get; set; }
     }
 }


### PR DESCRIPTION
Story: https://skillsfundingagency.atlassian.net/browse/FAI-2326

✨ Refactor handling of additional questions in the application process

- Update `WhenHandlingGetIndexQuery.cs` to sort additional questions by order.
- Change `additionalQuestions` in `ApplyCommandHandler.cs` to use key-value pairs.
- Ensure additional questions are ordered in `GetApplicationViewQueryHandler.cs`.
- Modify `PutApplicationApiRequest` to use a list of key-value pairs for questions.
- Add `QuestionOrder` property to `Question` class in `GetApplicationApiResponse.cs`.

