### PR TITLE
DASD-12694 - Added secure gateway

### DIFF
--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -19,6 +19,7 @@ parameters:
   SandboxEnabled: $False
   AddXForwardedAuthorization: $False
   useProductAppInsights:
+  CheckClientCert: $False
 
 jobs:
 - deployment: DeployInfrastructure
@@ -113,6 +114,9 @@ jobs:
               -ApplicationIdentifierUri ${{ parameters.ApplicationIdentifierUri }} `
               -SandboxEnabled ${{ parameters.SandboxEnabled }} `
               -AddXForwardedAuthorization ${{ parameters.AddXForwardedAuthorization }} `
+              -CheckClientCert ${{ parameters.CheckClientCert }} `
+              -ApimKeyVaultUri $(ApimKeyVaultUri) `
+              -ApimKeyVaultClientCertName $(ApimKeyVaultClientCertName) `
               -Verbose
             azurePowerShellVersion: LatestVersion
             pwsh: true

--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -20,6 +20,7 @@ parameters:
   AddXForwardedAuthorization: $False
   useProductAppInsights:
   CheckClientCert: $False
+  MandateCheckClientCert: $False
 
 jobs:
 - deployment: DeployInfrastructure
@@ -115,6 +116,7 @@ jobs:
               -SandboxEnabled ${{ parameters.SandboxEnabled }} `
               -AddXForwardedAuthorization ${{ parameters.AddXForwardedAuthorization }} `
               -CheckClientCert ${{ parameters.CheckClientCert }} `
+              -MandateCheckClientCert ${{ parameters.MandateCheckClientCert }} `
               -ApimKeyVaultUri $(ApimKeyVaultUri) `
               -ApimKeyVaultClientCertName $(ApimKeyVaultClientCertName) `
               -Verbose

--- a/pipeline-templates/stage/outerapi-pipeline.yml
+++ b/pipeline-templates/stage/outerapi-pipeline.yml
@@ -2,6 +2,7 @@ parameters:
   OuterApiName:
   SandboxEnabled: $False
   AddXForwardedAuthorization: $False
+  CheckClientCert: $False
   SharedOuterApiProjectPathToInclude: 'src/Shared/SFA.DAS.SharedOuterApi/SFA.DAS.SharedOuterApi.csproj'
   SharedOuterApiTestProjectPathToInclude: 'src/Shared/SFA.DAS.SharedOuterApi.UnitTests/SFA.DAS.SharedOuterApi.UnitTests.csproj'
   AdditionalProjectPathToInclude: ''
@@ -60,6 +61,7 @@ stages:
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
+      CheckClientCert: ${{ parameters.CheckClientCert }}
 
 - stage: Deploy_TEST
   dependsOn: Build
@@ -91,6 +93,7 @@ stages:
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
+      CheckClientCert: ${{ parameters.CheckClientCert }}
 
 - stage: Deploy_TEST2
   dependsOn: Build
@@ -122,6 +125,7 @@ stages:
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
+      CheckClientCert: ${{ parameters.CheckClientCert }}
 
 - stage: Deploy_PP
   dependsOn: Build
@@ -153,7 +157,7 @@ stages:
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
-
+      CheckClientCert: ${{ parameters.CheckClientCert }}
 
 - stage: Deploy_PROD
   dependsOn: Build
@@ -184,6 +188,7 @@ stages:
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
+      CheckClientCert: ${{ parameters.CheckClientCert }}
 
 - stage: Deploy_MO
   dependsOn: Build
@@ -214,6 +219,7 @@ stages:
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
+      CheckClientCert: ${{ parameters.CheckClientCert }}
 
 - stage: Deploy_DEMO
   dependsOn: Build
@@ -245,3 +251,4 @@ stages:
       SandboxEnabled: ${{ parameters.SandboxEnabled }}
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
+      CheckClientCert: ${{ parameters.CheckClientCert }}

--- a/pipeline-templates/stage/outerapi-pipeline.yml
+++ b/pipeline-templates/stage/outerapi-pipeline.yml
@@ -3,6 +3,7 @@ parameters:
   SandboxEnabled: $False
   AddXForwardedAuthorization: $False
   CheckClientCert: $False
+  MandateCheckClientCert: $False
   SharedOuterApiProjectPathToInclude: 'src/Shared/SFA.DAS.SharedOuterApi/SFA.DAS.SharedOuterApi.csproj'
   SharedOuterApiTestProjectPathToInclude: 'src/Shared/SFA.DAS.SharedOuterApi.UnitTests/SFA.DAS.SharedOuterApi.UnitTests.csproj'
   AdditionalProjectPathToInclude: ''
@@ -62,6 +63,7 @@ stages:
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
       CheckClientCert: ${{ parameters.CheckClientCert }}
+      MandateCheckClientCert: ${{ parameters.MandateCheckClientCert }}
 
 - stage: Deploy_TEST
   dependsOn: Build
@@ -94,6 +96,7 @@ stages:
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
       CheckClientCert: ${{ parameters.CheckClientCert }}
+      MandateCheckClientCert: ${{ parameters.MandateCheckClientCert }}
 
 - stage: Deploy_TEST2
   dependsOn: Build
@@ -126,6 +129,7 @@ stages:
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
       CheckClientCert: ${{ parameters.CheckClientCert }}
+      MandateCheckClientCert: ${{ parameters.MandateCheckClientCert }}
 
 - stage: Deploy_PP
   dependsOn: Build
@@ -158,6 +162,7 @@ stages:
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
       CheckClientCert: ${{ parameters.CheckClientCert }}
+      MandateCheckClientCert: ${{ parameters.MandateCheckClientCert }}
 
 - stage: Deploy_PROD
   dependsOn: Build
@@ -189,6 +194,7 @@ stages:
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
       CheckClientCert: ${{ parameters.CheckClientCert }}
+      MandateCheckClientCert: ${{ parameters.MandateCheckClientCert }}
 
 - stage: Deploy_MO
   dependsOn: Build
@@ -220,6 +226,7 @@ stages:
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
       CheckClientCert: ${{ parameters.CheckClientCert }}
+      MandateCheckClientCert: ${{ parameters.MandateCheckClientCert }}
 
 - stage: Deploy_DEMO
   dependsOn: Build
@@ -252,3 +259,4 @@ stages:
       AddXForwardedAuthorization: ${{ parameters.AddXForwardedAuthorization }}
       useProductAppInsights: ${{ parameters.useProductAppInsights }}
       CheckClientCert: ${{ parameters.CheckClientCert }}
+      MandateCheckClientCert: ${{ parameters.MandateCheckClientCert }}

--- a/src/AdminAan/azure-pipelines.yml
+++ b/src/AdminAan/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/AdminAan/azure-pipelines.yml
+++ b/src/AdminAan/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/AdminAan/azure-pipelines.yml
+++ b/src/AdminAan/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/AparRegister/azure-pipelines.yml
+++ b/src/AparRegister/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/AparRegister/azure-pipelines.yml
+++ b/src/AparRegister/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/AparRegister/azure-pipelines.yml
+++ b/src/AparRegister/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApimDeveloper/azure-pipelines.yml
+++ b/src/ApimDeveloper/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApimDeveloper/azure-pipelines.yml
+++ b/src/ApimDeveloper/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApimDeveloper/azure-pipelines.yml
+++ b/src/ApimDeveloper/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeAan/azure-pipelines.yml
+++ b/src/ApprenticeAan/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeAan/azure-pipelines.yml
+++ b/src/ApprenticeAan/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeAan/azure-pipelines.yml
+++ b/src/ApprenticeAan/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeApp/azure-pipelines.yml
+++ b/src/ApprenticeApp/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeApp/azure-pipelines.yml
+++ b/src/ApprenticeApp/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeApp/azure-pipelines.yml
+++ b/src/ApprenticeApp/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeCommitments/azure-pipelines.yml
+++ b/src/ApprenticeCommitments/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeCommitments/azure-pipelines.yml
+++ b/src/ApprenticeCommitments/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeCommitments/azure-pipelines.yml
+++ b/src/ApprenticeCommitments/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeFeedback/azure-pipelines.yml
+++ b/src/ApprenticeFeedback/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeFeedback/azure-pipelines.yml
+++ b/src/ApprenticeFeedback/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticeFeedback/azure-pipelines.yml
+++ b/src/ApprenticeFeedback/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticePortal/azure-pipelines.yml
+++ b/src/ApprenticePortal/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticePortal/azure-pipelines.yml
+++ b/src/ApprenticePortal/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ApprenticePortal/azure-pipelines.yml
+++ b/src/ApprenticePortal/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Apprenticeships/azure-pipelines.yml
+++ b/src/Apprenticeships/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Apprenticeships/azure-pipelines.yml
+++ b/src/Apprenticeships/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Apprenticeships/azure-pipelines.yml
+++ b/src/Apprenticeships/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Approvals/azure-pipelines.yml
+++ b/src/Approvals/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Approvals/azure-pipelines.yml
+++ b/src/Approvals/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Approvals/azure-pipelines.yml
+++ b/src/Approvals/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Assessors/azure-pipelines.yml
+++ b/src/Assessors/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Assessors/azure-pipelines.yml
+++ b/src/Assessors/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Assessors/azure-pipelines.yml
+++ b/src/Assessors/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Campaign/azure-pipelines.yml
+++ b/src/Campaign/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Campaign/azure-pipelines.yml
+++ b/src/Campaign/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Campaign/azure-pipelines.yml
+++ b/src/Campaign/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EarlyConnect/azure-pipelines.yml
+++ b/src/EarlyConnect/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EarlyConnect/azure-pipelines.yml
+++ b/src/EarlyConnect/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EarlyConnect/azure-pipelines.yml
+++ b/src/EarlyConnect/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Earnings/azure-pipelines.yml
+++ b/src/Earnings/azure-pipelines.yml
@@ -36,7 +36,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Earnings/azure-pipelines.yml
+++ b/src/Earnings/azure-pipelines.yml
@@ -36,7 +36,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Earnings/azure-pipelines.yml
+++ b/src/Earnings/azure-pipelines.yml
@@ -36,7 +36,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerAan/azure-pipelines.yml
+++ b/src/EmployerAan/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerAan/azure-pipelines.yml
+++ b/src/EmployerAan/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerAan/azure-pipelines.yml
+++ b/src/EmployerAan/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerAccounts/azure-pipelines.yml
+++ b/src/EmployerAccounts/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerAccounts/azure-pipelines.yml
+++ b/src/EmployerAccounts/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerAccounts/azure-pipelines.yml
+++ b/src/EmployerAccounts/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerContactForms/azure-pipelines.yml
+++ b/src/EmployerContactForms/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerContactForms/azure-pipelines.yml
+++ b/src/EmployerContactForms/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerContactForms/azure-pipelines.yml
+++ b/src/EmployerContactForms/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerDemand/azure-pipelines.yml
+++ b/src/EmployerDemand/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerDemand/azure-pipelines.yml
+++ b/src/EmployerDemand/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerDemand/azure-pipelines.yml
+++ b/src/EmployerDemand/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerFeedback/azure-pipelines.yml
+++ b/src/EmployerFeedback/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerFeedback/azure-pipelines.yml
+++ b/src/EmployerFeedback/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerFeedback/azure-pipelines.yml
+++ b/src/EmployerFeedback/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerFinance/azure-pipelines.yml
+++ b/src/EmployerFinance/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerFinance/azure-pipelines.yml
+++ b/src/EmployerFinance/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerFinance/azure-pipelines.yml
+++ b/src/EmployerFinance/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerIncentives/azure-pipelines.yml
+++ b/src/EmployerIncentives/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerIncentives/azure-pipelines.yml
+++ b/src/EmployerIncentives/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerIncentives/azure-pipelines.yml
+++ b/src/EmployerIncentives/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerPR/azure-pipelines.yml
+++ b/src/EmployerPR/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerPR/azure-pipelines.yml
+++ b/src/EmployerPR/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerPR/azure-pipelines.yml
+++ b/src/EmployerPR/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerProfiles/azure-pipelines.yml
+++ b/src/EmployerProfiles/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerProfiles/azure-pipelines.yml
+++ b/src/EmployerProfiles/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerProfiles/azure-pipelines.yml
+++ b/src/EmployerProfiles/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/EmployerRequestApprenticeTraining/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmploymentCheck/azure-pipelines.yml
+++ b/src/EmploymentCheck/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmploymentCheck/azure-pipelines.yml
+++ b/src/EmploymentCheck/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EmploymentCheck/azure-pipelines.yml
+++ b/src/EmploymentCheck/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EpaoRegister/azure-pipelines.yml
+++ b/src/EpaoRegister/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EpaoRegister/azure-pipelines.yml
+++ b/src/EpaoRegister/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/EpaoRegister/azure-pipelines.yml
+++ b/src/EpaoRegister/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindAnApprenticeship/azure-pipelines.yml
+++ b/src/FindAnApprenticeship/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/heads/DASD-12694
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config
@@ -57,3 +57,4 @@ stages:
       NServiceBusLicense: $(NServiceBusLicense)
       ApimEndpointsRedisConnectionString: $(ApimEndpointsRedisConnectionString)
     useProductAppInsights: 'True'
+    CheckClientCert: $True

--- a/src/FindAnApprenticeship/azure-pipelines.yml
+++ b/src/FindAnApprenticeship/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/heads/DASD-12694
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindAnApprenticeship/azure-pipelines.yml
+++ b/src/FindAnApprenticeship/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/heads/DASD-12694
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindAnApprenticeship/azure-pipelines.yml
+++ b/src/FindAnApprenticeship/azure-pipelines.yml
@@ -41,7 +41,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/heads/DASD-12694
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindApprenticeshipJobs/azure-pipelines.yml
+++ b/src/FindApprenticeshipJobs/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/heads/DASD-12694
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindApprenticeshipJobs/azure-pipelines.yml
+++ b/src/FindApprenticeshipJobs/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/heads/DASD-12694
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindApprenticeshipJobs/azure-pipelines.yml
+++ b/src/FindApprenticeshipJobs/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindApprenticeshipTraining/azure-pipelines.yml
+++ b/src/FindApprenticeshipTraining/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindApprenticeshipTraining/azure-pipelines.yml
+++ b/src/FindApprenticeshipTraining/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindApprenticeshipTraining/azure-pipelines.yml
+++ b/src/FindApprenticeshipTraining/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindEpao/azure-pipelines.yml
+++ b/src/FindEpao/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindEpao/azure-pipelines.yml
+++ b/src/FindEpao/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/FindEpao/azure-pipelines.yml
+++ b/src/FindEpao/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Forecasting/azure-pipelines.yml
+++ b/src/Forecasting/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Forecasting/azure-pipelines.yml
+++ b/src/Forecasting/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Forecasting/azure-pipelines.yml
+++ b/src/Forecasting/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Funding/azure-pipelines.yml
+++ b/src/Funding/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Funding/azure-pipelines.yml
+++ b/src/Funding/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Funding/azure-pipelines.yml
+++ b/src/Funding/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/LevyTransferMatching/azure-pipelines.yml
+++ b/src/LevyTransferMatching/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/LevyTransferMatching/azure-pipelines.yml
+++ b/src/LevyTransferMatching/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/LevyTransferMatching/azure-pipelines.yml
+++ b/src/LevyTransferMatching/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Payments/azure-pipelines.yml
+++ b/src/Payments/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/heads/DASD-12694
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config
@@ -51,4 +51,4 @@ stages:
 - template: ../../pipeline-templates/stage/outerapi-pipeline.yml
   parameters:
     OuterApiName: Payments
-    CheckClientCert: $True
+    MandateCheckClientCert: $True

--- a/src/Payments/azure-pipelines.yml
+++ b/src/Payments/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.10
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Payments/azure-pipelines.yml
+++ b/src/Payments/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/heads/DASD-12694
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Payments/azure-pipelines.yml
+++ b/src/Payments/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config
@@ -51,3 +51,4 @@ stages:
 - template: ../../pipeline-templates/stage/outerapi-pipeline.yml
   parameters:
     OuterApiName: Payments
+    CheckClientCert: $True

--- a/src/ProviderFeedback/azure-pipelines.yml
+++ b/src/ProviderFeedback/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderFeedback/azure-pipelines.yml
+++ b/src/ProviderFeedback/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderFeedback/azure-pipelines.yml
+++ b/src/ProviderFeedback/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderPR/azure-pipelines.yml
+++ b/src/ProviderPR/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderPR/azure-pipelines.yml
+++ b/src/ProviderPR/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderPR/azure-pipelines.yml
+++ b/src/ProviderPR/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
+++ b/src/ProviderRequestApprenticeTraining/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/PublicSectorReporting/azure-pipelines.yml
+++ b/src/PublicSectorReporting/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/PublicSectorReporting/azure-pipelines.yml
+++ b/src/PublicSectorReporting/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/PublicSectorReporting/azure-pipelines.yml
+++ b/src/PublicSectorReporting/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Recruit/azure-pipelines.yml
+++ b/src/Recruit/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Recruit/azure-pipelines.yml
+++ b/src/Recruit/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Recruit/azure-pipelines.yml
+++ b/src/Recruit/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ReferenceDataJobs/azure-pipelines.yml
+++ b/src/ReferenceDataJobs/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ReferenceDataJobs/azure-pipelines.yml
+++ b/src/ReferenceDataJobs/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/ReferenceDataJobs/azure-pipelines.yml
+++ b/src/ReferenceDataJobs/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Reservations/azure-pipelines.yml
+++ b/src/Reservations/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Reservations/azure-pipelines.yml
+++ b/src/Reservations/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Reservations/azure-pipelines.yml
+++ b/src/Reservations/azure-pipelines.yml
@@ -42,7 +42,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Roatp/azure-pipelines.yml
+++ b/src/Roatp/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Roatp/azure-pipelines.yml
+++ b/src/Roatp/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Roatp/azure-pipelines.yml
+++ b/src/Roatp/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpCourseManagement/azure-pipelines.yml
+++ b/src/RoatpCourseManagement/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpCourseManagement/azure-pipelines.yml
+++ b/src/RoatpCourseManagement/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpCourseManagement/azure-pipelines.yml
+++ b/src/RoatpCourseManagement/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpOversight/azure-pipelines.yml
+++ b/src/RoatpOversight/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpOversight/azure-pipelines.yml
+++ b/src/RoatpOversight/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpOversight/azure-pipelines.yml
+++ b/src/RoatpOversight/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpProviderModeration/azure-pipelines.yml
+++ b/src/RoatpProviderModeration/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpProviderModeration/azure-pipelines.yml
+++ b/src/RoatpProviderModeration/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/RoatpProviderModeration/azure-pipelines.yml
+++ b/src/RoatpProviderModeration/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/TrackProgress/azure-pipelines.yml
+++ b/src/TrackProgress/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/TrackProgress/azure-pipelines.yml
+++ b/src/TrackProgress/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/TrackProgress/azure-pipelines.yml
+++ b/src/TrackProgress/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/TrackProgressInternal/azure-pipelines.yml
+++ b/src/TrackProgressInternal/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/TrackProgressInternal/azure-pipelines.yml
+++ b/src/TrackProgressInternal/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/TrackProgressInternal/azure-pipelines.yml
+++ b/src/TrackProgressInternal/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Vacancies/azure-pipelines.yml
+++ b/src/Vacancies/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Vacancies/azure-pipelines.yml
+++ b/src/Vacancies/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/Vacancies/azure-pipelines.yml
+++ b/src/Vacancies/azure-pipelines.yml
@@ -40,7 +40,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/VacanciesManage/azure-pipelines.yml
+++ b/src/VacanciesManage/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.18
+    ref: refs/tags/5.1.19
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/VacanciesManage/azure-pipelines.yml
+++ b/src/VacanciesManage/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.14
+    ref: refs/tags/5.1.16
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config

--- a/src/VacanciesManage/azure-pipelines.yml
+++ b/src/VacanciesManage/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   - repository: das-platform-automation
     type: github
     name: SkillsFundingAgency/das-platform-automation
-    ref: refs/tags/5.1.16
+    ref: refs/tags/5.1.18
     endpoint: SkillsFundingAgency
   pipelines:
   - pipeline: das-employer-config


### PR DESCRIPTION
- Added configuration for CheckClientCert and MandateCheckClientCert options to add different apim policy:
\- CheckClientCert will check the cert only if request has come through the secure-gateway dns, requests that come through normal apim gateway won't be checked.
\- MandateCheckClientCert  will also check the cert and will only work when using the secure-gateway. 
- Bumped versions of platform automation for all outers to be able to use the new version of Import-ApimSwaggerApiDefinition.ps1
- Added the MandateCheckClientCert on Payments outer api 
- Added the CheckClientCert on FindAnApprenticeship outer api