### PR TITLE
FAI-2370 Bug : Exception due to the new ML vacancy references

### DIFF
--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Commands/Vacancies/WhenHandlingDeleteSavedVacancyCommand.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Commands/Vacancies/WhenHandlingDeleteSavedVacancyCommand.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using SFA.DAS.FindAnApprenticeship.Application.Commands.Vacancies.DeleteSavedVacancy;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.Testing.AutoFixture;
 
@@ -21,8 +22,7 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Commands.Vacancies
             [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
             DeleteSavedVacancyCommandHandler handler)
         {
-            var vacancyReference =
-                command.VacancyReference.Replace("VAC", string.Empty, StringComparison.CurrentCultureIgnoreCase);
+            var vacancyReference = command.VacancyReference.TrimVacancyReference();
             var expectedRequest = new PostDeleteSavedVacancyApiRequest(command.CandidateId, vacancyReference);
 
             var actual = await handler.Handle(command, CancellationToken.None);

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/Applications/WhenHandlingGetAccountDeletionQuery.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/Applications/WhenHandlingGetAccountDeletionQuery.cs
@@ -4,6 +4,7 @@ using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using static SFA.DAS.FindAnApprenticeship.InnerApi.Responses.PostGetVacanciesByReferenceApiResponse;
 
@@ -23,6 +24,8 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Application
         {
             for (var i = 0; i < applicationApiResponse.Applications.Count; i++)
             {
+                applicationApiResponse.Applications[i].VacancyReference = applicationApiResponse.Applications[i]
+                    .VacancyReference.TrimVacancyReference();
                 applicationApiResponse.Applications[i].Status = ApplicationStatus.Submitted.ToString();
                 vacancies[i].VacancyReference = applicationApiResponse.Applications[i].VacancyReference;
             }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/Applications/WhenHandlingGetIndexQuery.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/Applications/WhenHandlingGetIndexQuery.cs
@@ -4,6 +4,7 @@ using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using static SFA.DAS.FindAnApprenticeship.InnerApi.Responses.PostGetVacanciesByReferenceApiResponse;
 
@@ -24,6 +25,8 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Application
         {
             for (var i = 0; i < applicationApiResponse.Applications.Count; i++)
             {
+                applicationApiResponse.Applications[i].VacancyReference = applicationApiResponse.Applications[i]
+                    .VacancyReference.TrimVacancyReference();
                 applicationApiResponse.Applications[i].Status = ApplicationStatus.Draft.ToString();
                 vacancies[i].VacancyReference = applicationApiResponse.Applications[i].VacancyReference;
             }
@@ -90,6 +93,8 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Application
             query.Status = ApplicationStatus.Submitted;
             for (var i = 0; i < applicationApiResponse.Applications.Count; i++)
             {
+                applicationApiResponse.Applications[i].VacancyReference = applicationApiResponse.Applications[i]
+                    .VacancyReference.TrimVacancyReference();
                 applicationApiResponse.Applications[i].Status = i == 0 ? ApplicationStatus.Submitted.ToString() : ApplicationStatus.Withdrawn.ToString();
                 vacancies[i].VacancyReference = applicationApiResponse.Applications[i].VacancyReference;
             }
@@ -156,6 +161,8 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Application
             query.Status = ApplicationStatus.Draft;
             for (var i = 0; i < applicationApiResponse.Applications.Count; i++)
             {
+                applicationApiResponse.Applications[i].VacancyReference = applicationApiResponse.Applications[i]
+                    .VacancyReference.TrimVacancyReference();
                 applicationApiResponse.Applications[i].Status = i == 0 ? ApplicationStatus.Draft.ToString() : ApplicationStatus.Expired.ToString();
                 vacancies[i].VacancyReference = applicationApiResponse.Applications[i].VacancyReference;
             }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/SearchByVacancyReference/WhenHandlingGetApprenticeshipVacancyQuery.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/SearchByVacancyReference/WhenHandlingGetApprenticeshipVacancyQuery.cs
@@ -6,6 +6,7 @@ using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Responses;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.InnerApi.Requests;
 using SFA.DAS.SharedOuterApi.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Interfaces;
@@ -93,7 +94,7 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.SearchByVac
             courseService.Setup(x => x.GetLevels()).ReturnsAsync(courseLevelsResponse);
 
             var expectedGetCandidateApplicationRequest =
-                new GetApplicationByReferenceApiRequest(query.CandidateId.Value, query.VacancyReference.Replace("VAC","", StringComparison.CurrentCultureIgnoreCase));
+                new GetApplicationByReferenceApiRequest(query.CandidateId.Value, query.VacancyReference.TrimVacancyReference());
             candidateApiClient
                 .Setup(client =>
                     client.Get<GetApplicationByReferenceApiResponse>(
@@ -109,7 +110,7 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.SearchByVac
                 .ReturnsAsync(candidateAddressApiResponse);
 
             var expectedGetSavedVacancyApiRequest =
-                new GetSavedVacancyApiRequest(query.CandidateId.Value, query.VacancyReference.Replace("VAC", "", StringComparison.CurrentCultureIgnoreCase));
+                new GetSavedVacancyApiRequest(query.CandidateId.Value, query.VacancyReference.TrimVacancyReference());
             candidateApiClient
                 .Setup(client =>
                     client.Get<GetSavedVacancyApiResponse>(

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/SearchByVacancyReference/WhenMappingFromGetClosedVacancyResponseToVacancy.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/SearchByVacancyReference/WhenMappingFromGetClosedVacancyResponseToVacancy.cs
@@ -4,6 +4,7 @@ using SFA.DAS.FindAnApprenticeship.Application.Queries.SearchByVacancyReference;
 using SFA.DAS.FindAnApprenticeship.Domain;
 using SFA.DAS.FindAnApprenticeship.Domain.Models;
 using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Responses;
+using SFA.DAS.SharedOuterApi.Extensions;
 
 namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.SearchByVacancyReference;
 
@@ -45,7 +46,7 @@ public class WhenMappingFromGetClosedVacancyResponseToVacancy
         actual.EmployerWebsiteUrl.Should().Be(source.EmployerWebsiteUrl);
         actual.ExpectedDuration.Should().Be(((DurationUnit)source.Wage.DurationUnit).GetDisplayName().ToLower().ToQuantity(source.Wage.Duration));
         actual.HoursPerWeek.Should().Be(source.Wage.WeeklyHours);
-        actual.Id.Should().Be(source.VacancyReference.Replace("VAC", ""));
+        actual.Id.Should().Be(source.VacancyReference.TrimVacancyReference());
         actual.IsClosed.Should().Be(source.ClosedDate.HasValue);
         actual.IsDisabilityConfident.Should().Be(source.IsDisabilityConfident);
         actual.IsEmployerAnonymous.Should().Be(source.IsAnonymous);
@@ -69,7 +70,7 @@ public class WhenMappingFromGetClosedVacancyResponseToVacancy
         actual.TrainingDescription.Should().Be(source.TrainingDescription);
         actual.Ukprn.Should().Be(source.TrainingProvider.Ukprn.ToString());
         actual.VacancyLocationType.Should().Be(source.VacancyLocationType);
-        actual.VacancyReference.Should().Be(source.VacancyReference.Replace("VAC", ""));
+        actual.VacancyReference.Should().Be(source.VacancyReference.TrimVacancyReference());
         actual.WageAdditionalInformation.Should().Be(source.Wage.WageAdditionalInformation);
         actual.WageType.Should().Be(source.Wage.WageType);
         actual.WageUnit.Should().Be(source.Wage.DurationUnit);

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/Vacancies/WhenHandlingApplyCommand.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/Application/Queries/Vacancies/WhenHandlingApplyCommand.cs
@@ -9,6 +9,7 @@ using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
 using SFA.DAS.Testing.AutoFixture;
@@ -29,7 +30,7 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Vacancies
         {
             var expectedPutData = new PutApplicationApiRequest.PutApplicationApiRequestData
             { CandidateId = query.CandidateId };
-            var expectedPutRequest = new PutApplicationApiRequest(query.VacancyReference.Replace("VAC", "", StringComparison.CurrentCultureIgnoreCase), expectedPutData);
+            var expectedPutRequest = new PutApplicationApiRequest(query.VacancyReference.TrimVacancyReference(), expectedPutData);
 
             var expectedGetRequest = new GetVacancyRequest(query.VacancyReference);
             faaApiResponse.IsDisabilityConfident = true;
@@ -63,7 +64,7 @@ namespace SFA.DAS.FindAnApprenticeship.UnitTests.Application.Queries.Vacancies
         {
             var expectedPutData = new PutApplicationApiRequest.PutApplicationApiRequestData
                 { CandidateId = query.CandidateId };
-            var expectedPutRequest = new PutApplicationApiRequest(query.VacancyReference.Replace("VAC", "", StringComparison.CurrentCultureIgnoreCase), expectedPutData);
+            var expectedPutRequest = new PutApplicationApiRequest(query.VacancyReference.TrimVacancyReference(), expectedPutData);
 
             var expectedGetRequest = new GetVacancyRequest(query.VacancyReference);
 

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Apply/WithdrawApplication/WithdrawApplicationCommandHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Apply/WithdrawApplication/WithdrawApplicationCommandHandler.cs
@@ -16,6 +16,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using SFA.DAS.SharedOuterApi.Extensions;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Commands.Apply.WithdrawApplication;
 
@@ -37,7 +38,7 @@ public class WithdrawApplicationCommandHandler(
         }
 
         var response = await recruitApiClient.PostWithResponseCode<NullResponse>(
-            new PostWithdrawApplicationRequest(request.CandidateId, Convert.ToInt64(application.VacancyReference.Replace("VAC", ""))), false);
+            new PostWithdrawApplicationRequest(request.CandidateId, Convert.ToInt64(application.VacancyReference.TrimVacancyReference())), false);
 
         if (response.StatusCode != HttpStatusCode.NoContent)
         {

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Users/DeleteCandidate/DeleteCandidateCommandHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Users/DeleteCandidate/DeleteCandidateCommandHandler.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using SFA.DAS.FindAnApprenticeship.InnerApi.FindApprenticeApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.RecruitApi.Responses;
+using SFA.DAS.SharedOuterApi.Extensions;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Commands.Users.DeleteCandidate
 {
@@ -55,7 +56,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Commands.Users.DeleteCandidat
             foreach (var application in applicationList)
             {
                 var response = await recruitApiClient.PostWithResponseCode<NullResponse>(
-                    new PostWithdrawApplicationRequest(command.CandidateId, Convert.ToInt64(application.VacancyReference.Replace("VAC", ""))), false);
+                    new PostWithdrawApplicationRequest(command.CandidateId, Convert.ToInt64(application.VacancyReference.TrimVacancyReference())), false);
 
                 if (response.StatusCode != HttpStatusCode.NoContent)
                 {

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Vacancies/ApplyCommandHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Vacancies/ApplyCommandHandler.cs
@@ -36,8 +36,7 @@ public class ApplyCommandHandler(
             IsAdditionalQuestion2Complete = string.IsNullOrEmpty(result.AdditionalQuestion2) ? (short)4 : (short)0,
             IsDisabilityConfidenceComplete = result.IsDisabilityConfident ? (short)0 : (short)4
         };
-        var vacancyReference =
-            request.VacancyReference.Replace("VAC", "", StringComparison.CurrentCultureIgnoreCase);
+        var vacancyReference = request.VacancyReference.TrimVacancyReference();
         var putRequest = new PutApplicationApiRequest(vacancyReference, putApplicationApiRequestData);
 
         var applicationResult =

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Vacancies/DeleteSavedVacancy/DeleteSavedVacancyCommandHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Vacancies/DeleteSavedVacancy/DeleteSavedVacancyCommandHandler.cs
@@ -5,6 +5,7 @@ using SFA.DAS.SharedOuterApi.Interfaces;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using SFA.DAS.SharedOuterApi.Extensions;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Commands.Vacancies.DeleteSavedVacancy
 {
@@ -12,8 +13,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Commands.Vacancies.DeleteSave
     {
         public async Task<Unit> Handle(DeleteSavedVacancyCommand request, CancellationToken cancellationToken)
         {
-            var vacancyReference =
-                request.VacancyReference.Replace("VAC", string.Empty, StringComparison.CurrentCultureIgnoreCase);
+            var vacancyReference = request.VacancyReference.TrimVacancyReference();
 
             var postRequest = new PostDeleteSavedVacancyApiRequest(request.CandidateId, vacancyReference);
 

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Vacancies/SaveVacancy/SaveVacancyCommandHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/Vacancies/SaveVacancy/SaveVacancyCommandHandler.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Commands.Vacancies.SaveVacanc
         {
             var postData = new PostSavedVacancyApiRequestData
             {
-                VacancyReference = request.VacancyReference.Replace("VAC", string.Empty, StringComparison.CurrentCultureIgnoreCase),
+                VacancyReference = request.VacancyReference.TrimVacancyReference(),
                 CreatedOn = DateTime.UtcNow
             };
 

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplications/GetApplicationsQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplications/GetApplicationsQueryHandler.cs
@@ -8,6 +8,7 @@ using SFA.DAS.SharedOuterApi.Interfaces;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using SFA.DAS.SharedOuterApi.Extensions;
 using static System.Enum;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Queries.Applications.GetApplications;
@@ -43,7 +44,7 @@ public class GetApplicationsQueryHandler(
 
         foreach (var application in applicationList)
         {
-            var vacancy = vacancies.FirstOrDefault(v => v.VacancyReference.Replace("VAC", string.Empty) == application.VacancyReference);
+            var vacancy = vacancies.FirstOrDefault(v => v.VacancyReference.TrimVacancyReference() == application.VacancyReference);
             
             if(vacancy is null) continue;
 

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/GetSavedVacancies/GetSavedVacanciesQuery.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/GetSavedVacancies/GetSavedVacanciesQuery.cs
@@ -9,6 +9,7 @@ using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
 
@@ -63,12 +64,11 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.GetSavedVacancies
 
             foreach (var application in savedVacancyList)
             {
-                var vacancy = vacancies.FirstOrDefault(v => v.VacancyReference.Replace("VAC", string.Empty) == application.VacancyReference);
+                var vacancy = vacancies.FirstOrDefault(v => v.VacancyReference.TrimVacancyReference() == application.VacancyReference);
 
                 if (vacancy == null) continue;
 
-                var vacancyReference =
-                    application.VacancyReference.Replace("VAC", "", StringComparison.CurrentCultureIgnoreCase);
+                var vacancyReference = application.VacancyReference.TrimVacancyReference();
 
                 var applicationResult = await candidateApiClient.Get<GetApplicationByReferenceApiResponse>(
                     new GetApplicationByReferenceApiRequest(request.CandidateId, vacancyReference));

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SearchApprenticeships/SearchApprenticeshipsQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SearchApprenticeships/SearchApprenticeshipsQueryHandler.cs
@@ -16,6 +16,7 @@ using SFA.DAS.FindAnApprenticeship.InnerApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Queries.SearchApprenticeships
@@ -181,7 +182,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.SearchApprenticeships
             // increase the count of vacancy appearing in search results counter metrics.
             foreach (var vacancy in apprenticeshipVacancies.Where(fil => fil.VacancySource == VacancyDataSource.Raa))
             {
-                metrics.IncreaseVacancySearchResultViews(vacancy.Id);
+                metrics.IncreaseVacancySearchResultViews(vacancy.VacancyReference.TrimVacancyReference());
             }
 
             return new SearchApprenticeshipsResult

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SearchByVacancyReference/GetApprenticeshipVacancyQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SearchByVacancyReference/GetApprenticeshipVacancyQueryHandler.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using SFA.DAS.FindAnApprenticeship.Domain.Models;
+using SFA.DAS.SharedOuterApi.Extensions;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Queries.SearchByVacancyReference
 {
@@ -54,7 +55,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.SearchByVacancyRefere
             if (request.CandidateId.HasValue)
             {
                 var vacancyReference =
-                    request.VacancyReference.Replace("VAC", "", StringComparison.CurrentCultureIgnoreCase);
+                    request.VacancyReference.TrimVacancyReference();
 
                 var application = candidateApiClient.Get<GetApplicationByReferenceApiResponse>(
                     new GetApplicationByReferenceApiRequest(request.CandidateId.Value, vacancyReference));

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SearchByVacancyReference/GetApprenticeshipVacancyQueryResult.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SearchByVacancyReference/GetApprenticeshipVacancyQueryResult.cs
@@ -9,6 +9,7 @@ using Microsoft.OpenApi.Extensions;
 using SFA.DAS.FindAnApprenticeship.Domain;
 using SFA.DAS.FindAnApprenticeship.Domain.Models;
 using SFA.DAS.FindAnApprenticeship.Services;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Models;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Queries.SearchByVacancyReference
@@ -150,7 +151,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.SearchByVacancyRefere
                     EmployerWebsiteUrl = source.EmployerWebsiteUrl,
                     ExpectedDuration = durationUnit.GetDisplayName().ToLower().ToQuantity(source.Wage.Duration),
                     HoursPerWeek = source.Wage.WeeklyHours,
-                    Id = source.VacancyReference.Replace("VAC", ""),
+                    Id = source.VacancyReference.TrimVacancyReference(),
                     IsClosed = source.ClosedDate.HasValue,
                     IsDisabilityConfident = source.IsDisabilityConfident,
                     IsEmployerAnonymous = source.IsAnonymous,
@@ -183,7 +184,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.SearchByVacancyRefere
                     TrainingDescription = source.TrainingDescription,
                     Ukprn = source.TrainingProvider.Ukprn.ToString(),
                     VacancyLocationType = source.VacancyLocationType,
-                    VacancyReference = source.VacancyReference.Replace("VAC", ""),
+                    VacancyReference = source.VacancyReference.TrimVacancyReference(),
                     WageAdditionalInformation = source.Wage.WageAdditionalInformation,
                     WageType = source.Wage.WageType,
                     WageUnit = source.Wage.DurationUnit,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Users/GetAccountDeletionQuery/GetAccountDeletionQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Users/GetAccountDeletionQuery/GetAccountDeletionQueryHandler.cs
@@ -8,6 +8,7 @@ using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Requests;
 using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
 using SFA.DAS.FindAnApprenticeship.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
 
 namespace SFA.DAS.FindAnApprenticeship.Application.Queries.Users.GetAccountDeletionQuery
@@ -36,7 +37,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.Users.GetAccountDelet
             foreach (var application in applicationList)
             {
                 var vacancy = vacancies.FirstOrDefault(v =>
-                    v.VacancyReference.Replace("VAC", string.Empty) == application.VacancyReference);
+                    v.VacancyReference.TrimVacancyReference() == application.VacancyReference);
                 Enum.TryParse<ApplicationStatus>(application.Status, out var status);
                 result.SubmittedApplications.Add(new GetAccountDeletionQueryResult.Application
                 {

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Services/VacancyService.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Services/VacancyService.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.FindAnApprenticeship.Services
 
         public async Task<IVacancy> GetClosedVacancy(string vacancyReference)
         {
-            var response = await recruitApiClient.Get<GetClosedVacancyResponse>(new GetClosedVacancyRequest(vacancyReference.Replace("VAC", "")));
+            var response = await recruitApiClient.Get<GetClosedVacancyResponse>(new GetClosedVacancyRequest(vacancyReference.TrimVacancyReference()));
             return AnonymizeClosedVacancy(response);
         }
 

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Telemetry/FindAnApprenticeshipMetrics.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Telemetry/FindAnApprenticeshipMetrics.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using SFA.DAS.FindAnApprenticeship.Domain;
 using SFA.DAS.FindAnApprenticeship.Services;
+using SFA.DAS.SharedOuterApi.Extensions;
 
 namespace SFA.DAS.FindAnApprenticeship.Telemetry
 {
@@ -25,28 +26,28 @@ namespace SFA.DAS.FindAnApprenticeship.Telemetry
         public void IncreaseVacancyViews(string vacancyReference, int viewCount = 1)
         {
             VacancyViewsCounter.Add(viewCount,
-                new KeyValuePair<string, object>("vacancy.reference", vacancyReference.Replace("VAC", string.Empty, StringComparison.CurrentCultureIgnoreCase)),
+                new KeyValuePair<string, object>("vacancy.reference", vacancyReference.TrimVacancyReference()),
                 new KeyValuePair<string, object>("vacancy.source", Constants.OpenTelemetry.RequestSourceName));
         }
 
         public void IncreaseVacancyStarted(string vacancyReference, int viewCount = 1)
         {
             VacancyStartedCounter.Add(viewCount,
-                new KeyValuePair<string, object>("vacancy.reference", vacancyReference.Replace("VAC", string.Empty, StringComparison.CurrentCultureIgnoreCase)),
+                new KeyValuePair<string, object>("vacancy.reference", vacancyReference.TrimVacancyReference()),
                 new KeyValuePair<string, object>("vacancy.source", Constants.OpenTelemetry.RequestSourceName));
         }
 
         public void IncreaseVacancySubmitted(string vacancyReference, int viewCount = 1)
         {
             VacancySubmittedCounter.Add(viewCount,
-                new KeyValuePair<string, object>("vacancy.reference", vacancyReference.Replace("VAC", string.Empty, StringComparison.CurrentCultureIgnoreCase)),
+                new KeyValuePair<string, object>("vacancy.reference", vacancyReference.TrimVacancyReference()),
                 new KeyValuePair<string, object>("vacancy.source", Constants.OpenTelemetry.RequestSourceName));
         }
 
         public void IncreaseVacancySearchResultViews(string vacancyReference, int viewCount = 1)
         {
             VacancySearchResultViewCounter.Add(viewCount,
-                new KeyValuePair<string, object>("vacancy.reference", vacancyReference.Replace("VAC", string.Empty, StringComparison.CurrentCultureIgnoreCase)),
+                new KeyValuePair<string, object>("vacancy.reference", vacancyReference.TrimVacancyReference()),
                 new KeyValuePair<string, object>("vacancy.source", Constants.OpenTelemetry.RequestSourceName));
         }
     }

--- a/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,22 @@
+using System;
+using FluentAssertions;
+using SFA.DAS.SharedOuterApi.Extensions;
+
+namespace SFA.DAS.SharedOuterApi.UnitTests.Extensions
+{
+    [TestFixture]
+    public class StringExtensionsTests
+    {
+        [TestCase("VAC12345", "12345")]
+        [TestCase("vac12345", "12345")]
+        [TestCase("12345VAC", "12345")]
+        [TestCase("12345vac", "12345")]
+        [TestCase("VAC12345VAC", "12345")]
+        [TestCase("vac12345vac", "12345")]
+        public void TrimVacancyReference_ShouldReturnExpectedResult(string input, string expected)
+        {
+            var result = input.TrimVacancyReference();
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi/Extensions/StringExtensions.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/Extensions/StringExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace SFA.DAS.SharedOuterApi.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string TrimVacancyReference(this string vacancyReference)
+        {
+            return string.IsNullOrEmpty(vacancyReference) 
+                ? string.Empty 
+                : vacancyReference.Replace("VAC", string.Empty, StringComparison.CurrentCultureIgnoreCase);
+        }
+    }
+}

--- a/src/Vacancies/SFA.DAS.Vacancies.Api.UnitTests/Controllers/WhenGettingVacancy.cs
+++ b/src/Vacancies/SFA.DAS.Vacancies.Api.UnitTests/Controllers/WhenGettingVacancy.cs
@@ -12,6 +12,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.Vacancies.Services;
 
 namespace SFA.DAS.Vacancies.Api.UnitTests.Controllers
@@ -41,7 +42,7 @@ namespace SFA.DAS.Vacancies.Api.UnitTests.Controllers
             Assert.That(model, Is.Not.Null);
             model.Should().BeEquivalentTo((GetVacancyResponse)queryResult);
 
-            metrics.Verify(x => x.IncreaseVacancyViews(vacancyReference, 1), Times.Once);
+            metrics.Verify(x => x.IncreaseVacancyViews(vacancyReference.TrimVacancyReference(), 1), Times.Once);
         }
 
         [Test, MoqAutoData]
@@ -62,7 +63,7 @@ namespace SFA.DAS.Vacancies.Api.UnitTests.Controllers
             Assert.That(controllerResult, Is.Not.Null);
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
 
-            metrics.Verify(x => x.IncreaseVacancyViews(vacancyReference, 1), Times.Once);
+            metrics.Verify(x => x.IncreaseVacancyViews(vacancyReference.TrimVacancyReference(), 1), Times.Once);
         }
 
         [Test, MoqAutoData]
@@ -81,7 +82,7 @@ namespace SFA.DAS.Vacancies.Api.UnitTests.Controllers
             Assert.That(controllerResult, Is.Not.Null);
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
 
-            metrics.Verify(x => x.IncreaseVacancyViews(vacancyReference, 1), Times.Once);
+            metrics.Verify(x => x.IncreaseVacancyViews(vacancyReference.TrimVacancyReference(), 1), Times.Once);
         }
     }
 }

--- a/src/Vacancies/SFA.DAS.Vacancies.Api/Controllers/VacancyController.cs
+++ b/src/Vacancies/SFA.DAS.Vacancies.Api/Controllers/VacancyController.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Security;
 using System.Threading.Tasks;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Models;
 using SFA.DAS.Vacancies.Api.Models;
 using SFA.DAS.Vacancies.Application.Vacancies.Queries;
@@ -131,7 +132,7 @@ namespace SFA.DAS.Vacancies.Api.Controllers
             }
             finally
             {
-                _metrics.IncreaseVacancyViews(vacancyReference);
+                _metrics.IncreaseVacancyViews(vacancyReference.TrimVacancyReference());
             }
         }
     }

--- a/src/Vacancies/SFA.DAS.Vacancies/Application/Vacancies/Queries/GetVacanciesQueryHandler.cs
+++ b/src/Vacancies/SFA.DAS.Vacancies/Application/Vacancies/Queries/GetVacanciesQueryHandler.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.InnerApi.Requests;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
@@ -90,7 +91,7 @@ namespace SFA.DAS.Vacancies.Application.Vacancies.Queries
                 vacanciesItem.VacancyUrl = $"{_vacanciesConfiguration.FindAnApprenticeshipBaseUrl}/apprenticeship/reference/{vacanciesItem.VacancyReference.Replace("VAC","")}";
 
                 // increase the count of vacancy appearing in search results counter metrics.
-                _metrics.IncreaseVacancySearchResultViews(vacanciesItem.Id);
+                _metrics.IncreaseVacancySearchResultViews(vacanciesItem.VacancyReference.TrimVacancyReference());
             }
             
             return new GetVacanciesQueryResult()


### PR DESCRIPTION
✨ Refactor vacancy reference handling with new extension

- Introduced `TrimVacancyReference` method in `StringExtensions`.
- Replaced `Replace("VAC", "", ...)` with `TrimVacancyReference()` calls.
- Updated command and query handlers for consistent vacancy reference handling.
- Added `StringExtensionsTests` to verify the new method's functionality.
- Included `using SFA.DAS.SharedOuterApi.Extensions;` in relevant files.

Changes made by Balaji Jambulingam