### PR TITLE
FAI-2275 Enable FAA user accounts to display single location vacancies when deleting account

### DIFF
--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/RecruitApi/Responses/GetClosedVacancyResponse.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/RecruitApi/Responses/GetClosedVacancyResponse.cs
@@ -23,7 +23,8 @@ public class GetClosedVacancyResponse: IVacancy
     public int CourseId => Convert.ToInt32(ProgrammeId);
     public Address EmployerLocation { get; set; }
     public List<Address>? EmployerLocations { get; set; }
-    public Address? Address {
+    public Address? Address
+    {
         get
         {
             return EmployerLocationOption switch
@@ -38,11 +39,7 @@ public class GetClosedVacancyResponse: IVacancy
     public List<Address>? OtherAddresses {
         get
         {
-            if (EmployerLocationOption is not AvailableWhere.MultipleLocations)
-            {
-                return null;
-            }
-
+            if (EmployerLocationOption is not AvailableWhere.MultipleLocations) return null;
             var firstAddress = EmployerLocations!.FirstOrDefault().ToSingleLineAddress();
             var otherAddresses = EmployerLocations
                 .Skip(1)
@@ -57,7 +54,7 @@ public class GetClosedVacancyResponse: IVacancy
     [JsonPropertyName("employmentLocationInformation")]
     public string? EmploymentLocationInformation { get; set; }
 
-    [JsonPropertyName("employerLocationOption")]
+    [JsonPropertyName("employerLocationOption"), JsonConverter(typeof(JsonStringEnumConverter<AvailableWhere>))]
     public AvailableWhere? EmployerLocationOption { get; set; }
     public TrainingProviderDetails TrainingProvider { get; set; }
     public string AdditionalQuestion1 { get; set; }

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Responses/GetLiveVacanciesApiResponse.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Responses/GetLiveVacanciesApiResponse.cs
@@ -1,6 +1,7 @@
 ﻿using SFA.DAS.FindApprenticeshipJobs.Application.Shared;
 using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Models;
+using System.Text.Json.Serialization;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
 public class GetLiveVacanciesApiResponse
@@ -28,6 +29,7 @@ public class LiveVacancy
     public string? EmployerDescription { get; set; }
     public Address? EmployerLocation { get; set; }
     public List<Address>? EmployerLocations { get; set; } = [];
+    [JsonPropertyName("employerLocationOption"), JsonConverter(typeof(JsonStringEnumConverter<AvailableWhere>))]
     public AvailableWhere? EmployerLocationOption { get; set; }
     public string? EmployerLocationInformation { get; set; }
 


### PR DESCRIPTION
✨ Refactor vacancy response classes for improved serialization

- Enhanced `GetClosedVacancyResponse.Address` getter logic.
- Simplified `OtherAddresses` property in `GetClosedVacancyResponse`.
- Updated `EmployerLocationOption` with JSON converter in both classes.
- Added `System.Text.Json.Serialization` using directive in `GetLiveVacanciesApiResponse`.
- Initialized `EmployerLocations` to an empty list in `GetLiveVacanciesApiResponse`.

Changes made by Balaji Jambulingam