### PR TITLE
FAI-2275 BUG AvailableWhere Json Serialization Error

### DIFF
--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/RecruitApi/Responses/GetClosedVacancyResponse.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/RecruitApi/Responses/GetClosedVacancyResponse.cs
@@ -57,7 +57,7 @@ public class GetClosedVacancyResponse: IVacancy
     [JsonPropertyName("employmentLocationInformation")]
     public string? EmploymentLocationInformation { get; set; }
 
-    [JsonPropertyName("employerLocationOption")]
+    [JsonPropertyName("employerLocationOption"), JsonConverter(typeof(JsonStringEnumConverter<AvailableWhere>))]
     public AvailableWhere? EmployerLocationOption { get; set; }
     public TrainingProviderDetails TrainingProvider { get; set; }
     public string AdditionalQuestion1 { get; set; }

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Responses/GetLiveVacanciesApiResponse.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Responses/GetLiveVacanciesApiResponse.cs
@@ -1,6 +1,7 @@
 ﻿using SFA.DAS.FindApprenticeshipJobs.Application.Shared;
 using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Models;
+using System.Text.Json.Serialization;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
 public class GetLiveVacanciesApiResponse
@@ -28,6 +29,7 @@ public class LiveVacancy
     public string? EmployerDescription { get; set; }
     public Address? EmployerLocation { get; set; }
     public List<Address>? EmployerLocations { get; set; } = [];
+    [JsonPropertyName("employerLocationOption"), JsonConverter(typeof(JsonStringEnumConverter<AvailableWhere>))]
     public AvailableWhere? EmployerLocationOption { get; set; }
     public string? EmployerLocationInformation { get; set; }
 


### PR DESCRIPTION
✨ Update vacancy response classes with new location options

- Added `EmployerLocationOption` to `GetClosedVacancyResponse`.
- Removed old `employerLocationOption` property from the same class.
- Included `System.Text.Json.Serialization` namespace in `GetLiveVacanciesApiResponse`.
- Introduced `EmployerLocationOption` in `LiveVacancy` class.
- Both new properties use JSON converters for `AvailableWhere` enum.

Changes made by Balaji Jambulingam