### PR TITLE
FAI-2331 Add Nationwide Filter Search Alert

### DIFF
--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Controllers/SearchApprenticeshipsController.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Controllers/SearchApprenticeshipsController.cs
@@ -108,6 +108,7 @@ public class SearchApprenticeshipsController(ILogger<SearchApprenticeshipsContro
                 id,
                 candidateId,
                 apiRequest.DisabilityConfident,
+                apiRequest.ExcludeNational,
                 apiRequest.Distance,
                 apiRequest.Location,
                 apiRequest.SearchTerm,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Models/SavedSearches/PostSaveSearchApiRequest.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Models/SavedSearches/PostSaveSearchApiRequest.cs
@@ -4,6 +4,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Models.SavedSearches;
 
 public record PostSaveSearchApiRequest(
     bool DisabilityConfident,
+    bool? ExcludeNational,
     int? Distance,
     string? Location,
     string? SearchTerm,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/InnerApi/FindApprenticeApi/Responses/Shared/WhenComparingSearchParametersDto.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.UnitTests/InnerApi/FindApprenticeApi/Responses/Shared/WhenComparingSearchParametersDto.cs
@@ -6,15 +6,15 @@ public class WhenComparingSearchParametersDto
 {
     private static readonly object?[] EqualTestCases =
     [
-        new object[] { new SearchParametersDto("foo", null, null, false, null, null, null, null), new SearchParametersDto("foo", null, null, false, null, null, null, null) },
-        new object[] { new SearchParametersDto(null, [1, 2], null, false, null, null, null, null), new SearchParametersDto(null, [1, 2], null, false, null, null, null, null) },
-        new object[] { new SearchParametersDto(null, null, 1, false, null, null, null, null), new SearchParametersDto(null, null, 1, false, null, null, null, null) },
-        new object[] { new SearchParametersDto(null, null, null, false, null, null, null, null), new SearchParametersDto(null, null, null, false, null, null, null, null) },
-        new object[] { new SearchParametersDto(null, null, null, true, null, null, null, null), new SearchParametersDto(null, null, null, true, null, null, null, null) },
-        new object[] { new SearchParametersDto(null, null, null, false, [1, 2], null, null, null), new SearchParametersDto(null, null, null, false, [1, 2], null, null, null) },
-        new object[] { new SearchParametersDto(null, null, null, false, null, "London", null, null), new SearchParametersDto(null, null, null, false, null, "London", null, null) },
-        new object[] { new SearchParametersDto(null, null, null, false, null, null, "1.0", null), new SearchParametersDto(null, null, null, false, null, null, "1.0", null) },
-        new object[] { new SearchParametersDto(null, null, null, false, null, null, null, "1.0"), new SearchParametersDto(null, null, null, false, null, null, null, "1.0") },
+        new object[] { new SearchParametersDto("foo", null, null, false, false, null, null, null, null), new SearchParametersDto("foo", null, null, false, false, null, null, null, null) },
+        new object[] { new SearchParametersDto(null, [1, 2], null, false, false, null, null, null, null), new SearchParametersDto(null, [1, 2], null, false, false, null, null, null, null) },
+        new object[] { new SearchParametersDto(null, null, 1, false, false, null, null, null, null), new SearchParametersDto(null, null, 1, false, false, null, null, null, null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, null, null, null, null), new SearchParametersDto(null, null, null, false, false, null, null, null, null) },
+        new object[] { new SearchParametersDto(null, null, null, true, true, null, null, null, null), new SearchParametersDto(null, null, null, true, true, null, null, null, null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, [1, 2], null, null, null), new SearchParametersDto(null, null, null, false, false, [1, 2], null, null, null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, null, "London", null, null), new SearchParametersDto(null, null, null, false, false, null, "London", null, null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, null, null, "1.0", null), new SearchParametersDto(null, null, null, false, false, null, null, "1.0", null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, null, null, null, "1.0"), new SearchParametersDto(null, null, null, false, false, null, null, null, "1.0") },
     ];
     
     [TestCaseSource(nameof(EqualTestCases))]
@@ -29,14 +29,14 @@ public class WhenComparingSearchParametersDto
     
     private static readonly object?[] NotEqualTestCases =
     [
-        new object[] { new SearchParametersDto("foo", null, null, false, null, null, null, null), new SearchParametersDto("foo2", null, null, false, null, null, null, null) },
-        new object[] { new SearchParametersDto(null, [1, 2], null, false, null, null, null, null), new SearchParametersDto(null, [1, 3], null, false, null, null, null, null) },
-        new object[] { new SearchParametersDto(null, null, 1, false, null, null, null, null), new SearchParametersDto(null, null, 2, false, null, null, null, null) },
-        new object[] { new SearchParametersDto(null, null, null, false, null, null, null, null), new SearchParametersDto(null, null, null, true, null, null, null, null) },
-        new object[] { new SearchParametersDto(null, null, null, false, [1, 2], null, null, null), new SearchParametersDto(null, null, null, false, [1, 3], null, null, null) },
-        new object[] { new SearchParametersDto(null, null, null, false, null, "London", null, null), new SearchParametersDto(null, null, null, false, null, "Glasgow", null, null) },
-        new object[] { new SearchParametersDto(null, null, null, false, null, null, "1.0", null), new SearchParametersDto(null, null, null, false, null, null, "1.1", null) },
-        new object[] { new SearchParametersDto(null, null, null, false, null, null, null, "1.0 "), new SearchParametersDto(null, null, null, false, null, null, null, "1.1") },
+        new object[] { new SearchParametersDto("foo", null, null, false, false, null, null, null, null), new SearchParametersDto("foo2", null, null, false, false, null, null, null, null) },
+        new object[] { new SearchParametersDto(null, [1, 2], null, false, false, null, null, null, null), new SearchParametersDto(null, [1, 3], null, false, false, null, null, null, null) },
+        new object[] { new SearchParametersDto(null, null, 1, false, false, null, null, null, null), new SearchParametersDto(null, null, 2, false, false, null, null, null, null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, null, null, null, null), new SearchParametersDto(null, null, null, true,true, null, null, null, null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, [1, 2], null, null, null), new SearchParametersDto(null, null, null, false, false, [1, 3], null, null, null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, null, "London", null, null), new SearchParametersDto(null, null, null, false, false, null, "Glasgow", null, null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, null, null, "1.0", null), new SearchParametersDto(null, null, null, false, false, null, null, "1.1", null) },
+        new object[] { new SearchParametersDto(null, null, null, false, false, null, null, null, "1.0 "), new SearchParametersDto(null, null, null, false, false, null, null, null, "1.1") },
     ];
     
     [TestCaseSource(nameof(NotEqualTestCases))]

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/SaveSearch/CreateSaveSearch/SaveSearchCommand.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/SaveSearch/CreateSaveSearch/SaveSearchCommand.cs
@@ -8,6 +8,7 @@ public record SaveSearchCommand(
     Guid Id,
     Guid CandidateId,
     bool DisabilityConfident,
+    bool? ExcludeNational,
     int? Distance,
     string? Location,
     string SearchTerm,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/SaveSearch/CreateSaveSearch/SaveSearchCommandHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Commands/SaveSearch/CreateSaveSearch/SaveSearchCommandHandler.cs
@@ -27,6 +27,7 @@ public class SaveSearchCommandHandler(
                     request.SelectedRouteIds,
                     request.Distance,
                     request.DisabilityConfident,
+                    request.ExcludeNational,
                     request.SelectedLevelIds,
                     request.Location,
                     location?.GeoPoint[0].ToString(CultureInfo.InvariantCulture),

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SavedSearches/GetUnsubscribeSavedSearchQueryResult.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SavedSearches/GetUnsubscribeSavedSearchQueryResult.cs
@@ -27,6 +27,7 @@ public record GetUnsubscribeSavedSearchQueryResult(SavedSearch SavedSearch, IEnu
                 source.SearchParameters.SelectedRouteIds,
                 source.SearchParameters.Distance,
                 source.SearchParameters.DisabilityConfident,
+                source.SearchParameters.ExcludeNational,
                 source.SearchParameters.SelectedLevelIds,
                 source.SearchParameters.Location,
                 source.SearchParameters.Latitude,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SearchApprenticeships/SearchApprenticeshipsQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/SearchApprenticeships/SearchApprenticeshipsQueryHandler.cs
@@ -164,6 +164,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.SearchApprenticeships
                     request.SelectedRouteIds?.Select(x => Convert.ToInt32(x)).ToList(),
                     request.Distance,
                     request.DisabilityConfident,
+                    request.ExcludeNational,
                     request.SelectedLevelIds?.Select(x => Convert.ToInt32(x)).ToList(),
                     request.Location,
                     location?.GeoPoint?.FirstOrDefault().ToString(CultureInfo.InvariantCulture),

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Users/GetSavedSearch/GetCandidateSavedSearchQueryResult.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Users/GetSavedSearch/GetCandidateSavedSearchQueryResult.cs
@@ -28,6 +28,7 @@ public record GetCandidateSavedSearchQueryResult(SavedSearch SavedSearch, List<G
                 source.SearchParameters.SelectedRouteIds,
                 source.SearchParameters.Distance,
                 source.SearchParameters.DisabilityConfident,
+                source.SearchParameters.ExcludeNational,
                 source.SearchParameters.SelectedLevelIds,
                 source.SearchParameters.Location,
                 source.SearchParameters.Latitude,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Domain/Models/SearchParameters.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Domain/Models/SearchParameters.cs
@@ -7,6 +7,7 @@ public record SearchParameters(
     List<int>? SelectedRouteIds,
     int? Distance,
     bool DisabilityConfident,
+    bool? ExcludeNational,
     List<int>? SelectedLevelIds,
     string? Location,
     string? Latitude,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/FindApprenticeApi/Responses/Shared/SavedSearchDto.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/FindApprenticeApi/Responses/Shared/SavedSearchDto.cs
@@ -27,6 +27,7 @@ public static class SavedSearchExtensions
                 source.SearchParameters.SelectedRouteIds,
                 source.SearchParameters.Distance,
                 source.SearchParameters.DisabilityConfident,
+                source.SearchParameters.ExcludeNational,
                 source.SearchParameters.SelectedLevelIds,
                 source.SearchParameters.Location,
                 source.SearchParameters.Latitude,

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/FindApprenticeApi/Responses/Shared/SearchParametersDto.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/InnerApi/FindApprenticeApi/Responses/Shared/SearchParametersDto.cs
@@ -9,6 +9,7 @@ public record SearchParametersDto(
     List<int>? SelectedRouteIds,
     int? Distance,
     bool DisabilityConfident,
+    bool? ExcludeNational,
     List<int>? SelectedLevelIds,
     string? Location,
     string? Latitude,
@@ -40,6 +41,7 @@ public record SearchParametersDto(
             && SearchTerm == other.SearchTerm
             && Distance == other.Distance
             && DisabilityConfident == other.DisabilityConfident
+            && ExcludeNational == other.ExcludeNational
             && Location == other.Location
             && Latitude == other.Latitude
             && Longitude == other.Longitude;

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Controllers/SavedSearchesController.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Controllers/SavedSearchesController.cs
@@ -58,6 +58,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Api.Controllers
                         request.SearchTerm,
                         request.Location,
                         request.DisabilityConfident,
+                        request.ExcludeNational,
                         request.Longitude,
                         request.Latitude,
                         request.SelectedLevelIds,

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/GetCandidateSavedVacanciesRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/GetCandidateSavedVacanciesRequest.cs
@@ -11,6 +11,7 @@ public class GetCandidateSavedVacanciesRequest
     public string? SearchTerm { get; set; }
     public string? Location { get; set; }
     public bool DisabilityConfident { get; set; }
+    public bool? ExcludeNational { get; set; }
     public string? Longitude { get; set; }
     public string? Latitude { get; set; }
     public List<int>? SelectedLevelIds { get; set; } = [];

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/SavedSearchApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/SavedSearchApiRequest.cs
@@ -14,6 +14,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Api.Models
         public decimal? Distance { get; set; }
         public string? SearchTerm { get; set; }
         public bool DisabilityConfident { get; set; }
+        public bool? ExcludeNational { get; set; }
         public string? UnSubscribeToken { get; set; }
         public List<Vacancy> Vacancies { get; set; } = [];
 
@@ -80,6 +81,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Api.Models
                 }).ToList(),
                 Distance = savedSearchApiRequest.Distance,
                 DisabilityConfident = savedSearchApiRequest.DisabilityConfident,
+                ExcludeNational = savedSearchApiRequest.ExcludeNational,
                 Location = savedSearchApiRequest.Location,
                 SearchTerm = savedSearchApiRequest.SearchTerm,
                 UnSubscribeToken = savedSearchApiRequest.UnSubscribeToken,

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
@@ -20,6 +20,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
             List<string> categories = ["IT", "Engineering"];
             List<string> levels = ["Intermediate", "Advanced"];
             const bool disabilityConfident = true;
+            const bool excludeNational = false;
 
             const string expected = """
                                     
@@ -32,11 +33,41 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                                     """;
 
             // Act
-            var result = EmailTemplateBuilder.GetSavedSearchSearchParams(searchTerm, distance, location, categories, levels, disabilityConfident);
+            var result = EmailTemplateBuilder.GetSavedSearchSearchParams(searchTerm, distance, location, categories, levels, disabilityConfident, excludeNational);
 
             // Assert
             result.Trim().Should().BeEquivalentTo(expected.Trim());
         }
+
+        [Test]
+        public void GetSavedSearchSearchParams_When_ExcludeNational_True_ReturnsExpectedResult()
+        {
+            // Arrange
+            const string searchTerm = "Software Developer";
+            const int distance = 10;
+            const string location = "London";
+            List<string> categories = ["IT", "Engineering"];
+            List<string> levels = ["Intermediate", "Advanced"];
+            const bool disabilityConfident = true;
+            const bool excludeNational = true;
+
+            const string expected = """
+                                    
+                                    What: Software Developer
+                                    Where: London (within 10 miles) - hide companies recruiting nationally
+                                    Categories: IT, Engineering
+                                    Apprenticeship levels: Intermediate, Advanced
+                                    Only show Disability Confident apprenticeships
+                                    
+                                    """;
+
+            // Act
+            var result = EmailTemplateBuilder.GetSavedSearchSearchParams(searchTerm, distance, location, categories, levels, disabilityConfident, excludeNational);
+
+            // Assert
+            result.Trim().Should().BeEquivalentTo(expected.Trim());
+        }
+
         [Test]
         public void GetSavedSearchSearchParams_WhenCalled_ReturnsExpectedResult_Across_All_Of_England()
         {
@@ -46,6 +77,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
             List<string> categories = ["IT", "Engineering"];
             List<string> levels = ["Intermediate", "Advanced"];
             const bool disabilityConfident = true;
+            const bool excludeNational = false;
 
             const string expected = """
 
@@ -58,7 +90,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                                     """;
 
             // Act
-            var result = EmailTemplateBuilder.GetSavedSearchSearchParams(searchTerm, null, location, categories, levels, disabilityConfident);
+            var result = EmailTemplateBuilder.GetSavedSearchSearchParams(searchTerm, null, location, categories, levels, disabilityConfident, excludeNational);
 
             // Assert
             result.Trim().Should().BeEquivalentTo(expected.Trim());
@@ -74,6 +106,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
             List<string> categories = ["IT", "Engineering"];
             List<string> levels = ["Intermediate", "Advanced"];
             const bool disabilityConfident = true;
+            const bool excludeNational = false;
 
             const string expected = """
 
@@ -86,7 +119,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                                     """;
 
             // Act
-            var result = EmailTemplateBuilder.GetSavedSearchSearchParams(searchTerm, distance, location, categories, levels, disabilityConfident);
+            var result = EmailTemplateBuilder.GetSavedSearchSearchParams(searchTerm, distance, location, categories, levels, disabilityConfident, excludeNational);
 
             // Assert
             result.Trim().Should().BeEquivalentTo(expected.Trim());
@@ -102,6 +135,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
             List<string> categories = ["IT", "Engineering"];
             List<string> levels = ["Intermediate", "Advanced"];
             const bool disabilityConfident = true;
+            const bool excludeNational = false;
 
             const string expected = """
 
@@ -114,7 +148,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                                     """;
 
             // Act
-            var result = EmailTemplateBuilder.GetSavedSearchSearchParams(searchTerm, distance, location, categories, levels, disabilityConfident);
+            var result = EmailTemplateBuilder.GetSavedSearchSearchParams(searchTerm, distance, location, categories, levels, disabilityConfident, excludeNational);
 
             // Assert
             result.Trim().Should().BeEquivalentTo(expected.Trim());
@@ -141,7 +175,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                 """;
 
             // Act
-            var result = EmailTemplateBuilder.GetSavedSearchSearchParams("Software Developer", distance, location, ["IT", "Engineering"], ["Intermediate", "Advanced"], true);
+            var result = EmailTemplateBuilder.GetSavedSearchSearchParams("Software Developer", distance, location, ["IT", "Engineering"], ["Intermediate", "Advanced"], true, false);
 
             // Assert
             result.Trim().Should().BeEquivalentTo(expected);
@@ -157,11 +191,12 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
             List<string> categoryIds = ["1", "2", "3"];
             List<string> levelCodes = ["4", "5"];
             const bool disabilityConfident = true;
+            const bool excludeNational = true;
 
-            const string expectedQueryParameters = "&searchTerm=software developer&location=London&distance=10&routeIds=1&routeIds=2&routeIds=3&levelIds=4&levelIds=5&DisabilityConfident=true";
+            const string expectedQueryParameters = "&searchTerm=software developer&location=London&distance=10&routeIds=1&routeIds=2&routeIds=3&levelIds=4&levelIds=5&DisabilityConfident=true&excludeNational=true";
 
             // Act
-            var queryParameters = EmailTemplateBuilder.GetSavedSearchUrl(searchTerm, distance, location, categoryIds, levelCodes, disabilityConfident);
+            var queryParameters = EmailTemplateBuilder.GetSavedSearchUrl(searchTerm, distance, location, categoryIds, levelCodes, disabilityConfident, excludeNational);
 
             // Assert
             queryParameters.Should().Be(expectedQueryParameters);

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/InnerApi/WhenBuildingGetVacanciesRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/InnerApi/WhenBuildingGetVacanciesRequest.cs
@@ -19,16 +19,17 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.InnerApi
             int pageSize,
             List<string> categories,
             List<int>? levels,
-            bool disabilityConfident)
+            bool disabilityConfident,
+            bool excludeNational)
         {
-            var actual = new GetVacanciesRequest(lat, lon, distance, whatSearchTerm, pageNumber, pageSize, categories, levels, sort, disabilityConfident, new List<VacancyDataSource>
+            var actual = new GetVacanciesRequest(lat, lon, distance, whatSearchTerm, pageNumber, pageSize, categories, levels, sort, disabilityConfident, excludeNational, new List<VacancyDataSource>
                 {
                     VacancyDataSource.Nhs
                 });
 
             actual.GetUrl
                 .Should()
-                .Be($"/api/vacancies?lat={lat}&lon={lon}&distanceInMiles={distance}&sort={sort}&pageNumber={pageNumber}&pageSize={pageSize}&categories={string.Join("&categories=", categories)}&levels={string.Join("&levels=", levels)}&searchTerm={whatSearchTerm}&disabilityConfident={disabilityConfident}&additionalDataSources=Nhs&postedInLastNumberOfDays=7");
+                .Be($"/api/vacancies?lat={lat}&lon={lon}&distanceInMiles={distance}&sort={sort}&pageNumber={pageNumber}&pageSize={pageSize}&categories={string.Join("&categories=", categories)}&levels={string.Join("&levels=", levels)}&searchTerm={whatSearchTerm}&disabilityConfident={disabilityConfident}&excludeNational={excludeNational}&additionalDataSources=Nhs&postedInLastNumberOfDays=7");
             actual.Version.Should().Be("2.0");
         }
     }

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/SavedSearches/WhenHandlingGetSavedSearchVacanciesQuery.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/SavedSearches/WhenHandlingGetSavedSearchVacanciesQuery.cs
@@ -107,6 +107,7 @@ public class WhenHandlingGetSavedSearchVacanciesQuery
             levels.Select(c=>c.Code).ToList(),
             mockQuery.ApprenticeshipSearchResultsSortOrder,
             mockQuery.DisabilityConfident,
+            mockQuery.ExcludeNational,
             new List<VacancyDataSource> { VacancyDataSource.Nhs });
 
         mockFindApprenticeshipApiClient.Setup(client => client.Get<GetVacanciesResponse>(It.Is<GetVacanciesRequest>(c => c.GetUrl == getVacanciesExpectedUrl.GetUrl))).ReturnsAsync(getVacanciesResponse);

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommand.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommand.cs
@@ -14,6 +14,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Application.Commands.SavedSearch.SendNo
         public string? Location { get; set; }
         public string? SearchTerm { get; set; }
         public bool DisabilityConfident { get; set; }
+        public bool? ExcludeNational { get; set; }
         public string? UnSubscribeToken { get; set; }
         public List<Vacancy> Vacancies { get; set; } = [];
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommandHandler.cs
@@ -41,14 +41,16 @@ namespace SFA.DAS.FindApprenticeshipJobs.Application.Commands.SavedSearch.SendNo
                 command.Location,
                 (command.Categories != null && command.Categories.Any()) ? command.Categories?.Select(cat => cat.Name).ToList() : null,
                 command.Levels != null && command.Levels.Any() ? command.Levels.Select(lev => lev.Name).ToList() : null,
-                command.DisabilityConfident);
+                command.DisabilityConfident,
+                command.ExcludeNational);
 
             var queryParameters = EmailTemplateBuilder.GetSavedSearchUrl(command.SearchTerm,
                 command.Distance,
                 command.Location,
                 (command.Categories != null && command.Categories.Any()) ? command.Categories?.Select(cat => cat.Id.ToString()).ToList() : null,
                 command.Levels != null && command.Levels.Any() ? command.Levels.Select(lev => lev.Code.ToString()).ToList() : null,
-                command.DisabilityConfident);
+                command.DisabilityConfident,
+                command.ExcludeNational);
 
             var email = new SavedSearchEmailNotificationTemplate(
                 EmailEnvironmentHelper.SavedSearchEmailNotificationTemplateId,

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearchVacancies/GetSavedSearchVacanciesQuery.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearchVacancies/GetSavedSearchVacanciesQuery.cs
@@ -11,6 +11,7 @@ public record GetSavedSearchVacanciesQuery(
     string? SearchTerm,
     string? Location,
     bool DisabilityConfident,
+    bool? ExcludeNational,
     string? Longitude,
     string? Latitude,
     List<int>? SelectedLevelIds,

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearchVacancies/GetSavedSearchVacanciesQueryHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearchVacancies/GetSavedSearchVacanciesQueryHandler.cs
@@ -1,6 +1,4 @@
-using System.Collections.Concurrent;
 using MediatR;
-using SFA.DAS.FindApprenticeshipJobs.Application.Queries.SavedSearch.GetSavedSearches;
 using SFA.DAS.FindApprenticeshipJobs.Domain.Models;
 using SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;
 using SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
@@ -71,10 +69,10 @@ public class GetSavedSearchVacanciesQueryHandler(
                 levels.Select(level => level.Code).ToList(),
                 request.ApprenticeshipSearchResultsSortOrder,
                 request.DisabilityConfident,
-                new List<VacancyDataSource>
-                {
+                request.ExcludeNational,
+                [
                     VacancyDataSource.Nhs
-                }));
+                ]));
 
         var searchResult = new GetSavedSearchVacanciesQueryResult
         {
@@ -85,6 +83,7 @@ public class GetSavedSearchVacanciesQueryHandler(
             Categories = categories,
             Levels = levels,
             DisabilityConfident = request.DisabilityConfident,
+            ExcludeNational = request.ExcludeNational,
             Distance = request.Distance,
             UnSubscribeToken = request.UnSubscribeToken,
             Vacancies = vacanciesResponse?.ApprenticeshipVacancies != null ? vacanciesResponse.ApprenticeshipVacancies.Select(x =>

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearchVacancies/GetSavedSearchVacanciesQueryResult.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearchVacancies/GetSavedSearchVacanciesQueryResult.cs
@@ -15,6 +15,7 @@ public class GetSavedSearchVacanciesQueryResult
     public string? SearchTerm { get; set; }
     public string? Location { get; set; }
     public bool DisabilityConfident { get; set; }
+    public bool? ExcludeNational { get; set; }
     public string? UnSubscribeToken { get; set; }
     public List<ApprenticeshipVacancy> Vacancies { get; set; } = [];
     

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearches/GetSavedSearchesQueryResult.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearches/GetSavedSearchesQueryResult.cs
@@ -21,6 +21,7 @@ public record GetSavedSearchesQueryResult
         public string? SearchTerm { get; set; }
         public string? Location { get; set; }
         public bool DisabilityConfident { get; set; }
+        public bool? ExcludeNational { get; set; }
         public string? Longitude { get; set; }
         public string? Latitude { get; set; }
         public List<int>? SelectedLevelIds { get; set; } = [];
@@ -37,6 +38,7 @@ public record GetSavedSearchesQueryResult
                 SearchTerm = savedSearch.SearchParameters.SearchTerm,
                 Location = savedSearch.SearchParameters.Location,
                 DisabilityConfident = savedSearch.SearchParameters.DisabilityConfident,
+                ExcludeNational = savedSearch.SearchParameters.ExcludeNational,
                 UnSubscribeToken = savedSearch.UnSubscribeToken,
                 Longitude = savedSearch.SearchParameters.Longitude,
                 Latitude = savedSearch.SearchParameters.Latitude,

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
@@ -22,22 +22,32 @@ namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
             string? location,
             List<string?>? categories,
             List<string?>? levels,
-            bool? disabilityConfident)
+            bool? disabilityConfident,
+            bool? excludeNational)
         {
             var sb = new StringBuilder();
 
             sb.AppendLine();
             if (!string.IsNullOrEmpty(searchTerm)) sb.AppendLine($"What: {searchTerm}");
-
+            
             var locationText = location?.Trim() switch
             {
                 "" => "Where: All of England",
-                not null when distance is >1 => $"Where: {location} (within {distance} miles)",
+                not null when distance is > 1 => $"Where: {location} (within {distance} miles)",
                 not null when distance is 1 => $"Where: {location} (within 1 mile)",
                 not null => $"Where: {location} (Across England)",
                 null => "Where: All of England"
             };
-            sb.AppendLine(locationText);
+
+            if (distance != null && excludeNational != null && excludeNational.Value)
+            {
+                sb.AppendLine($"{locationText} - hide companies recruiting nationally");
+            }
+            else
+            {
+                sb.AppendLine(locationText);                
+            }
+            
             
             if (categories is { Count: > 0 }) sb.AppendLine($"Categories: {string.Join(", ", categories)}");
             if (levels is { Count: > 0 }) sb.AppendLine($"Apprenticeship levels: {string.Join(", ", levels)}");
@@ -53,7 +63,8 @@ namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
             string? location,
             List<string>? categoryIds,
             List<string>? levelCodes,
-            bool? disabilityConfident)
+            bool? disabilityConfident,
+            bool? excludeNational)
         {
             var queryParameters = string.Empty;
 
@@ -63,6 +74,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
             if (categoryIds is { Count: > 0 }) queryParameters += "&routeIds=" + string.Join("&routeIds=", categoryIds);
             if (levelCodes is { Count: > 0 }) queryParameters += "&levelIds=" + string.Join("&levelIds=", levelCodes);
             if (disabilityConfident != null && disabilityConfident.Value) queryParameters += "&DisabilityConfident=true";
+            if (excludeNational != null && excludeNational.Value) queryParameters += "&excludeNational=true";
 
             return queryParameters;
         }

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetVacanciesRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetVacanciesRequest.cs
@@ -16,6 +16,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests
         private readonly string _searchTerm;
         private readonly VacancySort _sort;
         private readonly bool _disabilityConfident;
+        private readonly bool? _excludeNational;
         private readonly string _additionalDataSources;
 
         public GetVacanciesRequest(
@@ -29,6 +30,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests
             IReadOnlyCollection<int>? levels,
             VacancySort sort,
             bool disabilityConfident,
+            bool? excludeNational,
             IReadOnlyCollection<VacancyDataSource> additionalDataSources)
         {
             _lat = lat;
@@ -41,11 +43,12 @@ namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests
             _levels = levels is { Count: > 0 } ? string.Join("&levels=", levels) : string.Empty;
             _searchTerm = searchTerm;
             _disabilityConfident = disabilityConfident;
+            _excludeNational = excludeNational;
             _additionalDataSources = additionalDataSources is { Count: > 0 } ? string.Join("&additionalDataSources=", additionalDataSources) : string.Empty;
         }
 
         public string Version => "2.0";
-        public string GetUrl => $"/api/vacancies?lat={_lat}&lon={_lon}&distanceInMiles={_distance}&sort={_sort}&pageNumber={_pageNumber}&pageSize={_pageSize}&categories={_categories}&levels={_levels}&searchTerm={_searchTerm}&disabilityConfident={_disabilityConfident}&additionalDataSources={_additionalDataSources}&postedInLastNumberOfDays=7";
+        public string GetUrl => $"/api/vacancies?lat={_lat}&lon={_lon}&distanceInMiles={_distance}&sort={_sort}&pageNumber={_pageNumber}&pageSize={_pageSize}&categories={_categories}&levels={_levels}&searchTerm={_searchTerm}&disabilityConfident={_disabilityConfident}&excludeNational={_excludeNational}&additionalDataSources={_additionalDataSources}&postedInLastNumberOfDays=7";
     }
 }
 public enum VacancyDataSource

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Responses/GetSavedSearchesApiResponse.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Responses/GetSavedSearchesApiResponse.cs
@@ -68,6 +68,9 @@ namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses
             
             [JsonProperty("disabilityConfident")]
             public bool DisabilityConfident { get; set; }
+
+            [JsonProperty("excludeNational")]
+            public bool? ExcludeNational { get; set; }
         }
     }
 }


### PR DESCRIPTION
✨ Add ExcludeNational property to search parameters

- Introduced optional boolean `ExcludeNational` to several classes.
- Updated `PostSaveSearchApiRequest` and `SaveSearchCommand` to include it.
- Modified `SearchParameters` and `SearchParametersDto` to support the new property.
- Adjusted test cases to ensure proper comparisons with `ExcludeNational`.
- Enhanced search functionality for users to exclude national options.

Changes made by Balaji Jambulingam