### PR TITLE
FAI-2265 FAI-2271 Bug Amendments to Email Template Builder for One Location

### DIFF
--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessApplicationReminder.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessApplicationReminder.cs
@@ -47,11 +47,11 @@ public class WhenHandlingProcessApplicationReminder
     {
         recruitApiResponse.EmployerLocationOption = employerLocationOption;
 
-        recruitApiResponse.EmployerLocation.AddressLine1 = address1;
-        recruitApiResponse.EmployerLocation.AddressLine2 = address2;
-        recruitApiResponse.EmployerLocation.AddressLine3 = address3;
-        recruitApiResponse.EmployerLocation.AddressLine4 = address4;
-        recruitApiResponse.EmployerLocation.Postcode = postcode;
+        recruitApiResponse.EmployerLocations[0].AddressLine1 = address1;
+        recruitApiResponse.EmployerLocations[0].AddressLine2 = address2;
+        recruitApiResponse.EmployerLocations[0].AddressLine3 = address3;
+        recruitApiResponse.EmployerLocations[0].AddressLine4 = address4;
+        recruitApiResponse.EmployerLocations[0].Postcode = postcode;
 
 
         candidatePreference.PreferenceType = "Closing";

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessVacancyClosedEarlyCommand.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessVacancyClosedEarlyCommand.cs
@@ -47,11 +47,11 @@ public class WhenHandlingProcessVacancyClosedEarlyCommand
     {
         recruitApiResponse.EmployerLocationOption = employerLocationOption;
 
-        recruitApiResponse.EmployerLocation.AddressLine1 = address1;
-        recruitApiResponse.EmployerLocation.AddressLine2 = address2;
-        recruitApiResponse.EmployerLocation.AddressLine3 = address3;
-        recruitApiResponse.EmployerLocation.AddressLine4 = address4;
-        recruitApiResponse.EmployerLocation.Postcode = postcode;
+        recruitApiResponse.EmployerLocations[0].AddressLine1 = address1;
+        recruitApiResponse.EmployerLocations[0].AddressLine2 = address2;
+        recruitApiResponse.EmployerLocations[0].AddressLine3 = address3;
+        recruitApiResponse.EmployerLocations[0].AddressLine4 = address4;
+        recruitApiResponse.EmployerLocations[0].Postcode = postcode;
 
         candidateApiClient.Setup(x => 
                 x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>()))

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
@@ -188,7 +188,6 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                         AddressLine1 = "123 Main St",
                         Postcode = "12345"
                     },
-                    EmployerLocationOption = AvailableWhere.OneLocation,
                     Distance = 10,
                     TrainingCourse = "Software Engineering",
                     Wage = "£30,000 a year",
@@ -241,7 +240,65 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                         AddressLine1 = "123 Main St",
                         Postcode = "12345"
                     },
+                    Distance = 10,
+                    TrainingCourse = "Software Engineering",
+                    Wage = "£30,000 a year",
+                    ClosingDate = "2022-12-31"
+                }
+            };
+
+            const string expectedSnippet = """
+
+                                           #[Software Developer](https://example.com/vacancy/12345)
+                                           ABC Company
+                                           123 Main St (12345)
+
+                                           * Training course: Software Engineering
+                                           * Wage: £30,000 a year
+
+                                           2022-12-31
+
+                                           ---
+
+                                           """;
+
+            // Act
+            var snippet = EmailTemplateBuilder.GetSavedSearchVacanciesSnippet(environmentHelper, vacancies, false);
+
+            // Assert
+            snippet.Should().Be(expectedSnippet);
+        }
+
+        [Test]
+        public void GetSavedSearchVacanciesSnippet_Should_Return_Correct_Snippet_With_One_Location()
+        {
+            // Arrange
+            var environmentHelper = new EmailEnvironmentHelper("test")
+            {
+                VacancyDetailsUrl = "https://example.com/vacancy/{vacancy-reference}"
+            };
+
+            var vacancies = new List<PostSendSavedSearchNotificationCommand.Vacancy>
+            {
+                new()
+                {
+                    Title = "Software Developer",
+                    VacancyReference = "12345",
+                    EmployerName = "ABC Company",
                     EmployerLocationOption = AvailableWhere.OneLocation,
+                    EmployerLocation = new Address
+                    {
+                        AddressLine1 = "123 Main St",
+                        Postcode = "12345"
+                    },
+                    EmployerLocations =
+                    [
+                        new Address
+                        {
+                            AddressLine1 = "123 Main St",
+                            Postcode = "12345"
+                        }
+                    ],
                     Distance = 10,
                     TrainingCourse = "Software Engineering",
                     Wage = "£30,000 a year",
@@ -295,7 +352,6 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                         AddressLine1 = "123 Main St",
                         Postcode = "12345"
                     },
-                    EmployerLocationOption = AvailableWhere.OneLocation,
                     Distance = 1,
                     TrainingCourse = "Software Engineering",
                     Wage = "£30,000 a year",
@@ -321,6 +377,71 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                                            ---
 
                                            """;
+
+            // Act
+            var snippet = EmailTemplateBuilder.GetSavedSearchVacanciesSnippet(environmentHelper, vacancies, true);
+
+            // Assert
+            snippet.Should().Be(expectedSnippet);
+        }
+
+        [TestCase("Competitive", "", "Competitive")]
+        [TestCase("", "month", "£30,000 a year")]
+        [TestCase("", "hour", "£30,000 a year")]
+        public void GetSavedSearchVacanciesSnippet_Should_Return_Snippet_With_Correct_Wage_Text_For_Faa_VacancySource_And_Different_WageTypes_With_OneLocation(
+            string wagetype, string wageUnit, string expectedWageText)
+        {
+            // Arrange
+            var environmentHelper = new EmailEnvironmentHelper("test")
+            {
+                VacancyDetailsUrl = "https://example.com/vacancy/{vacancy-reference}"
+            };
+
+            var vacancies = new List<PostSendSavedSearchNotificationCommand.Vacancy>
+            {
+                new()
+                {
+                    Title = "Software Developer",
+                    VacancyReference = "12345",
+                    EmployerName = "ABC Company",
+                    EmployerLocation = new Address
+                    {
+                        AddressLine1 = "123 Main St",
+                        Postcode = "12345"
+                    },
+                    EmployerLocations =
+                    [
+                        new Address
+                        {
+                            AddressLine1 = "123 Main St",
+                            Postcode = "12345"
+                        }
+                    ],
+                    Distance = 1,
+                    TrainingCourse = "Software Engineering",
+                    Wage = "£30,000 a year",
+                    ClosingDate = "2022-12-31",
+                    VacancySource = "FAA",
+                    WageUnit = wageUnit,
+                    WageType = wagetype
+                }
+            };
+
+            var expectedSnippet = $"""
+
+                                   #[Software Developer](https://example.com/vacancy/12345)
+                                   ABC Company
+                                   123 Main St (12345)
+
+                                   * Distance: 1 mile
+                                   * Training course: Software Engineering
+                                   * Wage: {expectedWageText}
+
+                                   2022-12-31
+
+                                   ---
+
+                                   """;
 
             // Act
             var snippet = EmailTemplateBuilder.GetSavedSearchVacanciesSnippet(environmentHelper, vacancies, true);

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using SFA.DAS.FindApprenticeshipJobs.Application.Shared;
+using SFA.DAS.FindApprenticeshipJobs.Domain.Constants;
 using SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates;
 using SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;
 using SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
@@ -7,6 +8,7 @@ using SFA.DAS.Notifications.Messages.Commands;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
+using static SFA.DAS.FindApprenticeshipJobs.Application.Commands.SavedSearch.SendNotification.PostSendSavedSearchNotificationCommand;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Application.Commands;
 
@@ -34,9 +36,10 @@ public class ProcessApplicationReminderCommandHandler(
 
         var employmentWorkLocation = vacancyTask.Result.EmployerLocationOption switch
         {
+            AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
             AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.EmployerLocations),
-            AvailableWhere.AcrossEngland => "Recruiting nationally",
-            _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.EmployerLocation)
+            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.EmployerLocations!.First()),
+            _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address)
         };
 
         foreach (var candidate in candidatesTask.Result.Candidates)

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.AspNetCore.JsonPatch;
 using SFA.DAS.FindApprenticeshipJobs.Application.Shared;
+using SFA.DAS.FindApprenticeshipJobs.Domain.Constants;
 using SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates;
 using SFA.DAS.FindApprenticeshipJobs.Domain.Models;
 using SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;
@@ -30,9 +31,10 @@ public class ProcessVacancyClosedEarlyCommandHandler(
 
         var employmentWorkLocation = vacancyTask.Result.EmployerLocationOption switch
         {
+            AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
             AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.EmployerLocations),
-            AvailableWhere.AcrossEngland => "Recruiting nationally",
-            _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.EmployerLocation)
+            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.EmployerLocations!.First()),
+            _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address)
         };
 
         foreach (var candidate in allCandidateApplicationsTask.Result.Candidates)

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/Constants/EmailTemplateBuilderConstants.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/Constants/EmailTemplateBuilderConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.FindApprenticeshipJobs.Domain.Constants
+{
+    public static class EmailTemplateBuilderConstants
+    {
+        public const string RecruitingNationally = "Recruiting nationally";
+    }
+}

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
@@ -1,10 +1,10 @@
-﻿using System.Globalization;
+﻿using SFA.DAS.FindApprenticeshipJobs.Application.Commands.SavedSearch.SendNotification;
+using SFA.DAS.FindApprenticeshipJobs.Application.Shared;
+using SFA.DAS.FindApprenticeshipJobs.Domain.Constants;
+using SFA.DAS.SharedOuterApi.Extensions;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using SFA.DAS.FindApprenticeshipJobs.Application.Commands.SavedSearch.SendNotification;
-using SFA.DAS.FindApprenticeshipJobs.Application.Shared;
-using SFA.DAS.SharedOuterApi.Extensions;
-using SFA.DAS.SharedOuterApi.Models;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
 {
@@ -80,8 +80,9 @@ namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
                 string? wageText;
                 var employmentWorkLocation = vacancy.EmployerLocationOption switch
                 {
+                    AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
                     AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocations(vacancy.EmployerLocations),
-                    AvailableWhere.AcrossEngland => "Recruiting nationally",
+                    AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.EmployerLocations!.First()),
                     _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.EmployerLocation)
                 };
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.csproj
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
✨ Refactor employer location handling in email templates

- Updated `WhenHandlingProcessApplicationReminder` and `WhenHandlingProcessVacancyClosedEarlyCommand` to use a list of employer locations.
- Modified tests in `EmailTemplateBuilderTests` to reflect new employer location structure.
- Enhanced `ProcessApplicationReminderCommandHandler` and `ProcessVacancyClosedEarlyCommandHandler` to support multiple location options.
- Introduced `EmailTemplateBuilderConstants` for centralized string management.
- Cleaned up `EmailTemplateBuilder` and updated project file for .NET SDK compatibility.

Changes made by Balaji Jambulingam