### PR TITLE
FAI-2265 FAI-2271 Bug fixes related to Email Notifications Issues

### DIFF
--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/SavedSearchApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/SavedSearchApiRequest.cs
@@ -28,7 +28,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Api.Models
             public string? EmployerName { get; set; }
 
             public Address? EmployerLocation { get; set; }
-            public List<Address>? EmployerLocations { get; set; }
+            public List<Address>? OtherAddresses { get; set; }
             public AvailableWhere? EmployerLocationOption { get; set; }
 
             public string? Wage { get; set; }
@@ -103,7 +103,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Api.Models
                         VacancyReference = vacancy.VacancyReference,
                         Wage = vacancy.Wage,
                         EmployerLocation = vacancy.EmployerLocation,
-                        EmployerLocations = vacancy.EmployerLocations,
+                        OtherAddresses = vacancy.OtherAddresses,
                         EmployerLocationOption = vacancy.EmployerLocationOption,
                         VacancySource = vacancy.VacancySource,
                         WageUnit = vacancy.WageUnit,

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/SavedSearchApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/SavedSearchApiRequest.cs
@@ -27,7 +27,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Api.Models
 
             public string? EmployerName { get; set; }
 
-            public Address? EmployerLocation { get; set; }
+            public Address? Address { get; set; }
             public List<Address>? OtherAddresses { get; set; }
             public AvailableWhere? EmploymentLocationOption { get; set; }
 
@@ -102,7 +102,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Api.Models
                         TrainingCourse = vacancy.TrainingCourse,
                         VacancyReference = vacancy.VacancyReference,
                         Wage = vacancy.Wage,
-                        EmployerLocation = vacancy.EmployerLocation,
+                        EmployerLocation = vacancy.Address,
                         OtherAddresses = vacancy.OtherAddresses,
                         EmploymentLocationOption = vacancy.EmploymentLocationOption,
                         VacancySource = vacancy.VacancySource,

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/SavedSearchApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/Models/SavedSearchApiRequest.cs
@@ -29,7 +29,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Api.Models
 
             public Address? EmployerLocation { get; set; }
             public List<Address>? OtherAddresses { get; set; }
-            public AvailableWhere? EmployerLocationOption { get; set; }
+            public AvailableWhere? EmploymentLocationOption { get; set; }
 
             public string? Wage { get; set; }
 
@@ -104,7 +104,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Api.Models
                         Wage = vacancy.Wage,
                         EmployerLocation = vacancy.EmployerLocation,
                         OtherAddresses = vacancy.OtherAddresses,
-                        EmployerLocationOption = vacancy.EmployerLocationOption,
+                        EmploymentLocationOption = vacancy.EmploymentLocationOption,
                         VacancySource = vacancy.VacancySource,
                         WageUnit = vacancy.WageUnit,
                         WageType = vacancy.WageType

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessApplicationReminder.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessApplicationReminder.cs
@@ -1,8 +1,10 @@
 using AutoFixture.NUnit3;
+using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.FindApprenticeshipJobs.Application.Commands;
 using SFA.DAS.FindApprenticeshipJobs.Application.Shared;
+using SFA.DAS.FindApprenticeshipJobs.Domain.Constants;
 using SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates;
 using SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;
 using SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
@@ -22,10 +24,10 @@ public class WhenHandlingProcessApplicationReminder
     [MoqInlineAutoData("address1", "address2", "address3", null, "postcode", "address3 (postcode)", AvailableWhere.OneLocation)]
     [MoqInlineAutoData("address1", "address2", null, null, "postcode", "address2 (postcode)", AvailableWhere.OneLocation)]
     [MoqInlineAutoData("address1", null, null, null, "postcode", "address1 (postcode)", AvailableWhere.OneLocation)]
-    [MoqInlineAutoData("address1", "address2", "address3", "address4", "postcode", "Recruiting nationally", AvailableWhere.AcrossEngland)]
-    [MoqInlineAutoData("address1", "address2", "address3", null, "postcode", "Recruiting nationally", AvailableWhere.AcrossEngland)]
-    [MoqInlineAutoData("address1", "address2", null, null, "postcode", "Recruiting nationally", AvailableWhere.AcrossEngland)]
-    [MoqInlineAutoData("address1", null, null, null, "postcode", "Recruiting nationally", AvailableWhere.AcrossEngland)]
+    [MoqInlineAutoData("address1", "address2", "address3", "address4", "postcode", EmailTemplateBuilderConstants.RecruitingNationally, AvailableWhere.AcrossEngland)]
+    [MoqInlineAutoData("address1", "address2", "address3", null, "postcode", EmailTemplateBuilderConstants.RecruitingNationally, AvailableWhere.AcrossEngland)]
+    [MoqInlineAutoData("address1", "address2", null, null, "postcode", EmailTemplateBuilderConstants.RecruitingNationally, AvailableWhere.AcrossEngland)]
+    [MoqInlineAutoData("address1", null, null, null, "postcode", EmailTemplateBuilderConstants.RecruitingNationally, AvailableWhere.AcrossEngland)]
     public async Task Then_The_Vacancy_Candidates_Are_Found_And_Emails_Sent(
         string address1,
         string address2,
@@ -47,7 +49,7 @@ public class WhenHandlingProcessApplicationReminder
     {
         recruitApiResponse.EmployerLocationOption = employerLocationOption;
 
-        recruitApiResponse.EmployerLocations[0].AddressLine1 = address1;
+        recruitApiResponse.EmployerLocations![0].AddressLine1 = address1;
         recruitApiResponse.EmployerLocations[0].AddressLine2 = address2;
         recruitApiResponse.EmployerLocations[0].AddressLine3 = address3;
         recruitApiResponse.EmployerLocations[0].AddressLine4 = address4;
@@ -134,7 +136,7 @@ public class WhenHandlingProcessApplicationReminder
         foreach (var candidate in candidateApiResponse.Candidates)
         {
             var employmentWorkLocation =
-                EmailTemplateAddressExtension.GetEmploymentLocationCityNames(recruitApiResponse.EmployerLocations);
+                EmailTemplateAddressExtension.GetEmploymentLocationCityNames(recruitApiResponse.OtherAddresses);
 
             notificationService.Verify(x => x.Send(
                 It.Is<SendEmailCommand>(c =>
@@ -145,6 +147,150 @@ public class WhenHandlingProcessApplicationReminder
                     && c.Tokens["vacancy"] == recruitApiResponse.Title
                     && c.Tokens["employer"] == recruitApiResponse.EmployerName
                     && c.Tokens["location"] == $"{employmentWorkLocation}"
+                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("d MMM yyyy")
+                    && !string.IsNullOrEmpty(c.Tokens["continueApplicationLink"])
+                    && !string.IsNullOrEmpty(c.Tokens["vacancyUrl"])
+                    && !string.IsNullOrEmpty(c.Tokens["settingsUrl"])
+                )
+            ), Times.Once);
+        }
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Vacancy_With_Anon_Multiple_Locations_And_Candidates_Are_Found_And_Emails_Sent(
+        List<Address> addresses,
+        ProcessApplicationReminderCommand command,
+        Preference candidatePreference,
+        Preference candidatePreference1,
+        GetCandidateApplicationApiResponse candidateApiResponse,
+        GetLiveVacancyApiResponse recruitApiResponse,
+        EmailEnvironmentHelper emailEnvironmentHelper,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+        [Frozen] Mock<INotificationService> notificationService,
+        ProcessApplicationReminderCommandHandler handler)
+    {
+        const string expectedAddress = "Leeds (3 available locations)";
+
+        recruitApiResponse.EmployerLocationOption = AvailableWhere.MultipleLocations;
+        recruitApiResponse.EmployerLocations =
+        [
+            new Address {AddressLine3 = "Leeds", Postcode = "LS6"},
+            new Address {AddressLine3 = "Leeds", Postcode = "LS6"},
+            new Address {AddressLine3 = "Leeds", Postcode = "LS16"},
+            new Address {AddressLine3 = "Leeds", Postcode = "LS9"},
+            new Address {AddressLine3 = "Leeds", Postcode = "LS9"}
+        ];
+
+        candidatePreference.PreferenceType = "Closing";
+        candidateApiClient
+            .Setup(x => x.Get<GetCandidateApplicationApiResponse>(
+                It.Is<GetCandidateApplicationsByVacancyRequest>(c =>
+                    c.GetUrl.Contains(command.VacancyReference.ToString())
+                    && c.GetUrl.Contains(candidatePreference.PreferenceId.ToString())))).ReturnsAsync(candidateApiResponse);
+        candidateApiClient
+            .Setup(x => x.Get<GetPreferencesApiResponse>(
+                It.IsAny<GetCandidatePreferencesRequest>())).ReturnsAsync(new GetPreferencesApiResponse
+                {
+                    Preferences =
+                [candidatePreference, candidatePreference1]
+                });
+        recruitApiClient
+            .Setup(x => x.Get<GetLiveVacancyApiResponse>(
+                It.Is<GetLiveVacancyApiRequest>(c =>
+                    c.GetUrl.Contains(command.VacancyReference.ToString()))))
+            .ReturnsAsync(recruitApiResponse);
+
+        await handler.Handle(command, CancellationToken.None);
+
+        foreach (var candidate in candidateApiResponse.Candidates)
+        {
+            var employmentWorkLocation =
+                EmailTemplateAddressExtension.GetEmploymentLocationCityNames(recruitApiResponse.OtherAddresses);
+            
+            employmentWorkLocation.Should().Be(expectedAddress);
+
+            notificationService.Verify(x => x.Send(
+                It.Is<SendEmailCommand>(c =>
+                    c.RecipientsAddress == candidate.Candidate.Email
+                    && c.TemplateId == emailEnvironmentHelper.ApplicationReminderEmailTemplateId
+                    && c.Tokens["firstName"] == candidate.Candidate.FirstName
+                    && c.Tokens["daysRemaining"] == command.DaysUntilClosing.ToString()
+                    && c.Tokens["vacancy"] == recruitApiResponse.Title
+                    && c.Tokens["employer"] == recruitApiResponse.EmployerName
+                    && c.Tokens["location"] == $"{expectedAddress}"
+                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("d MMM yyyy")
+                    && !string.IsNullOrEmpty(c.Tokens["continueApplicationLink"])
+                    && !string.IsNullOrEmpty(c.Tokens["vacancyUrl"])
+                    && !string.IsNullOrEmpty(c.Tokens["settingsUrl"])
+                )
+            ), Times.Once);
+        }
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Vacancy_With_Multiple_Locations_With_SameCities_And_Candidates_Are_Found_And_Emails_Sent(
+        List<Address> addresses,
+        ProcessApplicationReminderCommand command,
+        Preference candidatePreference,
+        Preference candidatePreference1,
+        GetCandidateApplicationApiResponse candidateApiResponse,
+        GetLiveVacancyApiResponse recruitApiResponse,
+        EmailEnvironmentHelper emailEnvironmentHelper,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+        [Frozen] Mock<INotificationService> notificationService,
+        ProcessApplicationReminderCommandHandler handler)
+    {
+        const string expectedAddress = "Leeds, Manchester, Sheffield";
+
+        recruitApiResponse.EmployerLocationOption = AvailableWhere.MultipleLocations;
+        recruitApiResponse.EmployerLocations =
+        [
+            new Address {AddressLine3 = "Leeds", Postcode = "LS6 8AA"},
+            new Address {AddressLine3 = "Manchester", Postcode = "MA1 1AN"},
+            new Address {AddressLine3 = "Sheffield", Postcode = "SF1 1AN"},
+            new Address {AddressLine3 = "Sheffield", Postcode = "SF1 1AN"},
+            new Address {AddressLine3 = "Manchester", Postcode = "MA1 1AN"},
+        ];
+
+        candidatePreference.PreferenceType = "Closing";
+        candidateApiClient
+            .Setup(x => x.Get<GetCandidateApplicationApiResponse>(
+                It.Is<GetCandidateApplicationsByVacancyRequest>(c =>
+                    c.GetUrl.Contains(command.VacancyReference.ToString())
+                    && c.GetUrl.Contains(candidatePreference.PreferenceId.ToString())))).ReturnsAsync(candidateApiResponse);
+        candidateApiClient
+            .Setup(x => x.Get<GetPreferencesApiResponse>(
+                It.IsAny<GetCandidatePreferencesRequest>())).ReturnsAsync(new GetPreferencesApiResponse
+                {
+                    Preferences =
+                [candidatePreference, candidatePreference1]
+                });
+        recruitApiClient
+            .Setup(x => x.Get<GetLiveVacancyApiResponse>(
+                It.Is<GetLiveVacancyApiRequest>(c =>
+                    c.GetUrl.Contains(command.VacancyReference.ToString()))))
+            .ReturnsAsync(recruitApiResponse);
+
+        await handler.Handle(command, CancellationToken.None);
+
+        foreach (var candidate in candidateApiResponse.Candidates)
+        {
+            var employmentWorkLocation =
+                EmailTemplateAddressExtension.GetEmploymentLocationCityNames(recruitApiResponse.OtherAddresses);
+
+            employmentWorkLocation.Should().Be(expectedAddress);
+
+            notificationService.Verify(x => x.Send(
+                It.Is<SendEmailCommand>(c =>
+                    c.RecipientsAddress == candidate.Candidate.Email
+                    && c.TemplateId == emailEnvironmentHelper.ApplicationReminderEmailTemplateId
+                    && c.Tokens["firstName"] == candidate.Candidate.FirstName
+                    && c.Tokens["daysRemaining"] == command.DaysUntilClosing.ToString()
+                    && c.Tokens["vacancy"] == recruitApiResponse.Title
+                    && c.Tokens["employer"] == recruitApiResponse.EmployerName
+                    && c.Tokens["location"] == $"{expectedAddress}"
                     && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("d MMM yyyy")
                     && !string.IsNullOrEmpty(c.Tokens["continueApplicationLink"])
                     && !string.IsNullOrEmpty(c.Tokens["vacancyUrl"])

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessVacancyClosedEarlyCommand.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessVacancyClosedEarlyCommand.cs
@@ -1,5 +1,5 @@
-using System.Net;
 using AutoFixture.NUnit3;
+using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.FindApprenticeshipJobs.Application.Commands;
@@ -14,6 +14,8 @@ using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
 using SFA.DAS.Testing.AutoFixture;
+using System.Net;
+using SFA.DAS.FindApprenticeshipJobs.Domain.Constants;
 
 namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Application;
 
@@ -24,10 +26,10 @@ public class WhenHandlingProcessVacancyClosedEarlyCommand
     [MoqInlineAutoData("address1", "address2", "address3", null, "postcode", "address3 (postcode)", AvailableWhere.OneLocation)]
     [MoqInlineAutoData("address1", "address2", null, null, "postcode", "address2 (postcode)", AvailableWhere.OneLocation)]
     [MoqInlineAutoData("address1", null, null, null, "postcode", "address1 (postcode)", AvailableWhere.OneLocation)]
-    [MoqInlineAutoData("address1", "address2", "address3", "address4", "postcode", "Recruiting nationally", AvailableWhere.AcrossEngland)]
-    [MoqInlineAutoData("address1", "address2", "address3", null, "postcode", "Recruiting nationally", AvailableWhere.AcrossEngland)]
-    [MoqInlineAutoData("address1", "address2", null, null, "postcode", "Recruiting nationally", AvailableWhere.AcrossEngland)]
-    [MoqInlineAutoData("address1", null, null, null, "postcode", "Recruiting nationally", AvailableWhere.AcrossEngland)]
+    [MoqInlineAutoData("address1", "address2", "address3", "address4", "postcode", EmailTemplateBuilderConstants.RecruitingNationally, AvailableWhere.AcrossEngland)]
+    [MoqInlineAutoData("address1", "address2", "address3", null, "postcode", EmailTemplateBuilderConstants.RecruitingNationally, AvailableWhere.AcrossEngland)]
+    [MoqInlineAutoData("address1", "address2", null, null, "postcode", EmailTemplateBuilderConstants.RecruitingNationally, AvailableWhere.AcrossEngland)]
+    [MoqInlineAutoData("address1", null, null, null, "postcode", EmailTemplateBuilderConstants.RecruitingNationally, AvailableWhere.AcrossEngland)]
     public async Task Then_The_Vacancy_Candidates_Are_Found_Emails_Sent_And_Application_Status_Updated(
         string address1,
         string address2,
@@ -47,7 +49,7 @@ public class WhenHandlingProcessVacancyClosedEarlyCommand
     {
         recruitApiResponse.EmployerLocationOption = employerLocationOption;
 
-        recruitApiResponse.EmployerLocations[0].AddressLine1 = address1;
+        recruitApiResponse.EmployerLocations![0].AddressLine1 = address1;
         recruitApiResponse.EmployerLocations[0].AddressLine2 = address2;
         recruitApiResponse.EmployerLocations[0].AddressLine3 = address3;
         recruitApiResponse.EmployerLocations[0].AddressLine4 = address4;
@@ -81,6 +83,72 @@ public class WhenHandlingProcessVacancyClosedEarlyCommand
                     (ApplicationStatus)c.Data.Operations[0].value == ApplicationStatus.Expired
                 )), Times.Once
                 
+            );
+            notificationService.Verify(x => x.Send(
+                It.Is<SendEmailCommand>(c =>
+                    c.RecipientsAddress == candidate.Candidate.Email
+                    && c.TemplateId == emailEnvironmentHelper.VacancyClosedEarlyTemplateId
+                    && c.Tokens["firstName"] == candidate.Candidate.FirstName
+                    && c.Tokens["vacancy"] == recruitApiResponse.Title
+                    && c.Tokens["employer"] == recruitApiResponse.EmployerName
+                    && c.Tokens["dateApplicationStarted"] == candidate.ApplicationCreatedDate.ToString("d MMM yyyy")
+                    && c.Tokens["location"] == expectedAddress
+                    && !string.IsNullOrEmpty(c.Tokens["vacancyUrl"])
+                    && !string.IsNullOrEmpty(c.Tokens["settingsUrl"])
+                )
+            ), Times.Once);
+        }
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Vacancy_EmployerLocation_Null_Candidates_Are_Found_Emails_Sent_And_Application_Status_Updated(
+        ProcessVacancyClosedEarlyCommand command,
+        GetCandidateApplicationApiResponse candidateApiResponseAll,
+        GetLiveVacancyApiResponse recruitApiResponse,
+        EmailEnvironmentHelper emailEnvironmentHelper,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+        [Frozen] Mock<INotificationService> notificationService,
+        ProcessVacancyClosedEarlyCommandHandler handler)
+    {
+        const string expectedAddress = "city (postcode)";
+
+        recruitApiResponse.EmployerLocationOption = null;
+
+        recruitApiResponse.Address!.AddressLine1 = "address1";
+        recruitApiResponse.Address.AddressLine2 = "address2";
+        recruitApiResponse.Address.AddressLine3 = "address3";
+        recruitApiResponse.Address.AddressLine4 = "city";
+        recruitApiResponse.Address.Postcode = "postcode";
+
+        candidateApiClient.Setup(x =>
+                x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>()))
+            .ReturnsAsync(new ApiResponse<string>("", HttpStatusCode.Accepted, ""));
+
+        var candidateGetRequestAll =
+            new GetCandidateApplicationsByVacancyRequest(command.VacancyReference.ToString(), null,
+                false);
+        candidateApiClient
+             .Setup(x => x.Get<GetCandidateApplicationApiResponse>(
+                 It.Is<GetCandidateApplicationsByVacancyRequest>(c =>
+                     c.GetUrl == candidateGetRequestAll.GetUrl))).ReturnsAsync(candidateApiResponseAll);
+        recruitApiClient
+            .Setup(x => x.Get<GetLiveVacancyApiResponse>(
+                It.Is<GetLiveVacancyApiRequest>(c =>
+                    c.GetUrl.Contains(command.VacancyReference.ToString()))))
+            .ReturnsAsync(recruitApiResponse);
+
+        await handler.Handle(command, CancellationToken.None);
+
+        foreach (var candidate in candidateApiResponseAll.Candidates)
+        {
+            candidateApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchApplicationApiRequest>(c =>
+                    c.PatchUrl.Contains(candidate.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+                    c.PatchUrl.Contains(candidate.Candidate.Id.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+                    c.Data.Operations[0].path == "/Status" &&
+                    (ApplicationStatus)c.Data.Operations[0].value == ApplicationStatus.Expired
+                )), Times.Once
+
             );
             notificationService.Verify(x => x.Send(
                 It.Is<SendEmailCommand>(c =>
@@ -136,7 +204,7 @@ public class WhenHandlingProcessVacancyClosedEarlyCommand
         foreach (var candidate in candidateApiResponseAll.Candidates)
         {
             var employmentWorkLocation =
-                EmailTemplateAddressExtension.GetEmploymentLocationCityNames(recruitApiResponse.EmployerLocations);
+                EmailTemplateAddressExtension.GetEmploymentLocationCityNames(recruitApiResponse.OtherAddresses);
 
             candidateApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchApplicationApiRequest>(c =>
                     c.PatchUrl.Contains(candidate.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
@@ -173,8 +241,9 @@ public class WhenHandlingProcessVacancyClosedEarlyCommand
         [Frozen] Mock<INotificationService> notificationService,
         ProcessVacancyClosedEarlyCommandHandler handler)
     {
+        const string expectedAddress = "Leeds (3 available locations)";
+
         recruitApiResponse.EmployerLocationOption = AvailableWhere.MultipleLocations;
-        const string expectedAddress = "Leeds and 2 other available locations";
         recruitApiResponse.EmployerLocations =
         [
             new Address {AddressLine3 = "Leeds", Postcode = "LS6"},
@@ -206,7 +275,82 @@ public class WhenHandlingProcessVacancyClosedEarlyCommand
         foreach (var candidate in candidateApiResponseAll.Candidates)
         {
             var employmentWorkLocation =
-                EmailTemplateAddressExtension.GetEmploymentLocationCityNames(recruitApiResponse.EmployerLocations);
+                EmailTemplateAddressExtension.GetEmploymentLocationCityNames(recruitApiResponse.OtherAddresses);
+
+            employmentWorkLocation.Should().Be(expectedAddress);
+
+            candidateApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchApplicationApiRequest>(c =>
+                    c.PatchUrl.Contains(candidate.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+                    c.PatchUrl.Contains(candidate.Candidate.Id.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+                    c.Data.Operations[0].path == "/Status" &&
+                    (ApplicationStatus)c.Data.Operations[0].value == ApplicationStatus.Expired
+                )), Times.Once
+
+            );
+            notificationService.Verify(x => x.Send(
+                It.Is<SendEmailCommand>(c =>
+                    c.RecipientsAddress == candidate.Candidate.Email
+                    && c.TemplateId == emailEnvironmentHelper.VacancyClosedEarlyTemplateId
+                    && c.Tokens["firstName"] == candidate.Candidate.FirstName
+                    && c.Tokens["vacancy"] == recruitApiResponse.Title
+                    && c.Tokens["employer"] == recruitApiResponse.EmployerName
+                    && c.Tokens["dateApplicationStarted"] == candidate.ApplicationCreatedDate.ToString("d MMM yyyy")
+                    && c.Tokens["location"] == expectedAddress
+                    && !string.IsNullOrEmpty(c.Tokens["vacancyUrl"])
+                    && !string.IsNullOrEmpty(c.Tokens["settingsUrl"])
+                )
+            ), Times.Once);
+        }
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Vacancy_With_Multiple_Locations_And_Candidates_Are_Found_Emails_Sent_And_Application_Status_Updated(
+        ProcessVacancyClosedEarlyCommand command,
+        GetCandidateApplicationApiResponse candidateApiResponseAll,
+        GetLiveVacancyApiResponse recruitApiResponse,
+        EmailEnvironmentHelper emailEnvironmentHelper,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+        [Frozen] Mock<INotificationService> notificationService,
+        ProcessVacancyClosedEarlyCommandHandler handler)
+    {
+        const string expectedAddress = "Leeds, Manchester, Sheffield";
+
+        recruitApiResponse.EmployerLocationOption = AvailableWhere.MultipleLocations;
+        recruitApiResponse.EmployerLocations =
+        [
+            new Address {AddressLine3 = "Leeds", Postcode = "LS6 8AA"},
+            new Address {AddressLine3 = "Manchester", Postcode = "MA1 1AN"},
+            new Address {AddressLine3 = "Sheffield", Postcode = "SF1 1AN"},
+            new Address {AddressLine3 = "Sheffield", Postcode = "SF1 1AN"},
+            new Address {AddressLine3 = "Manchester", Postcode = "MA1 1AN"},
+        ];
+
+        candidateApiClient.Setup(x =>
+                x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>()))
+            .ReturnsAsync(new ApiResponse<string>("", HttpStatusCode.Accepted, ""));
+
+        var candidateGetRequestAll =
+            new GetCandidateApplicationsByVacancyRequest(command.VacancyReference.ToString(), null,
+                false);
+        candidateApiClient
+             .Setup(x => x.Get<GetCandidateApplicationApiResponse>(
+                 It.Is<GetCandidateApplicationsByVacancyRequest>(c =>
+                     c.GetUrl == candidateGetRequestAll.GetUrl))).ReturnsAsync(candidateApiResponseAll);
+        recruitApiClient
+            .Setup(x => x.Get<GetLiveVacancyApiResponse>(
+                It.Is<GetLiveVacancyApiRequest>(c =>
+                    c.GetUrl.Contains(command.VacancyReference.ToString()))))
+            .ReturnsAsync(recruitApiResponse);
+
+        await handler.Handle(command, CancellationToken.None);
+
+        foreach (var candidate in candidateApiResponseAll.Candidates)
+        {
+            var employmentWorkLocation =
+                EmailTemplateAddressExtension.GetEmploymentLocationCityNames(recruitApiResponse.OtherAddresses);
+
+            employmentWorkLocation.Should().Be(expectedAddress);
 
             candidateApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchApplicationApiRequest>(c =>
                     c.PatchUrl.Contains(candidate.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
@@ -285,7 +285,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                     Title = "Software Developer",
                     VacancyReference = "12345",
                     EmployerName = "ABC Company",
-                    EmployerLocationOption = AvailableWhere.OneLocation,
+                    EmploymentLocationOption = AvailableWhere.OneLocation,
                     EmployerLocation = new Address
                     {
                         AddressLine1 = "123 Main St",
@@ -563,7 +563,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                         AddressLine1 = "123 Main St",
                         Postcode = "12345"
                     },
-                    EmployerLocationOption = AvailableWhere.MultipleLocations,
+                    EmploymentLocationOption = AvailableWhere.MultipleLocations,
                     OtherAddresses =
                     [
                         new Address
@@ -641,7 +641,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                         AddressLine1 = "123 Main St",
                         Postcode = "12345"
                     },
-                    EmployerLocationOption = AvailableWhere.AcrossEngland,
+                    EmploymentLocationOption = AvailableWhere.AcrossEngland,
                     OtherAddresses =
                     [
                         new Address

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
@@ -568,11 +568,6 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                     [
                         new Address
                         {
-                            AddressLine1 = "123 Main St",
-                            Postcode = "12345"
-                        },
-                        new Address
-                        {
                             AddressLine1 = "address 1",
                             Postcode = "postcode 1"
                         },

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/EmailTemplateBuilderTests.cs
@@ -291,7 +291,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                         AddressLine1 = "123 Main St",
                         Postcode = "12345"
                     },
-                    EmployerLocations =
+                    OtherAddresses =
                     [
                         new Address
                         {
@@ -409,7 +409,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                         AddressLine1 = "123 Main St",
                         Postcode = "12345"
                     },
-                    EmployerLocations =
+                    OtherAddresses =
                     [
                         new Address
                         {
@@ -564,7 +564,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                         Postcode = "12345"
                     },
                     EmployerLocationOption = AvailableWhere.MultipleLocations,
-                    EmployerLocations =
+                    OtherAddresses =
                     [
                         new Address
                         {
@@ -642,7 +642,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.EmailTemplates
                         Postcode = "12345"
                     },
                     EmployerLocationOption = AvailableWhere.AcrossEngland,
-                    EmployerLocations =
+                    OtherAddresses =
                     [
                         new Address
                         {

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.sln
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32929.385
@@ -12,6 +11,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.FindApprenticeshipJobs.UnitTests", "SFA.DAS.FindApprenticeshipJobs.UnitTests\SFA.DAS.FindApprenticeshipJobs.UnitTests.csproj", "{5CCD854C-BD68-4106-A551-1AF037F1BE0B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.FindApprenticeshipJobs.Api.UnitTests", "SFA.DAS.FindApprenticeshipJobs.Api.UnitTests\SFA.DAS.FindApprenticeshipJobs.Api.UnitTests.csproj", "{97FD5567-49A5-4DE1-96FC-0190EB6EEA5A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.SharedOuterApi.UnitTests", "..\Shared\SFA.DAS.SharedOuterApi.UnitTests\SFA.DAS.SharedOuterApi.UnitTests.csproj", "{BA42848C-142E-4452-F891-F4F9C7633D96}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +40,10 @@ Global
 		{97FD5567-49A5-4DE1-96FC-0190EB6EEA5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97FD5567-49A5-4DE1-96FC-0190EB6EEA5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97FD5567-49A5-4DE1-96FC-0190EB6EEA5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA42848C-142E-4452-F891-F4F9C7633D96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA42848C-142E-4452-F891-F4F9C7633D96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA42848C-142E-4452-F891-F4F9C7633D96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA42848C-142E-4452-F891-F4F9C7633D96}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
@@ -37,7 +37,7 @@ public class ProcessApplicationReminderCommandHandler(
         {
             AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
             AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.OtherAddresses),
-            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.EmployerLocations!.First()),
+            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address),
             _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address)
         };
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
@@ -33,28 +33,30 @@ public class ProcessApplicationReminderCommandHandler(
 
         await Task.WhenAll(vacancyTask, candidatesTask);
 
-        var employmentWorkLocation = vacancyTask.Result.EmployerLocationOption switch
+        var vacancy = vacancyTask.Result;
+        var candidates = candidatesTask.Result;
+
+        var employmentWorkLocation = vacancy.EmployerLocationOption switch
         {
             AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
-            AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.OtherAddresses),
-            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address),
-            _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address)
+            AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancy.OtherAddresses),
+            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.Address),
+            _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.Address)
         };
 
-        foreach (var candidate in candidatesTask.Result.Candidates)
+        foreach (var email in candidates.Candidates.Select(candidate => new SendSubmitApplicationEmailReminderTemplate(
+                     helper.ApplicationReminderEmailTemplateId,
+                     candidate.Candidate.Email,
+                     candidate.Candidate.FirstName,
+                     request.DaysUntilClosing,
+                     vacancy.Title,
+                     helper.VacancyUrl,
+                     vacancy.EmployerName,
+                     employmentWorkLocation,
+                     helper.CandidateApplicationUrl,
+                     vacancy.ClosingDate,
+                     helper.SettingsUrl)))
         {
-            var email = new SendSubmitApplicationEmailReminderTemplate(
-                helper.ApplicationReminderEmailTemplateId,
-                candidate.Candidate.Email,
-                candidate.Candidate.FirstName,
-                request.DaysUntilClosing,
-                vacancyTask.Result.Title,
-                helper.VacancyUrl,
-                vacancyTask.Result.EmployerName,
-                employmentWorkLocation,
-                helper.CandidateApplicationUrl,
-                vacancyTask.Result.ClosingDate,
-                helper.SettingsUrl);
             await notificationService.Send(new SendEmailCommand(email.TemplateId, email.RecipientAddress, email.Tokens));
         }
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
@@ -8,7 +8,6 @@ using SFA.DAS.Notifications.Messages.Commands;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
-using static SFA.DAS.FindApprenticeshipJobs.Application.Commands.SavedSearch.SendNotification.PostSendSavedSearchNotificationCommand;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Application.Commands;
 
@@ -37,7 +36,7 @@ public class ProcessApplicationReminderCommandHandler(
         var employmentWorkLocation = vacancyTask.Result.EmployerLocationOption switch
         {
             AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
-            AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.EmployerLocations),
+            AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.OtherAddresses),
             AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.EmployerLocations!.First()),
             _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address)
         };

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
@@ -32,7 +32,7 @@ public class ProcessVacancyClosedEarlyCommandHandler(
         var employmentWorkLocation = vacancyTask.Result.EmployerLocationOption switch
         {
             AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
-            AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.EmployerLocations),
+            AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.OtherAddresses),
             AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.EmployerLocations!.First()),
             _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address)
         };

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
@@ -29,15 +29,18 @@ public class ProcessVacancyClosedEarlyCommandHandler(
         var notificationTasks = new List<Task>();
         var updateCandidate = new List<Task>();
 
-        var employmentWorkLocation = vacancyTask.Result.EmployerLocationOption switch
+        var vacancy = vacancyTask.Result;
+        var allCandidateApplications = allCandidateApplicationsTask.Result;
+
+        var employmentWorkLocation = vacancy.EmployerLocationOption switch
         {
             AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
-            AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.OtherAddresses),
-            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address),
-            _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address)
+            AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancy.OtherAddresses),
+            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.Address),
+            _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.Address)
         };
 
-        foreach (var candidate in allCandidateApplicationsTask.Result.Candidates)
+        foreach (var candidate in allCandidateApplications.Candidates)
         {
             var jsonPatchDocument = new JsonPatchDocument<Domain.Models.Application>();
             jsonPatchDocument.Replace(x => x.Status, ApplicationStatus.Expired);
@@ -47,9 +50,9 @@ public class ProcessVacancyClosedEarlyCommandHandler(
                 helper.VacancyClosedEarlyTemplateId,
                 candidate.Candidate.Email,
                 candidate.Candidate.FirstName,
-                vacancyTask.Result.Title,
+                vacancy.Title,
                 helper.VacancyUrl,
-                vacancyTask.Result.EmployerName,
+                vacancy.EmployerName,
                 employmentWorkLocation, 
                 candidate.ApplicationCreatedDate,
                 helper.SettingsUrl);

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
@@ -33,7 +33,7 @@ public class ProcessVacancyClosedEarlyCommandHandler(
         {
             AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
             AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocationCityNames(vacancyTask.Result.OtherAddresses),
-            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.EmployerLocations!.First()),
+            AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address),
             _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancyTask.Result.Address)
         };
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommand.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommand.cs
@@ -40,7 +40,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Application.Commands.SavedSearch.SendNo
             public string? EmployerName { get; set; }
 
             public Address? EmployerLocation { get; set; }
-            public List<Address>? EmployerLocations { get; set; }
+            public List<Address>? OtherAddresses { get; set; }
             public AvailableWhere? EmployerLocationOption { get; set; }
 
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommand.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommand.cs
@@ -41,7 +41,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Application.Commands.SavedSearch.SendNo
 
             public Address? EmployerLocation { get; set; }
             public List<Address>? OtherAddresses { get; set; }
-            public AvailableWhere? EmployerLocationOption { get; set; }
+            public AvailableWhere? EmploymentLocationOption { get; set; }
 
 
             public string? Wage { get; set; }

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/SavedSearch/SendNotification/PostSendSavedSearchNotificationCommandHandler.cs
@@ -39,14 +39,14 @@ namespace SFA.DAS.FindApprenticeshipJobs.Application.Commands.SavedSearch.SendNo
             var searchParamsEmailSnippet = EmailTemplateBuilder.GetSavedSearchSearchParams(command.SearchTerm,
                 command.Distance,
                 command.Location,
-                (command.Categories != null && command.Categories.Any()) ? command.Categories?.Select(cat => cat.Name).ToList() : null,
+                command.Categories != null && command.Categories.Any() ? command.Categories?.Select(cat => cat.Name).ToList() : null,
                 command.Levels != null && command.Levels.Any() ? command.Levels.Select(lev => lev.Name).ToList() : null,
                 command.DisabilityConfident);
 
             var queryParameters = EmailTemplateBuilder.GetSavedSearchUrl(command.SearchTerm,
                 command.Distance,
                 command.Location,
-                (command.Categories != null && command.Categories.Any()) ? command.Categories?.Select(cat => cat.Id.ToString()).ToList() : null,
+                command.Categories != null && command.Categories.Any() ? command.Categories?.Select(cat => cat.Id.ToString()).ToList() : null,
                 command.Levels != null && command.Levels.Any() ? command.Levels.Select(lev => lev.Code.ToString()).ToList() : null,
                 command.DisabilityConfident);
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
@@ -5,6 +5,7 @@ using SFA.DAS.SharedOuterApi.Extensions;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using SFA.DAS.SharedOuterApi.Models;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
 {
@@ -78,10 +79,14 @@ namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
             {
                 string? trainingCourseText;
                 string? wageText;
+                
                 var employmentWorkLocation = vacancy.EmploymentLocationOption switch
                 {
                     AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
-                    AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocations(vacancy.OtherAddresses),
+                    AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocations(
+                        vacancy.OtherAddresses is { Count: > 0 }
+                        ? new List<Address> { vacancy.EmployerLocation! }.Concat(vacancy.OtherAddresses).ToList()
+                        : [ vacancy.EmployerLocation! ]),
                     AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.EmployerLocation),
                     _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.EmployerLocation)
                 };

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
@@ -82,7 +82,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
                 {
                     AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
                     AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocations(vacancy.OtherAddresses),
-                    AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.OtherAddresses!.First()),
+                    AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.EmployerLocation),
                     _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.EmployerLocation)
                 };
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
@@ -81,8 +81,8 @@ namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
                 var employmentWorkLocation = vacancy.EmployerLocationOption switch
                 {
                     AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
-                    AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocations(vacancy.EmployerLocations),
-                    AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.EmployerLocations!.First()),
+                    AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocations(vacancy.OtherAddresses),
+                    AvailableWhere.OneLocation => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.OtherAddresses!.First()),
                     _ => EmailTemplateAddressExtension.GetOneLocationCityName(vacancy.EmployerLocation)
                 };
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/EmailTemplateBuilder.cs
@@ -78,7 +78,7 @@ namespace SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates
             {
                 string? trainingCourseText;
                 string? wageText;
-                var employmentWorkLocation = vacancy.EmployerLocationOption switch
+                var employmentWorkLocation = vacancy.EmploymentLocationOption switch
                 {
                     AvailableWhere.AcrossEngland => EmailTemplateBuilderConstants.RecruitingNationally,
                     AvailableWhere.MultipleLocations => EmailTemplateAddressExtension.GetEmploymentLocations(vacancy.OtherAddresses),

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Responses/GetLiveVacanciesApiResponse.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Responses/GetLiveVacanciesApiResponse.cs
@@ -51,11 +51,8 @@ public class LiveVacancy
         get
         {
             if (EmployerLocationOption is not AvailableWhere.MultipleLocations) return null;
-            var firstAddress = EmployerLocations!.FirstOrDefault().ToSingleLineAddress();
             var otherAddresses = EmployerLocations?
-                .Skip(1)
                 .DistinctBy(x => x.ToSingleLineAddress())
-                .Where(x => x.ToSingleLineAddress() != firstAddress)
                 .ToList();
             return otherAddresses;
         }

--- a/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Extensions/EmailTemplateAddressExtensionTests.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Extensions/EmailTemplateAddressExtensionTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using SFA.DAS.SharedOuterApi.Extensions;
+using SFA.DAS.SharedOuterApi.Models;
+
+namespace SFA.DAS.SharedOuterApi.UnitTests.Extensions
+{
+    [TestFixture]
+    public class EmailTemplateAddressExtensionTests
+    {
+        [Test]
+        public void GetEmploymentLocations_ShouldReturnEmptyString_WhenAddressesIsEmpty()
+        {
+            // Arrange
+            var addresses = new List<Address>();
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetEmploymentLocations(addresses);
+
+            // Assert
+            result.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void GetEmploymentLocations_ShouldReturnCorrectString_WhenAddressesIsNotEmpty()
+        {
+            // Arrange
+            var addresses = new List<Address>
+            {
+                new Address { AddressLine1 = "123 Main St", Postcode = "12345" },
+                new Address { AddressLine1 = "456 Elm St", Postcode = "67890" }
+            };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetEmploymentLocations(addresses);
+
+            // Assert
+            result.Should().Be("123 Main St (12345) and 1 other available locations");
+        }
+
+        [Test]
+        public void GetOneLocationCityName_ShouldReturnEmptyString_WhenAddressIsNull()
+        {
+            // Act
+            var result = EmailTemplateAddressExtension.GetOneLocationCityName(null);
+
+            // Assert
+            result.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void GetOneLocationCityName_ShouldReturnPostcode_And_City()
+        {
+            // Arrange
+            var address = new Address { AddressLine1 = "123 Main St", Postcode = "12345" };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetOneLocationCityName(address);
+
+            // Assert
+            result.Should().Be("123 Main St (12345)");
+        }
+
+        [Test]
+        public void GetOneLocationCityName_ShouldReturnPostcode_WhenCityIsEmpty()
+        {
+            // Arrange
+            var address = new Address { Postcode = "12345" };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetOneLocationCityName(address);
+
+            // Assert
+            result.Should().Be("12345");
+        }
+
+        [Test]
+        public void GetOneLocationCityName_ShouldReturnCityAndPostcode_WhenCityIsNotEmpty()
+        {
+            // Arrange
+            var address = new Address { AddressLine1 = "123 Main St", AddressLine2 = "City", Postcode = "12345" };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetOneLocationCityName(address);
+
+            // Assert
+            result.Should().Be("City (12345)");
+        }
+
+        [Test]
+        public void GetEmploymentLocationCityNames_ShouldReturnCorrectString_WhenAddressesIsNotEmpty()
+        {
+            // Arrange
+            var addresses = new List<Address>
+            {
+                new Address { AddressLine1 = "123 Main St", AddressLine2 = "CityA", Postcode = "12345" },
+                new Address { AddressLine1 = "456 Elm St", AddressLine2 = "CityB", Postcode = "67890" },
+                new Address { AddressLine1 = "789 Oak St", AddressLine2 = "CityA", Postcode = "54321" }
+            };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetEmploymentLocationCityNames(addresses);
+
+            // Assert
+            result.Should().Be("CityA, CityB");
+        }
+
+        [Test]
+        public void GetEmploymentLocationCityNames_ShouldReturnCorrectString_WhenAllAddressesHaveSameCity()
+        {
+            // Arrange
+            var addresses = new List<Address>
+            {
+                new Address { AddressLine1 = "123 Main St", AddressLine2 = "CityA", Postcode = "12345" },
+                new Address { AddressLine1 = "456 Elm St", AddressLine2 = "CityA", Postcode = "67890" }
+            };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetEmploymentLocationCityNames(addresses);
+
+            // Assert
+            result.Should().Be("CityA (2 available locations)");
+        }
+    }
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Extensions/EmailTemplateAddressExtensionTests.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Extensions/EmailTemplateAddressExtensionTests.cs
@@ -39,6 +39,66 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Extensions
         }
 
         [Test]
+        public void GetEmploymentLocations_ShouldReturnCorrectString_With_Same_Cities()
+        {
+            // Arrange
+            var addresses = new List<Address>
+            {
+                new Address { AddressLine1 = "Coventry", Postcode = "CV2" },
+                new Address { AddressLine1 = "Leeds", Postcode = "LS6" },
+                new Address { AddressLine1 = "Leeds", Postcode = "LS16" },
+                new Address { AddressLine1 = "Leeds", Postcode = "LS9" },
+                new Address { AddressLine1 = "London", Postcode = "SW1A" },
+                new Address { AddressLine1 = "Newcastle", Postcode = "ST5" },
+            };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetEmploymentLocations(addresses);
+
+            // Assert
+            result.Should().Be("Coventry (CV2) and 5 other available locations");
+        }
+
+        [Test]
+        public void GetEmploymentLocations_ShouldReturnCorrectString_With_Same_Not_Alphabetical_Cities()
+        {
+            // Arrange
+            var addresses = new List<Address>
+            {
+                new Address { AddressLine1 = "Newcastle", Postcode = "ST5" },
+                new Address { AddressLine1 = "Coventry", Postcode = "CV2" },
+                new Address { AddressLine1 = "Leeds", Postcode = "LS6" },
+                new Address { AddressLine1 = "Leeds", Postcode = "LS16" },
+                new Address { AddressLine1 = "Leeds", Postcode = "LS9" },
+                new Address { AddressLine1 = "London", Postcode = "SW1A" },
+            };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetEmploymentLocations(addresses);
+
+            // Assert
+            result.Should().Be("Newcastle (ST5) and 5 other available locations");
+        }
+
+        [Test]
+        public void GetEmploymentLocations_ShouldReturnCorrectString_With_Same_Cities_With_Different_Postcodes()
+        {
+            // Arrange
+            var addresses = new List<Address>
+            {
+                new Address { AddressLine1 = "Leeds", Postcode = "LS6" },
+                new Address { AddressLine1 = "Leeds", Postcode = "LS16" },
+                new Address { AddressLine1 = "Leeds", Postcode = "LS9" },
+            };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetEmploymentLocations(addresses);
+
+            // Assert
+            result.Should().Be("Leeds (LS6) and 2 other available locations");
+        }
+
+        [Test]
         public void GetOneLocationCityName_ShouldReturnEmptyString_WhenAddressIsNull()
         {
             // Act
@@ -106,20 +166,39 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Extensions
         }
 
         [Test]
-        public void GetEmploymentLocationCityNames_ShouldReturnCorrectString_WhenAllAddressesHaveSameCity()
+        public void GetEmploymentLocationCityNames_ShouldReturnCorrectString_WhenAddressesIsNotEmpty_Not_In_Different_Ordering()
         {
             // Arrange
             var addresses = new List<Address>
             {
+                new Address { AddressLine1 = "456 Elm St", AddressLine2 = "CityB", Postcode = "67890" },
                 new Address { AddressLine1 = "123 Main St", AddressLine2 = "CityA", Postcode = "12345" },
-                new Address { AddressLine1 = "456 Elm St", AddressLine2 = "CityA", Postcode = "67890" }
+                new Address { AddressLine1 = "789 Oak St", AddressLine2 = "CityA", Postcode = "54321" }
             };
 
             // Act
             var result = EmailTemplateAddressExtension.GetEmploymentLocationCityNames(addresses);
 
             // Assert
-            result.Should().Be("CityA (2 available locations)");
+            result.Should().Be("CityA, CityB");
+        }
+
+        [Test]
+        public void GetEmploymentLocationCityNames_ShouldReturnCorrectString_WhenAddressesIsNotEmpty_Not_In_Different_Postcode()
+        {
+            // Arrange
+            var addresses = new List<Address>
+            {
+                new Address { AddressLine1 = "456 Elm St", AddressLine2 = "CityA", Postcode = "67890" },
+                new Address { AddressLine1 = "123 Main St", AddressLine2 = "CityA", Postcode = "67890" },
+                new Address { AddressLine1 = "789 Oak St", AddressLine2 = "CityA", Postcode = "67890" }
+            };
+
+            // Act
+            var result = EmailTemplateAddressExtension.GetEmploymentLocationCityNames(addresses);
+
+            // Assert
+            result.Should().Be("CityA (3 available locations)");
         }
     }
 }

--- a/src/Shared/SFA.DAS.SharedOuterApi/Extensions/EmailTemplateAddressExtension.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/Extensions/EmailTemplateAddressExtension.cs
@@ -27,12 +27,11 @@ namespace SFA.DAS.SharedOuterApi.Extensions
             var cityNames = addresses
                 .Select(address => address.GetLastNonEmptyField())
                 .Distinct()
-                .OrderBy(city => city)
                 .ToList();
 
             return cityNames.Count == 1 && addresses.Count > 1
                 ? $"{cityNames.First()} ({addresses.Count} available locations)"
-                : string.Join(", ", cityNames);
+                : string.Join(", ", cityNames.OrderBy(x => x));
         }
     }
 }


### PR DESCRIPTION
✨ Refactor address handling in API and tests

- Replaced `EmployerLocations` with `OtherAddresses` in `SavedSearchApiRequest.cs`.
- Updated tests in `WhenHandlingProcessApplicationReminder.cs` to use constants.
- Modified `WhenHandlingProcessVacancyClosedEarlyCommand.cs` for address consistency.
- Adjusted `EmailTemplateBuilder.cs` to reflect new property names.
- Added unit tests in `EmailTemplateAddressExtensionTests.cs` for address methods.

Changes made by Balaji Jambulingam