### PR TITLE
FAI-2360 Add year to dates in Notify emails - Application Reminder & Saved Search Alerts

### DIFF
--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessApplicationReminder.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Application/WhenHandlingProcessApplicationReminder.cs
@@ -86,7 +86,7 @@ public class WhenHandlingProcessApplicationReminder
                     && c.Tokens["vacancy"] == recruitApiResponse.Title
                     && c.Tokens["employer"] == recruitApiResponse.EmployerName 
                     && c.Tokens["location"] == $"{expectedAddress}"
-                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("d MMM yyyy") 
+                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("dddd d MMMM yyyy") 
                     && !string.IsNullOrEmpty(c.Tokens["continueApplicationLink"])
                     && !string.IsNullOrEmpty(c.Tokens["vacancyUrl"])
                     && !string.IsNullOrEmpty(c.Tokens["settingsUrl"])
@@ -147,7 +147,7 @@ public class WhenHandlingProcessApplicationReminder
                     && c.Tokens["vacancy"] == recruitApiResponse.Title
                     && c.Tokens["employer"] == recruitApiResponse.EmployerName
                     && c.Tokens["location"] == $"{employmentWorkLocation}"
-                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("d MMM yyyy")
+                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("dddd d MMMM yyyy")
                     && !string.IsNullOrEmpty(c.Tokens["continueApplicationLink"])
                     && !string.IsNullOrEmpty(c.Tokens["vacancyUrl"])
                     && !string.IsNullOrEmpty(c.Tokens["settingsUrl"])
@@ -219,7 +219,7 @@ public class WhenHandlingProcessApplicationReminder
                     && c.Tokens["vacancy"] == recruitApiResponse.Title
                     && c.Tokens["employer"] == recruitApiResponse.EmployerName
                     && c.Tokens["location"] == $"{expectedAddress}"
-                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("d MMM yyyy")
+                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("dddd d MMMM yyyy")
                     && !string.IsNullOrEmpty(c.Tokens["continueApplicationLink"])
                     && !string.IsNullOrEmpty(c.Tokens["vacancyUrl"])
                     && !string.IsNullOrEmpty(c.Tokens["settingsUrl"])
@@ -291,7 +291,7 @@ public class WhenHandlingProcessApplicationReminder
                     && c.Tokens["vacancy"] == recruitApiResponse.Title
                     && c.Tokens["employer"] == recruitApiResponse.EmployerName
                     && c.Tokens["location"] == $"{expectedAddress}"
-                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("d MMM yyyy")
+                    && c.Tokens["closingDate"] == recruitApiResponse.ClosingDate.ToString("dddd d MMMM yyyy")
                     && !string.IsNullOrEmpty(c.Tokens["continueApplicationLink"])
                     && !string.IsNullOrEmpty(c.Tokens["vacancyUrl"])
                     && !string.IsNullOrEmpty(c.Tokens["settingsUrl"])

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/WhenBuildingSendSubmitApplicationEmailReminderTemplate.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/EmailTemplates/WhenBuildingSendSubmitApplicationEmailReminderTemplate.cs
@@ -18,7 +18,7 @@ public class WhenBuildingSendSubmitApplicationEmailReminderTemplate
             {"vacancyUrl", vacancyUrl },
             {"employer", employer },
             {"location", location },
-            {"closingDate", closingDate.ToString("d MMM yyyy") },
+            {"closingDate", closingDate.ToString("dddd d MMMM yyyy") },
             {"continueApplicationLink", continueApplicationUrl },
             {"settingsUrl", settingsUrl }
         };

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/Extensions/DateTimeExtensionTests.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.UnitTests/Domain/Extensions/DateTimeExtensionTests.cs
@@ -1,0 +1,34 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.FindApprenticeshipJobs.Domain.Extensions;
+
+namespace SFA.DAS.FindApprenticeshipJobs.UnitTests.Domain.Extensions
+{
+    [TestFixture]
+    public class DateTimeExtensionTests
+    {
+        [TestCase(-1, "Closed on {0:dddd d MMMM yyyy}")] // Past date
+        [TestCase(0, "Closes today at 11:59pm")] // Today (internal)
+        [TestCase(0, "Closes today", true)] // Today (external)
+        [TestCase(1, "Closes tomorrow ({0:dddd d MMMM yyyy} at 11:59pm)")] // Tomorrow (internal)
+        [TestCase(1, "Closes tomorrow ({0:dddd d MMMM yyyy})", true)] // Tomorrow (external)
+        [TestCase(5, "Closes in 5 days ({0:dddd d MMMM yyyy} at 11:59pm)")] // Within 31 days (internal)
+        [TestCase(5, "Closes in 5 days ({0:dddd d MMMM yyyy})", true)] // Within 31 days (external)
+        [TestCase(31, "Closes in 31 days ({0:dddd d MMMM yyyy} at 11:59pm)")] // Exactly 31 days (internal)
+        [TestCase(31, "Closes in 31 days ({0:dddd d MMMM yyyy})", true)] // Exactly 31 days (external)
+        [TestCase(32, "Closes on {0:dddd d MMMM yyyy}")] // More than 31 days (internal)
+        [TestCase(32, "Closes on {0:dddd d MMMM yyyy}", true)] // More than 31 days (external)
+        public void GetClosingDate_ShouldReturnExpectedOutput(int daysFromToday, string expectedFormat, bool isExternalVacancy = false)
+        {
+            // Arrange
+            var closingDate = DateTime.UtcNow.Date.AddDays(daysFromToday);
+            var expectedResult = string.Format(expectedFormat, closingDate);
+
+            // Act
+            var result = DateTimeExtension.GetClosingDate(closingDate, isExternalVacancy);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+    }
+}

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearchVacancies/GetSavedSearchVacanciesQueryResult.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearchVacancies/GetSavedSearchVacanciesQueryResult.cs
@@ -1,4 +1,5 @@
 using SFA.DAS.FindApprenticeshipJobs.Application.Shared;
+using SFA.DAS.FindApprenticeshipJobs.Domain.Extensions;
 using SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Models;
 using SFA.DAS.VacancyServices.Wage;
@@ -54,7 +55,7 @@ public class GetSavedSearchVacanciesQueryResult
             {
                 Id = source.Id,
                 VacancyReference = source.VacancyReference,
-                ClosingDate = GetClosingDate(source.ClosingDate, !string.IsNullOrEmpty(source.ApplicationUrl)),
+                ClosingDate = DateTimeExtension.GetClosingDate(source.ClosingDate, !string.IsNullOrEmpty(source.ApplicationUrl)),
                 Title = source.Title,
                 EmployerName = source.EmployerName,
                 Wage = source.WageText,
@@ -67,21 +68,6 @@ public class GetSavedSearchVacanciesQueryResult
                 TrainingCourse = $"{source.CourseTitle} (level {source.CourseLevel})",
                 Distance = source.Distance.HasValue ? Math.Round(source.Distance.Value, 1) : null,
                 VacancySource = source.VacancySource,
-            };
-        }
-        private static string GetClosingDate(DateTime closingDate, bool isExternalVacancy = false)
-        {
-            var timeSuffix = isExternalVacancy ? string.Empty : " at 11:59pm";
-            var timeUntilClosing = closingDate.Date - DateTime.UtcNow;
-            var daysToExpiry = (int)Math.Ceiling(timeUntilClosing.TotalDays);
-
-            return daysToExpiry switch
-            {
-                < 0 => $"Closed on {closingDate:dddd d MMMM}",
-                0 => $"Closes today{timeSuffix}",
-                1 => $"Closes tomorrow ({closingDate:dddd d MMMM}{timeSuffix})",
-                <= 31 => $"Closes in {daysToExpiry} days ({closingDate:dddd d MMMM}{timeSuffix})",
-                _ => $"Closes on {closingDate:dddd d MMMM}"
             };
         }
     }

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/SendSubmitApplicationEmailReminderTemplate.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/EmailTemplates/SendSubmitApplicationEmailReminderTemplate.cs
@@ -15,8 +15,8 @@ public class SendSubmitApplicationEmailReminderTemplate : EmailTemplateArguments
             {"vacancy", vacancy },
             {"vacancyUrl", vacancyUrl },
             {"employer", employer },
-            {"location", location},
-            {"closingDate", closingDate.ToString("d MMM yyyy") },
+            {"location", location },
+            {"closingDate", closingDate.ToString("dddd d MMMM yyyy") },
             {"continueApplicationLink", continueApplicationUrl },
             {"settingsUrl", settingsUrl }
         };

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/Extensions/DateTimeExtension.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Domain/Extensions/DateTimeExtension.cs
@@ -1,0 +1,21 @@
+﻿namespace SFA.DAS.FindApprenticeshipJobs.Domain.Extensions
+{
+    public static class DateTimeExtension
+    {
+        public static string GetClosingDate(DateTime closingDate, bool isExternalVacancy = false)
+        {
+            var timeSuffix = isExternalVacancy ? string.Empty : " at 11:59pm";
+            var timeUntilClosing = closingDate.Date - DateTime.UtcNow;
+            var daysToExpiry = (int)Math.Ceiling(timeUntilClosing.TotalDays);
+
+            return daysToExpiry switch
+            {
+                < 0 => $"Closed on {closingDate:dddd d MMMM yyyy}",
+                0 => $"Closes today{timeSuffix}",
+                1 => $"Closes tomorrow ({closingDate:dddd d MMMM yyyy}{timeSuffix})",
+                <= 31 => $"Closes in {daysToExpiry} days ({closingDate:dddd d MMMM yyyy}{timeSuffix})",
+                _ => $"Closes on {closingDate:dddd d MMMM yyyy}"
+            };
+        }
+    }
+}


### PR DESCRIPTION
✨ Add DateTimeExtension for closing date formatting

- Introduced `DateTimeExtension` class for closing date logic.
- Replaced existing closing date method in `GetSavedSearchVacanciesQueryResult`.
- Enhanced date formatting for internal and external vacancies.
- Updated email templates to utilize the new closing date format.
- Unit tests were added to validate the new closing date functionality.

Changes made by Balaji Jambulingam