### PR TITLE
FAI-2431 Missing location on unsuccessful application email

### DIFF
--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Candidates/Commands/WhenHandlingCandidateApplicationStatusCommand.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Candidates/Commands/WhenHandlingCandidateApplicationStatusCommand.cs
@@ -96,7 +96,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
     }
     
     [Test, MoqAutoData]
-    public async Task Then_The_Command_Is_Handled_And_The_Api_Called_And_Success_Email_Sent_When_Successful_With_Old_Location_Values(
+    public async Task Then_The_Command_Is_Handled_And_The_Api_Called_And_Success_Email_Sent_When_Successful_With_Null_Or_Empty_Location_Values(
         EmailEnvironmentHelper emailEnvironmentHelper,
         CandidateApplicationStatusCommand request,
         GetCandidateApiResponse candidateResponse,
@@ -129,13 +129,13 @@ public class WhenHandlingCandidateApplicationStatusCommand
                 && c.Tokens["firstName"] == candidateResponse.FirstName
                 && c.Tokens["vacancy"] == request.VacancyTitle
                 && c.Tokens["employer"] == request.VacancyEmployerName
-                && c.Tokens["location"] == $"{request.VacancyCity}, {request.VacancyPostcode}"
+                && c.Tokens["location"] == "Unknown"
             )
         ), Times.Once);
     }
     
     [Test, MoqAutoData]
-    public async Task Then_The_Command_Is_Handled_And_The_Api_Called_And_Unsuccess_Email_Sent_When_Unsuccessful_With_Old_Location_Values(
+    public async Task Then_The_Command_Is_Handled_And_The_Api_Called_And_Unsuccess_Email_Sent_When_Unsuccessful_With_Null_Or_Empty_Location_Values(
         CandidateApplicationStatusCommand request,
         EmailEnvironmentHelper emailEnvironmentHelper,
         GetCandidateApiResponse candidateResponse,
@@ -168,7 +168,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
                 && c.Tokens["firstName"] == candidateResponse.FirstName
                 && c.Tokens["vacancy"] == request.VacancyTitle
                 && c.Tokens["employer"] == request.VacancyEmployerName
-                && c.Tokens["location"] == $"{request.VacancyCity}, {request.VacancyPostcode}"
+                && c.Tokens["location"] == "Unknown"
             )
         ), Times.Once);
     }

--- a/src/Recruit/SFA.DAS.Recruit/Application/Candidates/Commands/CandidateApplicationStatus/CandidateApplicationStatusCommandHandler.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Candidates/Commands/CandidateApplicationStatus/CandidateApplicationStatusCommandHandler.cs
@@ -68,7 +68,7 @@ public class CandidateApplicationStatusCommandHandler : IRequestHandler<Candidat
                 _emailEnvironmentHelper.SuccessfulApplicationEmailTemplateId, 
                 candidate.Body.Email,
                 candidate.Body.FirstName, request.VacancyTitle, request.VacancyEmployerName,
-                GetLocation(request));
+                GetLocation(request.VacancyLocation));
             sendEmailCommand = new SendEmailCommand(email.TemplateId, email.RecipientAddress, email.Tokens);
         }
         else
@@ -77,7 +77,7 @@ public class CandidateApplicationStatusCommandHandler : IRequestHandler<Candidat
                 _emailEnvironmentHelper.UnsuccessfulApplicationEmailTemplateId,
                 candidate.Body.Email,
                 candidate.Body.FirstName, request.VacancyTitle, request.VacancyEmployerName,
-                GetLocation(request),
+                GetLocation(request.VacancyLocation),
                 request.Feedback, _emailEnvironmentHelper.CandidateApplicationUrl);
             sendEmailCommand = new SendEmailCommand(unsuccessfulEmail.TemplateId, unsuccessfulEmail.RecipientAddress, unsuccessfulEmail.Tokens);
         }
@@ -86,18 +86,14 @@ public class CandidateApplicationStatusCommandHandler : IRequestHandler<Candidat
         return new Unit();
     }
 
-    private static string GetLocation(CandidateApplicationStatusCommand request)
+    /// <summary>
+    /// Gets the location of the vacancy from the request.
+    /// If the VacancyLocation is not provided, it returns "Unknown".
+    /// </summary>
+    /// <param name="vacancyLocation"></param>
+    /// <returns>The location of the vacancy or "Unknown" if not provided. This ensures that the email tokens always have a meaningful value, avoiding null or empty strings.</returns>
+    private static string GetLocation(string vacancyLocation)
     {
-        if (!string.IsNullOrWhiteSpace(request.VacancyLocation))
-        {
-            return request.VacancyLocation;
-        }
-
-        // TODO: remove once MultipleLocations is released
-        return string.IsNullOrEmpty(request.VacancyCity)
-            ? request.VacancyPostcode
-            : string.IsNullOrEmpty(request.VacancyPostcode)
-                ? request.VacancyCity
-                : $"{request.VacancyCity}, {request.VacancyPostcode}";
+        return !string.IsNullOrWhiteSpace(vacancyLocation) ? vacancyLocation : "Unknown";
     }
 }


### PR DESCRIPTION
✨ Update location handling in application status commands

- Rename test methods to handle null/empty location values.
- Align tests with new logic that defaults to "Unknown" location.
- Modify `GetLocation` method to accept a string parameter.
- Simplify location logic to ensure meaningful email tokens.
- Improve code clarity and maintainability by separating concerns.

Changes made by Balaji Jambulingam