### PR TITLE
CSP-1924: FAT Outer API: Cache Location API Response

### DIFF
--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/Courses/WhenCallingGetCourseByLarsCode.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/Courses/WhenCallingGetCourseByLarsCode.cs
@@ -30,13 +30,12 @@ public sealed class WhenCallingGetCourseByLarsCode
                 It.Is<GetCourseByLarsCodeQuery>(c =>
                     c.LarsCode.Equals(query.LarsCode) &&
                     c.Distance.Equals(query.Distance) &&
-                    c.Lat.Equals(query.Lat) &&
-                    c.Lon.Equals(query.Lon)
+                    c.Location.Equals(query.Location)
                 ),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(result);
 
-        var sut = await controller.GetCourseByLarsCode(query.LarsCode, query.Distance, query.Lat, query.Lon) as ObjectResult;
+        var sut = await controller.GetCourseByLarsCode(query.LarsCode, query.Distance, query.Location) as ObjectResult;
 
         Assert.That(sut, Is.Not.Null);
         Assert.That(sut.StatusCode, Is.EqualTo((int)HttpStatusCode.OK));
@@ -59,13 +58,12 @@ public sealed class WhenCallingGetCourseByLarsCode
                 It.Is<GetCourseByLarsCodeQuery>(c =>
                     c.LarsCode.Equals(query.LarsCode) &&
                     c.Distance.Equals(query.Distance) &&
-                    c.Lat.Equals(query.Lat) &&
-                    c.Lon.Equals(query.Lon)
+                    c.Location.Equals(query.Location)
                 ),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((GetCourseByLarsCodeQueryResult)null);
 
-        var sut = await controller.GetCourseByLarsCode(query.LarsCode, query.Distance, query.Lat, query.Lon) as NotFoundResult;
+        var sut = await controller.GetCourseByLarsCode(query.LarsCode, query.Distance, query.Location) as NotFoundResult;
 
         Assert.That(sut, Is.Not.Null);
         Assert.That(sut.StatusCode, Is.EqualTo((int)HttpStatusCode.NotFound));

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/Shortlist/WhenCallingPostToCreateShortlistUserItem.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/Shortlist/WhenCallingPostToCreateShortlistUserItem.cs
@@ -36,11 +36,11 @@ public class WhenCallingPostToCreateShortlistUserItem
                 It.Is<CreateShortlistForUserCommand>(command =>
                        command.ShortlistUserId == shortlistRequest.ShortlistUserId
                     && command.Ukprn.Equals(shortlistRequest.Ukprn)
-                    && command.LocationDescription.Equals(shortlistRequest.LocationDescription)
+                    && command.LocationName.Equals(shortlistRequest.LocationName)
                     && command.LarsCode.Equals(shortlistRequest.LarsCode)
                 ), It.IsAny<CancellationToken>()));
 
-        controllerResult.As<CreatedAtActionResult>().Should().NotBeNull();
-        controllerResult.As<CreatedAtActionResult>().Value.Should().BeEquivalentTo(expectedResult);
+        controllerResult.As<OkObjectResult>().Should().NotBeNull();
+        controllerResult.As<OkObjectResult>().Value.Should().BeEquivalentTo(expectedResult);
     }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/Shortlist/WhenCallingPostToCreateShortlistUserItem.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Controllers/Shortlist/WhenCallingPostToCreateShortlistUserItem.cs
@@ -34,9 +34,7 @@ public class WhenCallingPostToCreateShortlistUserItem
         mockMediator
             .Verify(mediator => mediator.Send(
                 It.Is<CreateShortlistForUserCommand>(command =>
-                    command.ShortlistUserId == shortlistRequest.ShortlistUserId
-                    && command.Lat.Equals(shortlistRequest.Lat)
-                    && command.Lon.Equals(shortlistRequest.Lon)
+                       command.ShortlistUserId == shortlistRequest.ShortlistUserId
                     && command.Ukprn.Equals(shortlistRequest.Ukprn)
                     && command.LocationDescription.Equals(shortlistRequest.LocationDescription)
                     && command.LarsCode.Equals(shortlistRequest.LarsCode)

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Services/WhenCallingCachedLocationLookupService.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Services/WhenCallingCachedLocationLookupService.cs
@@ -28,7 +28,7 @@ public sealed class WhenCallingCachedLocationLookupService
             .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{location}")
         ).ReturnsAsync(locationItem);
 
-        var result = await sut.GetCachedLocationInformation(location, 0, 0);
+        var result = await sut.GetCachedLocationInformation(location);
 
         Assert.That(result, Is.Not.Null);
 
@@ -65,7 +65,7 @@ public sealed class WhenCallingCachedLocationLookupService
             .Setup(a => a.GetLocationInformation(location, 0, 0, false)
         ).ReturnsAsync(locationItem);
         
-        var result = await sut.GetCachedLocationInformation(location, 0, 0);
+        var result = await sut.GetCachedLocationInformation(location);
 
         Assert.That(result, Is.Not.Null);
 
@@ -102,7 +102,7 @@ public sealed class WhenCallingCachedLocationLookupService
             .Setup(a => a.GetLocationInformation(location, 0, 0, false)
         ).ReturnsAsync((LocationItem)null);
 
-        var result = await sut.GetCachedLocationInformation(location, 0, 0);
+        var result = await sut.GetCachedLocationInformation(location);
 
         Assert.That(result, Is.Null);
 

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Services/WhenCallingCachedLocationLookupService.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Services/WhenCallingCachedLocationLookupService.cs
@@ -117,4 +117,31 @@ public sealed class WhenCallingCachedLocationLookupService
                 TimeSpan.FromHours(CachedLocationLookupService.LocationItemCacheExpirationInHours)
             ), Times.Never);
     }
+
+    [Test]
+    [MoqAutoData]
+    public async Task When_Location_Is_Null_Then_Null_Is_Returned(
+        [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
+        [Frozen] Mock<ILocationLookupService> _locationLookupService,
+        CachedLocationLookupService sut
+    )
+    {
+        var result = await sut.GetCachedLocationInformation(string.Empty);
+
+        Assert.That(result, Is.Null);
+
+        _cacheStorageServiceMock.Verify(x =>
+            x.RetrieveFromCache<LocationItem>(
+                It.IsAny<string>()
+            ), 
+            Times.Never
+        );
+
+        _cacheStorageServiceMock.Verify(x =>
+            x.SaveToCache(
+                It.IsAny<string>(),
+                It.IsAny<LocationItem>(),
+                TimeSpan.FromHours(CachedLocationLookupService.LocationItemCacheExpirationInHours)
+            ), Times.Never);
+    }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Services/WhenCallingCachedLocationLookupService.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api.UnitTests/Services/WhenCallingCachedLocationLookupService.cs
@@ -1,0 +1,120 @@
+﻿using AutoFixture.NUnit3;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.FindApprenticeshipTraining.Services;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using SFA.DAS.SharedOuterApi.Models;
+using SFA.DAS.Testing.AutoFixture;
+using System;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.FindApprenticeshipTraining.Api.UnitTests.Services;
+
+public sealed class WhenCallingCachedLocationLookupService
+{
+    [Test]
+    [MoqAutoData]
+    public async Task When_Cache_Hit_Then_Location_Is_Returned_From_The_Cache(
+        string locationName, 
+        string authorityName,
+        LocationItem locationItem,
+        [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
+        CachedLocationLookupService sut
+    )
+    {
+        var location = $"{locationName}, {authorityName}";
+
+        _cacheStorageServiceMock
+            .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{location}")
+        ).ReturnsAsync(locationItem);
+
+        var result = await sut.GetCachedLocationInformation(location, 0, 0);
+
+        Assert.That(result, Is.Not.Null);
+
+        _cacheStorageServiceMock.Verify(x =>
+               x.RetrieveFromCache<LocationItem>($"loc:{location}"
+            ), Times.Once);
+
+        _cacheStorageServiceMock.Verify(x =>
+            x.SaveToCache(
+                $"loc:{location}",
+                It.IsAny<LocationItem>(),
+                TimeSpan.FromHours(CachedLocationLookupService.LocationItemCacheExpirationInHours)
+            ), Times.Never);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task When_Cache_Miss_Then_Location_Is_Retrieved_From_Location_API_And_Saved_To_The_Cache(
+        string locationName,
+        string authorityName,
+        LocationItem locationItem,
+        [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
+        [Frozen] Mock<ILocationLookupService> _locationLookupService,
+        CachedLocationLookupService sut
+    )
+    {
+        var location = $"{locationName}, {authorityName}";
+
+        _cacheStorageServiceMock
+            .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{location}")
+        ).ReturnsAsync((LocationItem)null);
+
+        _locationLookupService
+            .Setup(a => a.GetLocationInformation(location, 0, 0, false)
+        ).ReturnsAsync(locationItem);
+        
+        var result = await sut.GetCachedLocationInformation(location, 0, 0);
+
+        Assert.That(result, Is.Not.Null);
+
+        _cacheStorageServiceMock.Verify(x =>
+               x.RetrieveFromCache<LocationItem>($"loc:{location}"
+            ), Times.Once);
+
+        _cacheStorageServiceMock.Verify(x =>
+            x.SaveToCache(
+                $"loc:{location}",
+                It.IsAny<LocationItem>(),
+                TimeSpan.FromHours(CachedLocationLookupService.LocationItemCacheExpirationInHours)
+            ), Times.Once);
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task When_Cache_Miss_And_Null_Location_API_Response_Then_Null_Is_Returned(
+        string locationName,
+        string authorityName,
+        LocationItem locationItem,
+        [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
+        [Frozen] Mock<ILocationLookupService> _locationLookupService,
+        CachedLocationLookupService sut
+    )
+    {
+        var location = $"{locationName}, {authorityName}";
+
+        _cacheStorageServiceMock
+            .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{location}")
+        ).ReturnsAsync((LocationItem)null);
+
+        _locationLookupService
+            .Setup(a => a.GetLocationInformation(location, 0, 0, false)
+        ).ReturnsAsync((LocationItem)null);
+
+        var result = await sut.GetCachedLocationInformation(location, 0, 0);
+
+        Assert.That(result, Is.Null);
+
+        _cacheStorageServiceMock.Verify(x =>
+               x.RetrieveFromCache<LocationItem>($"loc:{location}"
+            ), Times.Once);
+
+        _cacheStorageServiceMock.Verify(x =>
+            x.SaveToCache(
+                $"loc:{location}",
+                It.IsAny<LocationItem>(),
+                TimeSpan.FromHours(CachedLocationLookupService.LocationItemCacheExpirationInHours)
+            ), Times.Never);
+    }
+}

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/ApiRequests/CreateShortListRequest.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/ApiRequests/CreateShortListRequest.cs
@@ -5,8 +5,6 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.ApiRequests
     public class CreateShortListRequest
     {
         public Guid ShortlistUserId { get; set; }
-        public float? Lat { get; set; }
-        public float? Lon { get; set; }
         public int LarsCode { get; set; }
         public string LocationDescription { get; set; }
         public int Ukprn { get; set; }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/ApiRequests/CreateShortListRequest.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/ApiRequests/CreateShortListRequest.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 
-namespace SFA.DAS.FindApprenticeshipTraining.Api.ApiRequests
+namespace SFA.DAS.FindApprenticeshipTraining.Api.ApiRequests;
+
+public class CreateShortListRequest
 {
-    public class CreateShortListRequest
-    {
-        public Guid ShortlistUserId { get; set; }
-        public int LarsCode { get; set; }
-        public string LocationDescription { get; set; }
-        public int Ukprn { get; set; }
-    }
+    public Guid ShortlistUserId { get; set; }
+    public int LarsCode { get; set; }
+    public string LocationName { get; set; }
+    public int Ukprn { get; set; }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/AppStart/AddServiceRegistrationExtension.cs
@@ -26,6 +26,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.AppStart
             services.AddTransient<ICacheStorageService, CacheStorageService>();
             services.AddTransient<ICachedCoursesService, CachedCoursesService>();
             services.AddTransient<ILocationLookupService, LocationLookupService>();
+            services.AddTransient<ICachedLocationLookupService, CachedLocationLookupService>();
             services.AddTransient<IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration>, RoatpCourseManagementApiClient>();
         }
     }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/Controllers/CoursesController.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/Controllers/CoursesController.cs
@@ -75,13 +75,12 @@ public sealed class CoursesController(IMediator _mediator) : ControllerBase
     [Produces("application/json")]
     [ProducesResponseType(typeof(GetCourseByLarsCodeQueryResult), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetCourseByLarsCode([FromRoute] int larscode, [FromQuery] int? distance, [FromQuery] decimal? lat, [FromQuery] decimal? lon)
+    public async Task<IActionResult> GetCourseByLarsCode([FromRoute] int larscode, [FromQuery] int? distance, [FromQuery] string location)
     {
         var result = await _mediator.Send(new GetCourseByLarsCodeQuery
         {
             LarsCode = larscode,
-            Lat = lat,
-            Lon = lon,
+            Location = location,
             Distance = distance
         });
 

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/Controllers/ShortlistsController.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/Controllers/ShortlistsController.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using SFA.DAS.FindApprenticeshipTraining.Api.ApiRequests;
 using SFA.DAS.FindApprenticeshipTraining.Application.Shortlist.Commands.CreateShortlistForUser;
 using SFA.DAS.FindApprenticeshipTraining.Application.Shortlist.Commands.DeleteShortlistItem;
@@ -15,26 +15,28 @@ namespace SFA.DAS.FindApprenticeshipTraining.Api.Controllers;
 
 [ApiController]
 [Route("[controller]/")]
-public class ShortlistsController(IMediator _mediator, ILogger<ShortlistsController> _logger) : ControllerBase
+public class ShortlistsController(IMediator _mediator) : ControllerBase
 {
     [HttpPost]
     [Route("")]
+    [ProducesResponseType<PostShortListResponse>(StatusCodes.Status200OK)]
     public async Task<IActionResult> CreateShortlistForUser(CreateShortListRequest shortlistRequest)
     {
         PostShortListResponse result = await _mediator.Send(
             new CreateShortlistForUserCommand
             {
                 Ukprn = shortlistRequest.Ukprn,
-                LocationDescription = shortlistRequest.LocationDescription,
+                LocationName = shortlistRequest.LocationName,
                 LarsCode = shortlistRequest.LarsCode,
                 ShortlistUserId = shortlistRequest.ShortlistUserId
             });
 
-        return CreatedAtAction(nameof(GetShortlistsForUser), new { UserId = shortlistRequest.ShortlistUserId }, result);
+        return Ok(result);
     }
 
     [HttpDelete]
     [Route("{id}")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
     public async Task<IActionResult> DeleteShortlistItemForUser(Guid id)
     {
         await _mediator.Send(new DeleteShortlistItemCommand
@@ -46,9 +48,10 @@ public class ShortlistsController(IMediator _mediator, ILogger<ShortlistsControl
 
     [HttpGet]
     [Route("users/{userId}/count")]
+    [ProducesResponseType<GetShortlistCountForUserQueryResult>(StatusCodes.Status200OK)]
     public async Task<IActionResult> GetShortlistCountForUser(Guid userId)
     {
-        var result = await _mediator.Send(new GetShortlistCountForUserQuery(userId));
+        GetShortlistCountForUserQueryResult result = await _mediator.Send(new GetShortlistCountForUserQuery(userId));
         return Ok(result);
     }
 

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/Controllers/ShortlistsController.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/Controllers/ShortlistsController.cs
@@ -24,8 +24,6 @@ public class ShortlistsController(IMediator _mediator, ILogger<ShortlistsControl
         PostShortListResponse result = await _mediator.Send(
             new CreateShortlistForUserCommand
             {
-                Lat = shortlistRequest.Lat,
-                Lon = shortlistRequest.Lon,
                 Ukprn = shortlistRequest.Ukprn,
                 LocationDescription = shortlistRequest.LocationDescription,
                 LarsCode = shortlistRequest.LarsCode,

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/Properties/launchSettings.json
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.Api/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "SFA.DAS.FindApprenticeshipTraining.Api": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "applicationUrl": "https://localhost:5003;http://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Courses/Queries/GetCourseByLarsCode/WhenGettingCourseByLarsCode.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Courses/Queries/GetCourseByLarsCode/WhenGettingCourseByLarsCode.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using SFA.DAS.FindApprenticeshipTraining.Application.Courses.Queries.GetCourseByLarsCode;
 using SFA.DAS.SharedOuterApi.Configuration;
@@ -11,6 +10,7 @@ using SFA.DAS.SharedOuterApi.InnerApi.Responses.RoatpV2;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
 using SFA.DAS.Testing.AutoFixture;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -23,6 +23,7 @@ public sealed class WhenGettingCourseByLarsCode
 {
     private Mock<ICoursesApiClient<CoursesApiConfiguration>> _coursesApiClientMock;
     private Mock<IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration>> _roatpCourseManagementApiClientMock;
+    private Mock<ILocationLookupService> _locationLookupServiceMock;  
     private GetCourseByLarsCodeQueryHandler _handler;
 
     [SetUp]
@@ -30,10 +31,12 @@ public sealed class WhenGettingCourseByLarsCode
     {
         _coursesApiClientMock = new Mock<ICoursesApiClient<CoursesApiConfiguration>>();
         _roatpCourseManagementApiClientMock = new Mock<IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration>>();
+        _locationLookupServiceMock = new Mock<ILocationLookupService>();
 
         _handler = new GetCourseByLarsCodeQueryHandler(
             _coursesApiClientMock.Object,
-            _roatpCourseManagementApiClientMock.Object
+            _roatpCourseManagementApiClientMock.Object,
+            _locationLookupServiceMock.Object
         );
     }
 
@@ -163,9 +166,7 @@ public sealed class WhenGettingCourseByLarsCode
                 x.GetWithResponseCode<GetCourseTrainingProvidersCountResponse>(
                     It.Is<GetCourseTrainingProvidersCountRequest>(a => 
                         a.LarsCodes.SequenceEqual(new int[1] { query.LarsCode }) &&
-                        a.Distance.Equals(query.Distance) &&
-                        a.Latitude.Equals(query.Lat) &&
-                        a.Longitude.Equals(query.Lon)
+                        a.Distance.Equals(query.Distance)
                     )
                 )
             )
@@ -440,5 +441,57 @@ public sealed class WhenGettingCourseByLarsCode
             Assert.That(sut.TotalProvidersCount, Is.EqualTo(0));
             Assert.That(sut.ProvidersCountWithinDistance, Is.EqualTo(0));
         });
+    }
+
+    [Test]
+    [MoqAutoData]
+    public async Task Handle_Gets_Location_Information_And_Queries_Provider_Count_By_Longitude_And_Latitude(
+        LocationItem locationItem, 
+        StandardDetailResponse standardDetailsResponse,
+        GetCourseTrainingProvidersCountResponse courseTrainingProvidersCountResponse
+    )
+    {
+        var query = new GetCourseByLarsCodeQuery { LarsCode = 456, Location = "sw1", Distance = 10 };
+
+        _locationLookupServiceMock.Setup(x => 
+            x.GetLocationInformation(query.Location, 0, 0, false)
+        ).ReturnsAsync(locationItem);
+
+        _coursesApiClientMock
+            .Setup(x =>
+                x.GetWithResponseCode<StandardDetailResponse>(
+                    It.Is<GetStandardDetailsByIdRequest>(a =>
+                        a.Id.Equals(query.LarsCode.ToString())
+                    )
+                )
+            )
+            .ReturnsAsync(new ApiResponse<StandardDetailResponse>(standardDetailsResponse, HttpStatusCode.OK, string.Empty));
+
+        _roatpCourseManagementApiClientMock
+                .Setup(x =>
+                    x.GetWithResponseCode<GetCourseTrainingProvidersCountResponse>(
+                            It.Is<GetCourseTrainingProvidersCountRequest>(a =>
+                                a.LarsCodes.SequenceEqual(new int[1] { query.LarsCode }) &&
+                                a.Distance.Equals(query.Distance) &&
+                                a.Latitude.Equals((decimal?)locationItem.GeoPoint[0]) &&
+                                a.Longitude.Equals((decimal?)locationItem.GeoPoint[1])
+                            )
+                        )
+                    )
+                .ReturnsAsync(
+                    new ApiResponse<GetCourseTrainingProvidersCountResponse>(
+                        courseTrainingProvidersCountResponse,
+                        HttpStatusCode.OK,
+                        string.Empty
+                    )
+                );
+
+        var sut = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.That(sut, Is.Not.Null);
+
+        _locationLookupServiceMock.Verify(x =>
+            x.GetLocationInformation(query.Location, 0, 0, false
+        ), Times.Once);
     }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Courses/Queries/GetCourseByLarsCode/WhenGettingCourseByLarsCode.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Courses/Queries/GetCourseByLarsCode/WhenGettingCourseByLarsCode.cs
@@ -455,7 +455,7 @@ public sealed class WhenGettingCourseByLarsCode
         var query = new GetCourseByLarsCodeQuery { LarsCode = 456, Location = "sw1", Distance = 10 };
 
         _cachedLocationLookupService.Setup(x => 
-            x.GetCachedLocationInformation(query.Location, 0, 0, false)
+            x.GetCachedLocationInformation(query.Location, false)
         ).ReturnsAsync(locationItem);
 
         _coursesApiClientMock
@@ -492,7 +492,7 @@ public sealed class WhenGettingCourseByLarsCode
         Assert.That(sut, Is.Not.Null);
 
         _cachedLocationLookupService.Verify(x =>
-            x.GetCachedLocationInformation(query.Location, 0, 0, false
+            x.GetCachedLocationInformation(query.Location, false
         ), Times.Once);
     }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Courses/Queries/GetCourseByLarsCode/WhenGettingCourseByLarsCode.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Courses/Queries/GetCourseByLarsCode/WhenGettingCourseByLarsCode.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using NUnit.Framework;
 using SFA.DAS.FindApprenticeshipTraining.Application.Courses.Queries.GetCourseByLarsCode;
+using SFA.DAS.FindApprenticeshipTraining.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.InnerApi.Requests;
 using SFA.DAS.SharedOuterApi.InnerApi.Requests.RoatpV2;
@@ -23,7 +24,7 @@ public sealed class WhenGettingCourseByLarsCode
 {
     private Mock<ICoursesApiClient<CoursesApiConfiguration>> _coursesApiClientMock;
     private Mock<IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration>> _roatpCourseManagementApiClientMock;
-    private Mock<ILocationLookupService> _locationLookupServiceMock;  
+    private Mock<ICachedLocationLookupService> _cachedLocationLookupService;  
     private GetCourseByLarsCodeQueryHandler _handler;
 
     [SetUp]
@@ -31,12 +32,12 @@ public sealed class WhenGettingCourseByLarsCode
     {
         _coursesApiClientMock = new Mock<ICoursesApiClient<CoursesApiConfiguration>>();
         _roatpCourseManagementApiClientMock = new Mock<IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration>>();
-        _locationLookupServiceMock = new Mock<ILocationLookupService>();
+        _cachedLocationLookupService = new Mock<ICachedLocationLookupService>();
 
         _handler = new GetCourseByLarsCodeQueryHandler(
             _coursesApiClientMock.Object,
             _roatpCourseManagementApiClientMock.Object,
-            _locationLookupServiceMock.Object
+            _cachedLocationLookupService.Object
         );
     }
 
@@ -453,8 +454,8 @@ public sealed class WhenGettingCourseByLarsCode
     {
         var query = new GetCourseByLarsCodeQuery { LarsCode = 456, Location = "sw1", Distance = 10 };
 
-        _locationLookupServiceMock.Setup(x => 
-            x.GetLocationInformation(query.Location, 0, 0, false)
+        _cachedLocationLookupService.Setup(x => 
+            x.GetCachedLocationInformation(query.Location, 0, 0, false)
         ).ReturnsAsync(locationItem);
 
         _coursesApiClientMock
@@ -490,8 +491,8 @@ public sealed class WhenGettingCourseByLarsCode
 
         Assert.That(sut, Is.Not.Null);
 
-        _locationLookupServiceMock.Verify(x =>
-            x.GetLocationInformation(query.Location, 0, 0, false
+        _cachedLocationLookupService.Verify(x =>
+            x.GetCachedLocationInformation(query.Location, 0, 0, false
         ), Times.Once);
     }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Shortlist/Commands/WhenCreatingShortlistForUser.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Shortlist/Commands/WhenCreatingShortlistForUser.cs
@@ -33,7 +33,7 @@ public class WhenCreatingShortlistForUser
             .ReturnsAsync(new ApiResponse<PostShortListResponse>(expectedResult, HttpStatusCode.Created, ""));
 
         cachedLocationLookupService
-            .Setup(a => a.GetCachedLocationInformation(command.LocationDescription, false))
+            .Setup(a => a.GetCachedLocationInformation(command.LocationName, false))
             .ReturnsAsync(locationItem);
 
         //Act
@@ -43,11 +43,11 @@ public class WhenCreatingShortlistForUser
         roatpApiClient.Verify(x => x
             .PostWithResponseCode<PostShortListResponse>(It.Is<PostShortlistForUserRequest>(c =>
                    ((PostShortlistData)c.Data).Ukprn.Equals(command.Ukprn)
-                && ((PostShortlistData)c.Data).Latitude.Equals((float?)locationItem.Latitude)
-                && ((PostShortlistData)c.Data).Longitude.Equals((float?)locationItem.Longitude)
-                && ((PostShortlistData)c.Data).LocationDescription.Equals(command.LocationDescription)
+                && ((PostShortlistData)c.Data).Latitude.Equals(locationItem.Latitude)
+                && ((PostShortlistData)c.Data).Longitude.Equals(locationItem.Longitude)
+                && ((PostShortlistData)c.Data).LocationDescription.Equals(command.LocationName)
                 && ((PostShortlistData)c.Data).LarsCode.Equals(command.LarsCode)
-                && ((PostShortlistData)c.Data).UserId.Equals(command.ShortlistUserId)), false));
+                && ((PostShortlistData)c.Data).UserId.Equals(command.ShortlistUserId)), true));
         actualResult.Should().BeEquivalentTo(expectedResult);
     }
 
@@ -66,7 +66,7 @@ public class WhenCreatingShortlistForUser
             .ReturnsAsync(new ApiResponse<PostShortListResponse>(expectedResult, HttpStatusCode.Created, ""));
 
         cachedLocationLookupService
-            .Setup(a => a.GetCachedLocationInformation(command.LocationDescription, false))
+            .Setup(a => a.GetCachedLocationInformation(command.LocationName, false))
             .ReturnsAsync((LocationItem)null);
 
         //Act
@@ -78,9 +78,9 @@ public class WhenCreatingShortlistForUser
                    ((PostShortlistData)c.Data).Ukprn.Equals(command.Ukprn)
                 && ((PostShortlistData)c.Data).Latitude.Equals(null)
                 && ((PostShortlistData)c.Data).Longitude.Equals(null)
-                && ((PostShortlistData)c.Data).LocationDescription.Equals(command.LocationDescription)
+                && ((PostShortlistData)c.Data).LocationDescription.Equals(command.LocationName)
                 && ((PostShortlistData)c.Data).LarsCode.Equals(command.LarsCode)
-                && ((PostShortlistData)c.Data).UserId.Equals(command.ShortlistUserId)), false));
+                && ((PostShortlistData)c.Data).UserId.Equals(command.ShortlistUserId)), true));
         actualResult.Should().BeEquivalentTo(expectedResult);
     }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Shortlist/Commands/WhenCreatingShortlistForUser.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining.UnitTests/Application/Shortlist/Commands/WhenCreatingShortlistForUser.cs
@@ -7,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using SFA.DAS.FindApprenticeshipTraining.Application.Shortlist.Commands.CreateShortlistForUser;
 using SFA.DAS.FindApprenticeshipTraining.InnerApi.Requests;
+using SFA.DAS.FindApprenticeshipTraining.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
@@ -20,13 +21,20 @@ public class WhenCreatingShortlistForUser
     public async Task Then_Creates_The_Shortlist_From_The_Request_Calling_Shortlist_Api(
         PostShortListResponse expectedResult,
         CreateShortlistForUserCommand command,
+        LocationItem locationItem,
         [Frozen] Mock<IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration>> roatpApiClient,
-        CreateShortlistForUserCommandHandler sut)
+        [Frozen] Mock<ICachedLocationLookupService> cachedLocationLookupService,
+        CreateShortlistForUserCommandHandler sut
+    )
     {
         //Arrange
         roatpApiClient
             .Setup(x => x.PostWithResponseCode<PostShortListResponse>(It.IsAny<PostShortlistForUserRequest>(), It.IsAny<bool>()))
             .ReturnsAsync(new ApiResponse<PostShortListResponse>(expectedResult, HttpStatusCode.Created, ""));
+
+        cachedLocationLookupService
+            .Setup(a => a.GetCachedLocationInformation(command.LocationDescription, false))
+            .ReturnsAsync(locationItem);
 
         //Act
         PostShortListResponse actualResult = await sut.Handle(command, CancellationToken.None);
@@ -34,9 +42,42 @@ public class WhenCreatingShortlistForUser
         //Assert
         roatpApiClient.Verify(x => x
             .PostWithResponseCode<PostShortListResponse>(It.Is<PostShortlistForUserRequest>(c =>
-                ((PostShortlistData)c.Data).Latitude.Equals(command.Lat)
-                && ((PostShortlistData)c.Data).Longitude.Equals(command.Lon)
-                && ((PostShortlistData)c.Data).Ukprn.Equals(command.Ukprn)
+                   ((PostShortlistData)c.Data).Ukprn.Equals(command.Ukprn)
+                && ((PostShortlistData)c.Data).Latitude.Equals((float?)locationItem.Latitude)
+                && ((PostShortlistData)c.Data).Longitude.Equals((float?)locationItem.Longitude)
+                && ((PostShortlistData)c.Data).LocationDescription.Equals(command.LocationDescription)
+                && ((PostShortlistData)c.Data).LarsCode.Equals(command.LarsCode)
+                && ((PostShortlistData)c.Data).UserId.Equals(command.ShortlistUserId)), false));
+        actualResult.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Test, MoqAutoData]
+    public async Task When_Location_Is_Null_Then_Shortlist_Is_Created_With_No_Longitude_And_Latitude(
+        PostShortListResponse expectedResult,
+        CreateShortlistForUserCommand command,
+        [Frozen] Mock<IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration>> roatpApiClient,
+        [Frozen] Mock<ICachedLocationLookupService> cachedLocationLookupService,
+        CreateShortlistForUserCommandHandler sut
+    )
+    {
+        //Arrange
+        roatpApiClient
+            .Setup(x => x.PostWithResponseCode<PostShortListResponse>(It.IsAny<PostShortlistForUserRequest>(), It.IsAny<bool>()))
+            .ReturnsAsync(new ApiResponse<PostShortListResponse>(expectedResult, HttpStatusCode.Created, ""));
+
+        cachedLocationLookupService
+            .Setup(a => a.GetCachedLocationInformation(command.LocationDescription, false))
+            .ReturnsAsync((LocationItem)null);
+
+        //Act
+        PostShortListResponse actualResult = await sut.Handle(command, CancellationToken.None);
+
+        //Assert
+        roatpApiClient.Verify(x => x
+            .PostWithResponseCode<PostShortListResponse>(It.Is<PostShortlistForUserRequest>(c =>
+                   ((PostShortlistData)c.Data).Ukprn.Equals(command.Ukprn)
+                && ((PostShortlistData)c.Data).Latitude.Equals(null)
+                && ((PostShortlistData)c.Data).Longitude.Equals(null)
                 && ((PostShortlistData)c.Data).LocationDescription.Equals(command.LocationDescription)
                 && ((PostShortlistData)c.Data).LarsCode.Equals(command.LarsCode)
                 && ((PostShortlistData)c.Data).UserId.Equals(command.ShortlistUserId)), false));

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourseByLarsCode/GetCourseByLarsCodeQuery.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourseByLarsCode/GetCourseByLarsCodeQuery.cs
@@ -6,9 +6,7 @@ public class GetCourseByLarsCodeQuery : IRequest<GetCourseByLarsCodeQueryResult>
 {
     public int LarsCode { get; set; }
 
-    public decimal? Lon { get; set; }
-
-    public decimal? Lat { get; set; }
+    public string Location { get; set; }
 
     public int? Distance { get; set; }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourseByLarsCode/GetCourseByLarsCodeQueryHandler.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourseByLarsCode/GetCourseByLarsCodeQueryHandler.cs
@@ -9,7 +9,6 @@ using SFA.DAS.SharedOuterApi.InnerApi.Responses.Courses;
 using SFA.DAS.SharedOuterApi.InnerApi.Responses.RoatpV2;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,15 +41,15 @@ public sealed class GetCourseByLarsCodeQueryHandler(
             standardDetails.ApprenticeshipFunding[standardDetails.ApprenticeshipFunding.Count - 1] :
         null;
 
-        LocationItem locationItem = await _cachedLocationLookupService.GetCachedLocationInformation(query.Location, 0, 0);
+        LocationItem locationItem = await _cachedLocationLookupService.GetCachedLocationInformation(query.Location);
 
         var courseTrainingProvidersCountResponse =
             await _roatpCourseManagementApiClient.GetWithResponseCode<GetCourseTrainingProvidersCountResponse>(
                 new GetCourseTrainingProvidersCountRequest(
                     [query.LarsCode],
                     query.Distance,
-                    (decimal?)locationItem?.GeoPoint?[0] ?? null,
-                    (decimal?)locationItem?.GeoPoint?[1] ?? null
+                    locationItem?.Latitude,
+                    locationItem?.Longitude
                 )
         );
 

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourseByLarsCode/GetCourseByLarsCodeQueryHandler.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourseByLarsCode/GetCourseByLarsCodeQueryHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using SFA.DAS.FindApprenticeshipTraining.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.InnerApi.Requests;
@@ -18,7 +19,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.Courses.Queries.GetCour
 public sealed class GetCourseByLarsCodeQueryHandler(
     ICoursesApiClient<CoursesApiConfiguration> _coursesApiClient,
     IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration> _roatpCourseManagementApiClient,
-    ILocationLookupService _locationLookupService
+    ICachedLocationLookupService _cachedLocationLookupService
 ) : IRequestHandler<GetCourseByLarsCodeQuery, GetCourseByLarsCodeQueryResult>
 {
     public const string KsbsSkillsType = "Skill";
@@ -41,7 +42,7 @@ public sealed class GetCourseByLarsCodeQueryHandler(
             standardDetails.ApprenticeshipFunding[standardDetails.ApprenticeshipFunding.Count - 1] :
         null;
 
-        LocationItem locationItem = await _locationLookupService.GetLocationInformation(query.Location, 0, 0);
+        LocationItem locationItem = await _cachedLocationLookupService.GetCachedLocationInformation(query.Location, 0, 0);
 
         var courseTrainingProvidersCountResponse =
             await _roatpCourseManagementApiClient.GetWithResponseCode<GetCourseTrainingProvidersCountResponse>(

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourseProviders/GetTrainingCourseProvidersQueryHandler.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourseProviders/GetTrainingCourseProvidersQueryHandler.cs
@@ -1,78 +1,70 @@
 using MediatR;
 using SFA.DAS.FindApprenticeshipTraining.InnerApi.Requests;
 using SFA.DAS.FindApprenticeshipTraining.InnerApi.Responses;
+using SFA.DAS.FindApprenticeshipTraining.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.InnerApi.Requests;
 using SFA.DAS.SharedOuterApi.Interfaces;
-using System.Collections.Generic;
+using SFA.DAS.SharedOuterApi.Models;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace SFA.DAS.FindApprenticeshipTraining.Application.Courses.Queries.GetCourseProviders
+namespace SFA.DAS.FindApprenticeshipTraining.Application.Courses.Queries.GetCourseProviders;
+
+public class GetTrainingCourseProvidersQueryHandler(IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration> _roatpCourseManagementApiClient, ICachedLocationLookupService _cachedLocationLookupService, ICoursesApiClient<CoursesApiConfiguration> coursesApiClient) : IRequestHandler<GetCourseProvidersQuery, GetCourseProvidersResponse>
 {
-    public class GetTrainingCourseProvidersQueryHandler(IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration> _roatpCourseManagementApiClient, ILocationLookupService locationLookupService, ICoursesApiClient<CoursesApiConfiguration> coursesApiClient) : IRequestHandler<GetCourseProvidersQuery, GetCourseProvidersResponse>
+    public async Task<GetCourseProvidersResponse> Handle(GetCourseProvidersQuery request, CancellationToken cancellationToken)
     {
+        LocationItem locationItem = null;
 
-        public async Task<GetCourseProvidersResponse> Handle(GetCourseProvidersQuery request,
-            CancellationToken cancellationToken)
+        if (!string.IsNullOrWhiteSpace(request.Location))
         {
-            decimal? latitude = null;
-            decimal? longitude = null;
+            locationItem = await _cachedLocationLookupService.GetCachedLocationInformation(request.Location);
 
-            if (request.Location != null)
+            if (locationItem is null)
             {
-                var location = await locationLookupService.GetLocationInformation(request.Location, 0, 0);
+                GetStandardsListItem standard = await coursesApiClient.Get<GetStandardsListItem>(new GetStandardRequest(request.Id));
 
-                if (location == null)
+                var standardName = standard != null ? $"{standard.Title} (level {standard.Level})" : string.Empty;
+
+                return new GetCourseProvidersResponse
                 {
-                    GetStandardsListItem standard =
-                        await coursesApiClient.Get<GetStandardsListItem>(new GetStandardRequest(request.Id));
-
-                    var standardName = standard != null ? $"{standard.Title} (level {standard.Level})" : "";
-
-                    var responseToSendBack = new GetCourseProvidersResponse
-                    {
-                        PageSize = 10,
-                        Page = 1,
-                        LarsCode = request.Id,
-                        Providers = new List<ProviderData>(),
-                        QarPeriod = string.Empty,
-                        ReviewPeriod = string.Empty,
-                        StandardName = standardName,
-                        TotalCount = 0,
-                        TotalPages = 0
-                    };
-
-                    return responseToSendBack;
-                }
-
-                latitude = (decimal)location.GeoPoint[0];
-                longitude = (decimal)location.GeoPoint[1];
+                    PageSize = 10,
+                    Page = 1,
+                    LarsCode = request.Id,
+                    Providers = [],
+                    QarPeriod = string.Empty,
+                    ReviewPeriod = string.Empty,
+                    StandardName = standardName,
+                    TotalCount = 0,
+                    TotalPages = 0
+                };
             }
-
-            var response =
-                await _roatpCourseManagementApiClient.GetWithResponseCode<GetCourseProvidersResponse>(
-                    new GetProvidersByCourseIdRequest()
-                    {
-                        CourseId = request.Id,
-                        OrderBy = request.OrderBy,
-                        Distance = request.Distance,
-                        Latitude = latitude,
-                        Longitude = longitude,
-                        Location = request.Location,
-                        DeliveryModes = request.DeliveryModes,
-                        EmployerProviderRatings = request.EmployerProviderRatings,
-                        ApprenticeProviderRatings = request.ApprenticeProviderRatings,
-                        Qar = request.Qar,
-                        Page = request.Page,
-                        PageSize = request.PageSize,
-                        UserId = request.ShortlistUserId
-                    });
-
-            return ApiResponseErrorChecking.IsSuccessStatusCode(response.StatusCode)
-                    ? response.Body
-                    : new GetCourseProvidersResponse();
         }
+
+        var response =
+            await _roatpCourseManagementApiClient.GetWithResponseCode<GetCourseProvidersResponse>(
+                new GetProvidersByCourseIdRequest()
+                {
+                    CourseId = request.Id,
+                    OrderBy = request.OrderBy,
+                    Distance = request.Distance,
+                    Latitude = locationItem?.Latitude,
+                    Longitude = locationItem?.Longitude,
+                    Location = request.Location,
+                    DeliveryModes = request.DeliveryModes,
+                    EmployerProviderRatings = request.EmployerProviderRatings,
+                    ApprenticeProviderRatings = request.ApprenticeProviderRatings,
+                    Qar = request.Qar,
+                    Page = request.Page,
+                    PageSize = request.PageSize,
+                    UserId = request.ShortlistUserId
+                }
+            );
+
+        return ApiResponseErrorChecking.IsSuccessStatusCode(response.StatusCode)
+                ? response.Body
+                : new GetCourseProvidersResponse();
     }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourses/GetCoursesQueryHandler.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Courses/Queries/GetCourses/GetCoursesQueryHandler.cs
@@ -70,8 +70,8 @@ public sealed class GetCoursesQueryHandler(
                 new GetCourseTrainingProvidersCountRequest(
                     pagedStandards.Select(a => a.LarsCode).ToArray(),
                     query.Distance,
-                    (decimal?)locationItem?.GeoPoint?[0] ?? null,
-                    (decimal?)locationItem?.GeoPoint?[1] ?? null
+                    locationItem?.Latitude,
+                    locationItem?.Longitude
                 )
         );
 

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Shortlist/Commands/CreateShortlistForUser/CreateShortlistForUserCommand.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Shortlist/Commands/CreateShortlistForUser/CreateShortlistForUserCommand.cs
@@ -2,15 +2,12 @@
 using MediatR;
 using SFA.DAS.FindApprenticeshipTraining.InnerApi.Requests;
 
-namespace SFA.DAS.FindApprenticeshipTraining.Application.Shortlist.Commands.CreateShortlistForUser
+namespace SFA.DAS.FindApprenticeshipTraining.Application.Shortlist.Commands.CreateShortlistForUser;
+
+public class CreateShortlistForUserCommand : IRequest<PostShortListResponse>
 {
-    public class CreateShortlistForUserCommand : IRequest<PostShortListResponse>
-    {
-        public float? Lat { get; set; }
-        public float? Lon { get; set; }
-        public int Ukprn { get; set; }
-        public string LocationDescription { get; set; }
-        public int LarsCode { get; set; }
-        public Guid ShortlistUserId { get; set; }
-    }
+    public int Ukprn { get; set; }
+    public string LocationDescription { get; set; }
+    public int LarsCode { get; set; }
+    public Guid ShortlistUserId { get; set; }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Shortlist/Commands/CreateShortlistForUser/CreateShortlistForUserCommand.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Shortlist/Commands/CreateShortlistForUser/CreateShortlistForUserCommand.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.FindApprenticeshipTraining.Application.Shortlist.Commands.Crea
 public class CreateShortlistForUserCommand : IRequest<PostShortListResponse>
 {
     public int Ukprn { get; set; }
-    public string LocationDescription { get; set; }
+    public string LocationName { get; set; }
     public int LarsCode { get; set; }
     public Guid ShortlistUserId { get; set; }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Shortlist/Commands/CreateShortlistForUser/CreateShortlistForUserCommandHandler.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Shortlist/Commands/CreateShortlistForUser/CreateShortlistForUserCommandHandler.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using MediatR;
 using SFA.DAS.FindApprenticeshipTraining.InnerApi.Requests;
+using SFA.DAS.FindApprenticeshipTraining.Services;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Extensions;
 using SFA.DAS.SharedOuterApi.Interfaces;
@@ -9,17 +10,22 @@ using SFA.DAS.SharedOuterApi.Models;
 
 namespace SFA.DAS.FindApprenticeshipTraining.Application.Shortlist.Commands.CreateShortlistForUser;
 
-public class CreateShortlistForUserCommandHandler(IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration> _roatpCourseManagementApiClient) : IRequestHandler<CreateShortlistForUserCommand, PostShortListResponse>
+public class CreateShortlistForUserCommandHandler(
+    IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration> _roatpCourseManagementApiClient,
+    ICachedLocationLookupService _cachedLocationLookupService
+) : IRequestHandler<CreateShortlistForUserCommand, PostShortListResponse>
 {
     public async Task<PostShortListResponse> Handle(CreateShortlistForUserCommand request, CancellationToken cancellationToken)
     {
+        LocationItem locationItem = await _cachedLocationLookupService.GetCachedLocationInformation(request.LocationDescription);
+
         ApiResponse<PostShortListResponse> response = await _roatpCourseManagementApiClient.PostWithResponseCode<PostShortListResponse>(
             new PostShortlistForUserRequest
             {
                 Data = new PostShortlistData
                 {
-                    Latitude = request.Lat,
-                    Longitude = request.Lon,
+                    Latitude = (float?)locationItem?.Latitude,
+                    Longitude = (float?)locationItem?.Longitude,
                     Ukprn = request.Ukprn,
                     LocationDescription = request.LocationDescription,
                     LarsCode = request.LarsCode,

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Shortlist/Commands/CreateShortlistForUser/CreateShortlistForUserCommandHandler.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Application/Shortlist/Commands/CreateShortlistForUser/CreateShortlistForUserCommandHandler.cs
@@ -17,22 +17,22 @@ public class CreateShortlistForUserCommandHandler(
 {
     public async Task<PostShortListResponse> Handle(CreateShortlistForUserCommand request, CancellationToken cancellationToken)
     {
-        LocationItem locationItem = await _cachedLocationLookupService.GetCachedLocationInformation(request.LocationDescription);
+        LocationItem locationItem = await _cachedLocationLookupService.GetCachedLocationInformation(request.LocationName);
 
         ApiResponse<PostShortListResponse> response = await _roatpCourseManagementApiClient.PostWithResponseCode<PostShortListResponse>(
             new PostShortlistForUserRequest
             {
                 Data = new PostShortlistData
                 {
-                    Latitude = (float?)locationItem?.Latitude,
-                    Longitude = (float?)locationItem?.Longitude,
+                    Latitude = locationItem?.Latitude,
+                    Longitude = locationItem?.Longitude,
                     Ukprn = request.Ukprn,
-                    LocationDescription = request.LocationDescription,
+                    LocationDescription = request.LocationName,
                     LarsCode = request.LarsCode,
                     UserId = request.ShortlistUserId
                 }
             },
-            false);
+            true);
 
         response.EnsureSuccessStatusCode();
 

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/InnerApi/Requests/PostShortlistForUserRequest.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/InnerApi/Requests/PostShortlistForUserRequest.cs
@@ -15,12 +15,13 @@ namespace SFA.DAS.FindApprenticeshipTraining.InnerApi.Requests
         public int Ukprn { get; set; }
         public int LarsCode { get; set; }
         public string LocationDescription { get; set; }
-        public float? Latitude { get; set; }
-        public float? Longitude { get; set; }
+        public decimal? Latitude { get; set; }
+        public decimal? Longitude { get; set; }
     }
 
     public class PostShortListResponse
     {
         public Guid ShortlistId { get; set; }
+        public bool IsCreated { get; set; }
     }
 }

--- a/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Services/CachedLocationLookupService.cs
+++ b/src/FindApprenticeshipTraining/SFA.DAS.FindApprenticeshipTraining/Services/CachedLocationLookupService.cs
@@ -1,0 +1,46 @@
+﻿using SFA.DAS.SharedOuterApi.Interfaces;
+using SFA.DAS.SharedOuterApi.Models;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.FindApprenticeshipTraining.Services;
+
+public interface ICachedLocationLookupService
+{
+    Task<LocationItem> GetCachedLocationInformation(string location, double lat, double lon, bool includeDistrictNameInPostcodeDisplayName = false);
+}
+
+public sealed class CachedLocationLookupService : ICachedLocationLookupService
+{
+    private readonly ICacheStorageService _cacheStorageService;
+
+    private readonly ILocationLookupService _locationLookupService;
+
+    public const int LocationItemCacheExpirationInHours = 1;
+
+    public CachedLocationLookupService(ICacheStorageService cacheStorageService, ILocationLookupService locationLookupService)
+    {
+        _cacheStorageService = cacheStorageService;
+        _locationLookupService = locationLookupService;
+    }
+
+    public async Task<LocationItem> GetCachedLocationInformation(string location, double lat, double lon, bool includeDistrictNameInPostcodeDisplayName = false)
+    {
+        LocationItem locationItem = await _cacheStorageService.RetrieveFromCache<LocationItem>($"loc:{location}");
+
+        if (locationItem is not null)
+        {
+            return locationItem;
+        }
+
+        locationItem = await _locationLookupService.GetLocationInformation(location, 0, 0);
+
+        if (locationItem is not null)
+        {
+            await _cacheStorageService.SaveToCache($"loc:{location}", locationItem, TimeSpan.FromHours(LocationItemCacheExpirationInHours));
+        }
+
+        return locationItem;
+    }
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Models/WhenCreatingLocationItemModelTests.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Models/WhenCreatingLocationItemModelTests.cs
@@ -1,0 +1,55 @@
+﻿using FluentAssertions;
+using SFA.DAS.SharedOuterApi.Models;
+
+namespace SFA.DAS.SharedOuterApi.UnitTests.Models;
+
+public sealed class WhenCreatingLocationItemModelTests
+{
+    [Test]
+    public void When_GeoPoints_Are_Valid_Then_Latitude_An_Longitude_Should_Return_Correct_Values()
+    {
+        var geoPoint = new double[] { 52.123456, -1.987654 };
+        var locationItem = new LocationItem("Location", geoPoint, "UK");
+
+        locationItem.Latitude.Should().Be((decimal?)52.123456m);
+        locationItem.Longitude.Should().Be((decimal?)(-1.987654m));
+    }
+
+    [Test]
+    public void When_GeoPoints_Is_Null_Then_Latitude_An_Longitude_Should_Return_Null()
+    {
+        var locationItem = new LocationItem("Test Location", null, "UK");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(locationItem.Latitude, Is.Null);
+            Assert.That(locationItem.Longitude, Is.Null);
+        });
+    }
+
+    [Test]
+    public void When_GeoPoints_Is_Empty_Then_Latitude_An_Longitude_Should_Return_Null()
+    {
+        var locationItem = new LocationItem("Location", [], "UK");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(locationItem.Latitude, Is.Null);
+            Assert.That(locationItem.Longitude, Is.Null);
+        });
+    }
+
+    [Test]
+    public void When_GeoPoints_Has_One_Item_Then_Latitude_Should_Only_Be_Returned()
+    {
+        var geoPoint = new double[] { 40.712776 };
+        var locationItem = new LocationItem("Test Location", geoPoint, "USA");
+
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(locationItem.Latitude, Is.EqualTo((decimal?)40.712776m));
+            Assert.That(locationItem.Longitude, Is.Null);
+        });
+    }
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Services/LocationLookupServiceTests/WhenCallingGetExactMatchAddresses.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Services/LocationLookupServiceTests/WhenCallingGetExactMatchAddresses.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 using Moq;
-using NUnit.Framework;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.InnerApi.Requests;
 using SFA.DAS.SharedOuterApi.InnerApi.Responses;
@@ -17,13 +16,15 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
     public class WhenCallingGetExactMatchAddresses
     {
         private Mock<ILocationApiClient<LocationApiConfiguration>> _locationApiClientMock;
+        private Mock<ICacheStorageService> _cacheStorageService;
         private LocationLookupService _sut;
 
         [SetUp]
         public void Before_Each_Test()
         {
             _locationApiClientMock = new Mock<ILocationApiClient<LocationApiConfiguration>>();
-            _sut = new LocationLookupService(_locationApiClientMock.Object);
+            _cacheStorageService = new Mock<ICacheStorageService>();
+            _sut = new LocationLookupService(_locationApiClientMock.Object, _cacheStorageService.Object);
         }
 
         [Test]

--- a/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Services/LocationLookupServiceTests/WhenCallingGetExactMatchAddresses.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Services/LocationLookupServiceTests/WhenCallingGetExactMatchAddresses.cs
@@ -16,15 +16,13 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
     public class WhenCallingGetExactMatchAddresses
     {
         private Mock<ILocationApiClient<LocationApiConfiguration>> _locationApiClientMock;
-        private Mock<ICacheStorageService> _cacheStorageService;
         private LocationLookupService _sut;
 
         [SetUp]
         public void Before_Each_Test()
         {
             _locationApiClientMock = new Mock<ILocationApiClient<LocationApiConfiguration>>();
-            _cacheStorageService = new Mock<ICacheStorageService>();
-            _sut = new LocationLookupService(_locationApiClientMock.Object, _cacheStorageService.Object);
+            _sut = new LocationLookupService(_locationApiClientMock.Object);
         }
 
         [Test]

--- a/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Services/LocationLookupServiceTests/WhenCallingGetLocationInformation.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Services/LocationLookupServiceTests/WhenCallingGetLocationInformation.cs
@@ -21,16 +21,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         [Test, MoqAutoData]
         public async Task And_No_Location_Then_Does_Not_Call_Api(
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = "";
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             await service.GetLocationInformation(location, lat, lon);
 
@@ -43,17 +38,12 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string authorityName,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service
         )
         {
             var location = $"{locationName}, {authorityName} ";
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -74,17 +64,12 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string authorityName,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = $"{locationName}, {locationName}, {authorityName} ";
             var lat = 0;
             var lon = 0;
             var encodedLocation = "?locationName=" + HttpUtility.UrlEncode($"{locationName}, {locationName}");
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -104,16 +89,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string locationName,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = $"{locationName} ";//no regex match
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             var result = await service.GetLocationInformation(location, lat, lon);
 
@@ -125,7 +105,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         public async Task Then_If_There_Is_An_Outcode_Supplied_It_Is_Searched_And_Returned(
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var outcode = "CV1";
@@ -133,10 +112,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var location = $"{outcode}";
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -154,7 +129,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         [Test, MoqAutoData]
         public async Task Then_If_The_Outcode_Returns_No_Results_Then_No_Location_Is_Returned(
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var outcode = "NO1SE";
@@ -162,10 +136,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var location = $"{outcode}";
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -188,7 +158,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string postcode,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = $"{postcode}";
@@ -196,10 +165,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var lon = 0;
             apiLocationResponse.Outcode = "";
             apiLocationResponse.Postcode = postcode;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -219,7 +184,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         public async Task Then_If_There_Is_A_Postcode_And_Include_District_Name_Is_Included_Option_Then_It_Is_Returned_As_Display_Name(
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var postcode = "CV1 1AA";
@@ -228,10 +192,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var lon = 0;
             apiLocationResponse.Postcode = postcode;
             apiLocationResponse.Outcode = "";
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -251,17 +211,12 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         public async Task Then_If_There_Is_An_Outcode_And_District_Supplied_It_Is_Searched_And_Returned(
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var outcode = "CV1";
             var location = $"{outcode} Birmingham, West Midlands";
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -279,16 +234,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         [Test, MoqAutoData]
         public async Task Then_If_There_Is_A_Lat_Lon_In_The_Request_Then_The_Location_Is_Not_Searched(
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = "somewhere nice";
             var lat = 25;
             var lon = 2;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             await service.GetLocationInformation(location, lat, lon);
 
@@ -300,17 +250,12 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string location,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             apiLocationResponse.Postcode = "";
             apiLocationResponse.DistrictName = "";
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -328,16 +273,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         [Test, MoqAutoData]
         public async Task Then_If_Doing_A_Partial_Search_And_No_Matches_Then_Null_Location_Returned(
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService handler)
         {
             var location = "no-match";
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -352,16 +292,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
 
         [Test, MoqAutoData]
         public async Task Then_If_There_Is_A_Partial_Location_Name_Which_Is_Less_Than_Two_Characters_Then_Location_Is_Set_To_Null(
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = "C";
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             var result = await service.GetLocationInformation(location, lat, lon);
 
@@ -372,7 +307,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         public async Task Then_If_The_Location_Lookup_Returns_Empty_And_There_Is_A_Location_It_Is_Searched_And_First_Returned(
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             apiLocationResponse.Postcode = "";
@@ -380,10 +314,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var location = "LE1";
             var lat = 0;
             var lon = 0;
-
-            mockCacheStorageService
-                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
-                .ReturnsAsync((LocationItem)null);
 
             mockLocationApiClient
                 .Setup(client =>
@@ -405,106 +335,6 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             result.Name.Should().Be($"{apiLocationResponse.LocationName}, {apiLocationResponse.LocalAuthorityName}");
             result.GeoPoint.Should().BeEquivalentTo(apiLocationResponse.Location.GeoPoint);
             result.Country.Should().Be(apiLocationResponse.Country);
-        }
-
-        [Test, MoqAutoData]
-        public async Task When_Cache_Hit_Then_Location_Is_Returned_From_Cache(
-            LocationItem locationItem,
-            [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
-            LocationLookupService service
-        )
-        {
-            _cacheStorageServiceMock
-                .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{locationItem.Name}")
-            ).ReturnsAsync(locationItem);
-            
-            var sut = await service.GetLocationInformation(locationItem.Name, 0, 0);
-
-            Assert.That(sut.Name, Is.EqualTo(locationItem.Name));
-        
-            _cacheStorageServiceMock.Verify(x =>
-                x.SaveToCache(
-                    It.IsAny<string>(), 
-                    It.IsAny<object>(), 
-                    It.IsAny<int>()
-                ), Times.Never);
-
-            _cacheStorageServiceMock.Verify(x =>
-                x.RetrieveFromCache<LocationItem>($"loc:{locationItem.Name}"
-            ), Times.Once);
-        }
-
-        [Test, MoqAutoData]
-        public async Task When_Cache_Miss_Then_Location_Retrieved_From_Location_API_Client_And_Saved_To_Cache(
-            string locationName,
-            string authorityName,
-            GetLocationsListItem apiLocationResponse,
-            [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
-            [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            LocationLookupService service
-        )
-        {
-            var location = $"{locationName}, {authorityName}";
-
-            _cacheStorageServiceMock
-                .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{location}")
-            ).ReturnsAsync((LocationItem)null);
-
-            mockLocationApiClient
-                .Setup(client =>
-                    client.Get<GetLocationsListItem>(
-                        It.Is<GetLocationByLocationAndAuthorityName>(c => c.GetUrl.Contains(locationName.Trim()) && c.GetUrl.Contains(authorityName.Trim()))))
-                .ReturnsAsync(apiLocationResponse);
-
-            var sut = await service.GetLocationInformation(location, 0, 0);
-
-            _cacheStorageServiceMock.Verify(x =>
-               x.RetrieveFromCache<LocationItem>($"loc:{location}"
-            ), Times.Once);
-
-            _cacheStorageServiceMock.Verify(x =>
-                x.SaveToCache(
-                    $"loc:{sut.Name}",
-                    It.IsAny<LocationItem>(),
-                    TimeSpan.FromHours(LocationLookupService.LocationItemCacheExpirationInHours)
-                ), Times.Once);
-        }
-
-        [Test, MoqAutoData]
-        public async Task When_Location_Is_Null_Then_Cache_Update_Is_Avoided(
-            string locationName,
-            string authorityName,
-            [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
-            [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            LocationLookupService service
-        )
-        {
-            var location = $"{locationName}, {authorityName}";
-
-            _cacheStorageServiceMock
-                .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{location}")
-            ).ReturnsAsync((LocationItem)null);
-
-            mockLocationApiClient
-                .Setup(client =>
-                    client.Get<GetLocationsListItem>(
-                        It.Is<GetLocationByLocationAndAuthorityName>(c => c.GetUrl.Contains(locationName.Trim()) && c.GetUrl.Contains(authorityName.Trim()))))
-                .ReturnsAsync((GetLocationsListItem)null);
-
-            var sut = await service.GetLocationInformation(location, 0, 0);
-
-            Assert.That(sut, Is.Null);
-
-            _cacheStorageServiceMock.Verify(x =>
-               x.RetrieveFromCache<LocationItem>($"loc:{location}"
-           ), Times.Once);
-
-            _cacheStorageServiceMock.Verify(x =>
-                x.SaveToCache(
-                    It.IsAny<string>(),
-                    It.IsAny<LocationItem>(),
-                    TimeSpan.FromHours(LocationLookupService.LocationItemCacheExpirationInHours)
-                ), Times.Never);
         }
     }
 }

--- a/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Services/LocationLookupServiceTests/WhenCallingGetLocationInformation.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi.UnitTests/Services/LocationLookupServiceTests/WhenCallingGetLocationInformation.cs
@@ -1,17 +1,18 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Web;
-using AutoFixture.NUnit3;
+﻿using AutoFixture.NUnit3;
 using FluentAssertions;
 using Moq;
-using NUnit.Framework;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.InnerApi.Requests;
 using SFA.DAS.SharedOuterApi.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Interfaces;
+using SFA.DAS.SharedOuterApi.Models;
 using SFA.DAS.SharedOuterApi.Services;
 using SFA.DAS.Testing.AutoFixture;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
 
 namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
 {
@@ -20,11 +21,16 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         [Test, MoqAutoData]
         public async Task And_No_Location_Then_Does_Not_Call_Api(
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = "";
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
 
             await service.GetLocationInformation(location, lat, lon);
 
@@ -37,11 +43,18 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string authorityName,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
-            LocationLookupService service)
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
+            LocationLookupService service
+        )
         {
             var location = $"{locationName}, {authorityName} ";
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListItem>(
@@ -61,12 +74,18 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string authorityName,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = $"{locationName}, {locationName}, {authorityName} ";
             var lat = 0;
             var lon = 0;
             var encodedLocation = "?locationName=" + HttpUtility.UrlEncode($"{locationName}, {locationName}");
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListItem>(
@@ -85,11 +104,16 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string locationName,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = $"{locationName} ";//no regex match
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
 
             var result = await service.GetLocationInformation(location, lat, lon);
 
@@ -101,6 +125,7 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         public async Task Then_If_There_Is_An_Outcode_Supplied_It_Is_Searched_And_Returned(
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var outcode = "CV1";
@@ -108,6 +133,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var location = $"{outcode}";
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListItem>(
@@ -124,6 +154,7 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         [Test, MoqAutoData]
         public async Task Then_If_The_Outcode_Returns_No_Results_Then_No_Location_Is_Returned(
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var outcode = "NO1SE";
@@ -131,6 +162,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var location = $"{outcode}";
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListItem>(
@@ -152,6 +188,7 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string postcode,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = $"{postcode}";
@@ -159,6 +196,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var lon = 0;
             apiLocationResponse.Outcode = "";
             apiLocationResponse.Postcode = postcode;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListItem>(
@@ -177,6 +219,7 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         public async Task Then_If_There_Is_A_Postcode_And_Include_District_Name_Is_Included_Option_Then_It_Is_Returned_As_Display_Name(
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var postcode = "CV1 1AA";
@@ -185,6 +228,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var lon = 0;
             apiLocationResponse.Postcode = postcode;
             apiLocationResponse.Outcode = "";
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListItem>(
@@ -203,12 +251,18 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         public async Task Then_If_There_Is_An_Outcode_And_District_Supplied_It_Is_Searched_And_Returned(
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var outcode = "CV1";
             var location = $"{outcode} Birmingham, West Midlands";
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListItem>(
@@ -225,11 +279,16 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         [Test, MoqAutoData]
         public async Task Then_If_There_Is_A_Lat_Lon_In_The_Request_Then_The_Location_Is_Not_Searched(
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = "somewhere nice";
             var lat = 25;
             var lon = 2;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
 
             await service.GetLocationInformation(location, lat, lon);
 
@@ -241,12 +300,18 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             string location,
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             apiLocationResponse.Postcode = "";
             apiLocationResponse.DistrictName = "";
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListResponse>(
@@ -263,11 +328,17 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         [Test, MoqAutoData]
         public async Task Then_If_Doing_A_Partial_Search_And_No_Matches_Then_Null_Location_Returned(
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService handler)
         {
             var location = "no-match";
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListResponse>(
@@ -281,11 +352,16 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
 
         [Test, MoqAutoData]
         public async Task Then_If_There_Is_A_Partial_Location_Name_Which_Is_Less_Than_Two_Characters_Then_Location_Is_Set_To_Null(
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             var location = "C";
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
 
             var result = await service.GetLocationInformation(location, lat, lon);
 
@@ -296,6 +372,7 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
         public async Task Then_If_The_Location_Lookup_Returns_Empty_And_There_Is_A_Location_It_Is_Searched_And_First_Returned(
             GetLocationsListItem apiLocationResponse,
             [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            [Frozen] Mock<ICacheStorageService> mockCacheStorageService,
             LocationLookupService service)
         {
             apiLocationResponse.Postcode = "";
@@ -303,6 +380,11 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             var location = "LE1";
             var lat = 0;
             var lon = 0;
+
+            mockCacheStorageService
+                .Setup(x => x.RetrieveFromCache<LocationItem>(It.IsAny<string>()))
+                .ReturnsAsync((LocationItem)null);
+
             mockLocationApiClient
                 .Setup(client =>
                     client.Get<GetLocationsListItem>(
@@ -323,6 +405,106 @@ namespace SFA.DAS.SharedOuterApi.UnitTests.Services.LocationLookupServiceTests
             result.Name.Should().Be($"{apiLocationResponse.LocationName}, {apiLocationResponse.LocalAuthorityName}");
             result.GeoPoint.Should().BeEquivalentTo(apiLocationResponse.Location.GeoPoint);
             result.Country.Should().Be(apiLocationResponse.Country);
+        }
+
+        [Test, MoqAutoData]
+        public async Task When_Cache_Hit_Then_Location_Is_Returned_From_Cache(
+            LocationItem locationItem,
+            [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
+            LocationLookupService service
+        )
+        {
+            _cacheStorageServiceMock
+                .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{locationItem.Name}")
+            ).ReturnsAsync(locationItem);
+            
+            var sut = await service.GetLocationInformation(locationItem.Name, 0, 0);
+
+            Assert.That(sut.Name, Is.EqualTo(locationItem.Name));
+        
+            _cacheStorageServiceMock.Verify(x =>
+                x.SaveToCache(
+                    It.IsAny<string>(), 
+                    It.IsAny<object>(), 
+                    It.IsAny<int>()
+                ), Times.Never);
+
+            _cacheStorageServiceMock.Verify(x =>
+                x.RetrieveFromCache<LocationItem>($"loc:{locationItem.Name}"
+            ), Times.Once);
+        }
+
+        [Test, MoqAutoData]
+        public async Task When_Cache_Miss_Then_Location_Retrieved_From_Location_API_Client_And_Saved_To_Cache(
+            string locationName,
+            string authorityName,
+            GetLocationsListItem apiLocationResponse,
+            [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
+            [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            LocationLookupService service
+        )
+        {
+            var location = $"{locationName}, {authorityName}";
+
+            _cacheStorageServiceMock
+                .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{location}")
+            ).ReturnsAsync((LocationItem)null);
+
+            mockLocationApiClient
+                .Setup(client =>
+                    client.Get<GetLocationsListItem>(
+                        It.Is<GetLocationByLocationAndAuthorityName>(c => c.GetUrl.Contains(locationName.Trim()) && c.GetUrl.Contains(authorityName.Trim()))))
+                .ReturnsAsync(apiLocationResponse);
+
+            var sut = await service.GetLocationInformation(location, 0, 0);
+
+            _cacheStorageServiceMock.Verify(x =>
+               x.RetrieveFromCache<LocationItem>($"loc:{location}"
+            ), Times.Once);
+
+            _cacheStorageServiceMock.Verify(x =>
+                x.SaveToCache(
+                    $"loc:{sut.Name}",
+                    It.IsAny<LocationItem>(),
+                    TimeSpan.FromHours(LocationLookupService.LocationItemCacheExpirationInHours)
+                ), Times.Once);
+        }
+
+        [Test, MoqAutoData]
+        public async Task When_Location_Is_Null_Then_Cache_Update_Is_Avoided(
+            string locationName,
+            string authorityName,
+            [Frozen] Mock<ICacheStorageService> _cacheStorageServiceMock,
+            [Frozen] Mock<ILocationApiClient<LocationApiConfiguration>> mockLocationApiClient,
+            LocationLookupService service
+        )
+        {
+            var location = $"{locationName}, {authorityName}";
+
+            _cacheStorageServiceMock
+                .Setup(a => a.RetrieveFromCache<LocationItem>($"loc:{location}")
+            ).ReturnsAsync((LocationItem)null);
+
+            mockLocationApiClient
+                .Setup(client =>
+                    client.Get<GetLocationsListItem>(
+                        It.Is<GetLocationByLocationAndAuthorityName>(c => c.GetUrl.Contains(locationName.Trim()) && c.GetUrl.Contains(authorityName.Trim()))))
+                .ReturnsAsync((GetLocationsListItem)null);
+
+            var sut = await service.GetLocationInformation(location, 0, 0);
+
+            Assert.That(sut, Is.Null);
+
+            _cacheStorageServiceMock.Verify(x =>
+               x.RetrieveFromCache<LocationItem>($"loc:{location}"
+           ), Times.Once);
+
+            _cacheStorageServiceMock.Verify(x =>
+                x.SaveToCache(
+                    It.IsAny<string>(),
+                    It.IsAny<LocationItem>(),
+                    TimeSpan.FromHours(LocationLookupService.LocationItemCacheExpirationInHours)
+                ), Times.Never);
         }
     }
 }

--- a/src/Shared/SFA.DAS.SharedOuterApi/Models/LocationItem.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/Models/LocationItem.cs
@@ -1,7 +1,28 @@
-﻿using System.Text.Json.Serialization;
-using Newtonsoft.Json;
+﻿namespace SFA.DAS.SharedOuterApi.Models;
 
-namespace SFA.DAS.SharedOuterApi.Models
+public record LocationItem(string Name, double[] GeoPoint, string Country)
 {
-    public record LocationItem(string Name, double[] GeoPoint, string Country);
+    public decimal? Latitude
+    {
+        get
+        {
+            if (GeoPoint?.Length > 0 && decimal.TryParse(GeoPoint[0].ToString(), out var latitude))
+            {
+                return latitude;
+            }
+            return null;
+        }
+    }
+
+    public decimal? Longitude
+    {
+        get
+        {
+            if (GeoPoint?.Length > 1 && decimal.TryParse(GeoPoint[1].ToString(), out var longitude))
+            {
+                return longitude;
+            }
+            return null;
+        }
+    }
 }

--- a/src/Shared/SFA.DAS.SharedOuterApi/Services/LocationLookupService.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/Services/LocationLookupService.cs
@@ -23,6 +23,8 @@ public class LocationLookupService : ILocationLookupService
 
     public const int LocationItemCacheExpirationInHours = 1;
 
+    private TimeSpan RegexTimeOut = TimeSpan.FromMilliseconds(500);
+
     public LocationLookupService(ILocationApiClient<LocationApiConfiguration> locationApiClient, ICacheStorageService cacheStorageService)
     {
         _locationApiClient = locationApiClient;
@@ -50,13 +52,13 @@ public class LocationLookupService : ILocationLookupService
 
         GetLocationsListItem getLocationsListItem  = null;
         
-        if (Regex.IsMatch(location, PostcodeRegex))
+        if (Regex.IsMatch(location, PostcodeRegex, RegexOptions.None, RegexTimeOut))
         {
             getLocationsListItem =  await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByFullPostcodeRequest(location));
             getLocationsListItem.IncludeDistrictNameInPostcodeDisplayName = includeDistrictNameInPostcodeDisplayName;
             location = getLocationsListItem.DisplayName;
         }
-        else if (Regex.IsMatch(location, OutcodeDistrictRegex))
+        else if (Regex.IsMatch(location, OutcodeDistrictRegex, RegexOptions.None, RegexTimeOut))
         {
             getLocationsListItem = await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByOutcodeAndDistrictRequest(location.Split(' ').FirstOrDefault()));
             if (getLocationsListItem.Location != null)
@@ -64,7 +66,7 @@ public class LocationLookupService : ILocationLookupService
                 location = getLocationsListItem.DisplayName;
             }
         }
-        else if(Regex.IsMatch(location, OutcodeRegex))
+        else if(Regex.IsMatch(location, OutcodeRegex, RegexOptions.None, RegexTimeOut))
         {
             getLocationsListItem = await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByOutcodeRequest(location));
         }
@@ -103,7 +105,7 @@ public class LocationLookupService : ILocationLookupService
 
     public async Task<GetAddressesListResponse> GetExactMatchAddresses(string fullPostcode)
     {
-        if (!Regex.IsMatch(fullPostcode, PostcodeRegex, RegexOptions.None, TimeSpan.FromMilliseconds(500)))
+        if (!Regex.IsMatch(fullPostcode, PostcodeRegex, RegexOptions.None, RegexTimeOut))
         {
             return null;
         }

--- a/src/Shared/SFA.DAS.SharedOuterApi/Services/LocationLookupService.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/Services/LocationLookupService.cs
@@ -9,93 +9,112 @@ using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
-namespace SFA.DAS.SharedOuterApi.Services
-{
-    public class LocationLookupService : ILocationLookupService
-    {
-        private readonly ILocationApiClient<LocationApiConfiguration> _locationApiClient;
-        private const string PostcodeRegex = @"^[A-Za-z]{1,2}\d[A-Za-z\d]?\s*\d[A-Za-z]{2}$";
-        private const string OutcodeRegex = @"^[A-Za-z]{1,2}\d[A-Za-z\d]?";
-        private const string OutcodeDistrictRegex = @"^[A-Za-z]{1,2}\d[A-Za-z\d]?\s[A-Za-z]*";
-        private const double MinMatch = 1;
+namespace SFA.DAS.SharedOuterApi.Services;
 
-        public LocationLookupService(ILocationApiClient<LocationApiConfiguration> locationApiClient)
+public class LocationLookupService : ILocationLookupService
+{
+    private readonly ICacheStorageService _cacheStorageService;
+    private readonly ILocationApiClient<LocationApiConfiguration> _locationApiClient;
+
+    private const string PostcodeRegex = @"^[A-Za-z]{1,2}\d[A-Za-z\d]?\s*\d[A-Za-z]{2}$";
+    private const string OutcodeRegex = @"^[A-Za-z]{1,2}\d[A-Za-z\d]?";
+    private const string OutcodeDistrictRegex = @"^[A-Za-z]{1,2}\d[A-Za-z\d]?\s[A-Za-z]*";
+    private const double MinMatch = 1;
+
+    public const int LocationItemCacheExpirationInHours = 1;
+
+    public LocationLookupService(ILocationApiClient<LocationApiConfiguration> locationApiClient, ICacheStorageService cacheStorageService)
+    {
+        _locationApiClient = locationApiClient;
+        _cacheStorageService = cacheStorageService;
+    }
+
+    public async Task<LocationItem> GetLocationInformation(string location, double lat, double lon, bool includeDistrictNameInPostcodeDisplayName = false)
+    {
+        if (string.IsNullOrWhiteSpace(location))
         {
-            _locationApiClient = locationApiClient;
+            return null;
         }
 
-        public async Task<LocationItem> GetLocationInformation(string location, double lat, double lon, bool includeDistrictNameInPostcodeDisplayName = false)
-        {
-            if (string.IsNullOrEmpty(location))
-            {
-                return null;
-            }
-            
-            if (lat != 0 && lon != 0)
-            {
-                return new LocationItem(location, new []{ lat, lon}, string.Empty);
-            }
+        LocationItem cachedLocationItem = await _cacheStorageService.RetrieveFromCache<LocationItem>($"loc:{location}");
 
-            GetLocationsListItem getLocationsListItem  = null;
-            
-            if (Regex.IsMatch(location, PostcodeRegex))
+        if(cachedLocationItem is not null)
+        {
+            return cachedLocationItem;
+        }
+
+        if (lat != 0 && lon != 0)
+        {
+            return new LocationItem(location, new []{ lat, lon }, string.Empty);
+        }
+
+        GetLocationsListItem getLocationsListItem  = null;
+        
+        if (Regex.IsMatch(location, PostcodeRegex))
+        {
+            getLocationsListItem =  await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByFullPostcodeRequest(location));
+            getLocationsListItem.IncludeDistrictNameInPostcodeDisplayName = includeDistrictNameInPostcodeDisplayName;
+            location = getLocationsListItem.DisplayName;
+        }
+        else if (Regex.IsMatch(location, OutcodeDistrictRegex))
+        {
+            getLocationsListItem = await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByOutcodeAndDistrictRequest(location.Split(' ').FirstOrDefault()));
+            if (getLocationsListItem.Location != null)
             {
-                getLocationsListItem =  await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByFullPostcodeRequest(location));
-                getLocationsListItem.IncludeDistrictNameInPostcodeDisplayName = includeDistrictNameInPostcodeDisplayName;
                 location = getLocationsListItem.DisplayName;
             }
-            else if (Regex.IsMatch(location, OutcodeDistrictRegex))
-            {
-                getLocationsListItem = await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByOutcodeAndDistrictRequest(location.Split(' ').FirstOrDefault()));
-                if (getLocationsListItem.Location != null)
-                {
-                    location = getLocationsListItem.DisplayName;
-                }
-            }
-            else if(Regex.IsMatch(location, OutcodeRegex))
-            {
-                getLocationsListItem = await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByOutcodeRequest(location));
-            }
-            else if (location.Split(",").Length >= 2)
-            {
-                
-                var locationInformation = location.Split(",");
-                var locationName = string.Join(",",locationInformation.Take(locationInformation.Length-1)).Trim();
-                var authorityName = locationInformation.Last().Trim();
-                getLocationsListItem = await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByLocationAndAuthorityName(locationName, authorityName));
-            }
-            
-            if (location.Length >= 2 && getLocationsListItem?.Location == null)
-            {
-                var locations = await _locationApiClient.Get<GetLocationsListResponse>(new GetLocationsQueryRequest(location));
-
-                var locationsListItem = locations?.Locations?.FirstOrDefault();
-                if (locationsListItem != null)
-                {
-                    getLocationsListItem = locationsListItem;
-                    location = getLocationsListItem.DisplayName;    
-                }
-                
-            }
-
-            return getLocationsListItem?.Location != null
-                ? new LocationItem(location, getLocationsListItem.Location.GeoPoint, getLocationsListItem.Country) 
-                : null;
         }
-
-        public async Task<GetAddressesListResponse> GetExactMatchAddresses(string fullPostcode)
+        else if(Regex.IsMatch(location, OutcodeRegex))
         {
-            if (!Regex.IsMatch(fullPostcode, PostcodeRegex)) return null;
-
-            var response = await _locationApiClient.GetWithResponseCode<GetAddressesListResponse>(new GetAddressesQueryRequest(fullPostcode, MinMatch));
-
-            if (response.StatusCode != HttpStatusCode.OK)
-            {
-                var message = $"Location api did not return a successful response when trying to get addresses for postcode {fullPostcode}";
-                throw new InvalidOperationException(message);
-            }
-
-            return response.Body;
+            getLocationsListItem = await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByOutcodeRequest(location));
         }
+        else if (location.Split(",").Length >= 2)
+        {
+            
+            var locationInformation = location.Split(",");
+            var locationName = string.Join(",",locationInformation.Take(locationInformation.Length-1)).Trim();
+            var authorityName = locationInformation.Last().Trim();
+            getLocationsListItem = await _locationApiClient.Get<GetLocationsListItem>(new GetLocationByLocationAndAuthorityName(locationName, authorityName));
+        }
+        
+        if (location.Length >= 2 && getLocationsListItem?.Location == null)
+        {
+            var locations = await _locationApiClient.Get<GetLocationsListResponse>(new GetLocationsQueryRequest(location));
+
+            var locationsListItem = locations?.Locations?.FirstOrDefault();
+            if (locationsListItem != null)
+            {
+                getLocationsListItem = locationsListItem;
+                location = getLocationsListItem.DisplayName;    
+            }
+        }
+
+        LocationItem locationItem = getLocationsListItem?.Location != null
+            ? new LocationItem(location, getLocationsListItem.Location.GeoPoint, getLocationsListItem.Country)
+            : null;
+
+        if(locationItem is not null)
+        {
+            await _cacheStorageService.SaveToCache($"loc:{location}", locationItem, TimeSpan.FromHours(LocationItemCacheExpirationInHours));
+        }
+
+        return locationItem;
+    }
+
+    public async Task<GetAddressesListResponse> GetExactMatchAddresses(string fullPostcode)
+    {
+        if (!Regex.IsMatch(fullPostcode, PostcodeRegex))
+        {
+            return null;
+        }
+
+        var response = await _locationApiClient.GetWithResponseCode<GetAddressesListResponse>(new GetAddressesQueryRequest(fullPostcode, MinMatch));
+
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            throw new InvalidOperationException($"Location api did not return a successful response when trying to get addresses for postcode {fullPostcode}");
+        }
+
+        return response.Body;
     }
 }

--- a/src/Shared/SFA.DAS.SharedOuterApi/Services/LocationLookupService.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/Services/LocationLookupService.cs
@@ -103,7 +103,7 @@ public class LocationLookupService : ILocationLookupService
 
     public async Task<GetAddressesListResponse> GetExactMatchAddresses(string fullPostcode)
     {
-        if (!Regex.IsMatch(fullPostcode, PostcodeRegex))
+        if (!Regex.IsMatch(fullPostcode, PostcodeRegex, RegexOptions.None, TimeSpan.FromMilliseconds(500)))
         {
             return null;
         }


### PR DESCRIPTION
- Cache **LocationItem** response when getting **LocationInformation** from the Location API.
- Contains updates to **CoursesController** - **GetCourseByLarsCode** method removing **Lat** & **Lon** in place of Location for **CSP-1675**: Apprenticeship Training Course Details.