### PR TITLE
FAI-2446 Update Save Application Review Changes in Recruit

### DIFF
--- a/src/Recruit/SFA.DAS.Recruit.Api/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/AppStart/AddServiceRegistrationExtension.cs
@@ -30,6 +30,7 @@ namespace SFA.DAS.Recruit.Api.AppStart
             services.AddTransient<IEmployerAccountsService, EmployerAccountsService>();
             services.AddTransient<IRoatpV2TrainingProviderService, RoatpV2TrainingProviderService>();
             services.AddTransient<ICandidateApiClient<CandidateApiConfiguration>, CandidateApiClient>();
+            services.AddTransient<IRecruitApiClient<RecruitApiConfiguration>, RecruitApiClient>();
             services.AddTransient<IBusinessMetricsApiClient<BusinessMetricsConfiguration>, BusinessMetricsApiClient>();
             services.AddTransient<INotificationService, NotificationService>();
             services.AddSingleton(new EmailEnvironmentHelper(configuration["ResourceEnvironmentName"]));

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingPatchRecruitApplicationReviewRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingPatchRecruitApplicationReviewRequest.cs
@@ -1,0 +1,18 @@
+using System;
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.Recruit.InnerApi.Requests;
+
+namespace SFA.DAS.Recruit.UnitTests.Application.InnerApi.Requests;
+
+public class WhenBuildingPatchRecruitApplicationReviewRequest
+{
+    [Test, AutoData]
+    public void Then_The_Request_Is_Correctly_Built(Guid applicationId)
+    {
+        var actual = new PatchRecruitApplicationReviewApiRequest(applicationId, null);
+
+        actual.PatchUrl.Should().Be($"api/applicationReviews/{applicationId}");
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/Candidates/Commands/CandidateApplicationStatus/CandidateApplicationStatusCommandHandler.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Candidates/Commands/CandidateApplicationStatus/CandidateApplicationStatusCommandHandler.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.JsonPatch;
 using SFA.DAS.Notifications.Messages.Commands;
@@ -10,31 +6,29 @@ using SFA.DAS.Recruit.Domain.EmailTemplates;
 using SFA.DAS.Recruit.InnerApi.Requests;
 using SFA.DAS.Recruit.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Configuration;
-using SFA.DAS.SharedOuterApi.Infrastructure;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.Recruit.Application.Candidates.Commands.CandidateApplicationStatus;
 
-public class CandidateApplicationStatusCommandHandler : IRequestHandler<CandidateApplicationStatusCommand, Unit>
+public class CandidateApplicationStatusCommandHandler(
+    ICandidateApiClient<CandidateApiConfiguration> candidateApiClient,
+    IRecruitApiClient<RecruitApiConfiguration> recruitApiClient,
+    INotificationService notificationService,
+    EmailEnvironmentHelper emailEnvironmentHelper)
+    : IRequestHandler<CandidateApplicationStatusCommand, Unit>
 {
-    private readonly ICandidateApiClient<CandidateApiConfiguration> _candidateApiClient;
-    private readonly INotificationService _notificationService;
-    private readonly EmailEnvironmentHelper _emailEnvironmentHelper;
-
-    public CandidateApplicationStatusCommandHandler(ICandidateApiClient<CandidateApiConfiguration> candidateApiClient, INotificationService notificationService, EmailEnvironmentHelper emailEnvironmentHelper)
-    {
-        _candidateApiClient = candidateApiClient;
-        _notificationService = notificationService;
-        _emailEnvironmentHelper = emailEnvironmentHelper;
-    }
     public async Task<Unit> Handle(CandidateApplicationStatusCommand request, CancellationToken cancellationToken)
     {
         ApiResponse<GetCandidateApiResponse> candidate = null;
         if (request.ApplicationId == Guid.Empty)
         {
             candidate =
-                await _candidateApiClient.GetWithResponseCode<GetCandidateApiResponse>(new GetCandidateByMigratedCandidateIdApiRequest(request.CandidateId));
+                await candidateApiClient.GetWithResponseCode<GetCandidateApiResponse>(new GetCandidateByMigratedCandidateIdApiRequest(request.CandidateId));
             if (candidate.StatusCode == HttpStatusCode.NotFound)
             {
                 return new Unit();
@@ -42,30 +36,34 @@ public class CandidateApplicationStatusCommandHandler : IRequestHandler<Candidat
             var applicationRequest =
                 new GetApplicationByReferenceApiRequest(candidate.Body.Id, request.VacancyReference);
             var application = await
-                _candidateApiClient.GetWithResponseCode<GetApplicationByReferenceApiResponse>(applicationRequest);
+                candidateApiClient.GetWithResponseCode<GetApplicationByReferenceApiResponse>(applicationRequest);
             request.ApplicationId = application.Body.Id;
             request.CandidateId = application.Body.CandidateId;
         }
 
         candidate ??=
-            await _candidateApiClient.GetWithResponseCode<GetCandidateApiResponse>(
+            await candidateApiClient.GetWithResponseCode<GetCandidateApiResponse>(
                 new GetCandidateByIdApiRequest(request.CandidateId));
         
         var jsonPatchDocument = new JsonPatchDocument<InnerApi.Requests.Application>();
-
         var applicationStatus = request.Outcome.Equals("Successful", StringComparison.CurrentCultureIgnoreCase)
             ? ApplicationStatus.Successful
             : ApplicationStatus.UnSuccessful;
-        
         jsonPatchDocument.Replace(x => x.ResponseNotes, request.Feedback);
         jsonPatchDocument.Replace(x => x.Status, applicationStatus);
-        
         var patchRequest = new PatchApplicationApiRequest(request.ApplicationId, request.CandidateId, jsonPatchDocument);
+
+        var jsonPatchApplicationReviewDocument = new JsonPatchDocument<ApplicationReview>();
+        jsonPatchApplicationReviewDocument.Replace(x => x.CandidateFeedback, request.Feedback);
+        jsonPatchApplicationReviewDocument.Replace(x => x.Status, Enum.GetName(applicationStatus));
+        jsonPatchApplicationReviewDocument.Replace(x => x.StatusUpdatedDate, DateTime.UtcNow);
+        var patchApplicationReviewApiRequest = new PatchRecruitApplicationReviewApiRequest(request.ApplicationId, jsonPatchApplicationReviewDocument);
+        
         SendEmailCommand sendEmailCommand;
         if (applicationStatus == ApplicationStatus.Successful)
         {
             var email = new ApplicationResponseSuccessEmailTemplate(
-                _emailEnvironmentHelper.SuccessfulApplicationEmailTemplateId, 
+                emailEnvironmentHelper.SuccessfulApplicationEmailTemplateId, 
                 candidate.Body.Email,
                 candidate.Body.FirstName, request.VacancyTitle, request.VacancyEmployerName,
                 GetLocation(request.VacancyLocation));
@@ -74,15 +72,18 @@ public class CandidateApplicationStatusCommandHandler : IRequestHandler<Candidat
         else
         {
             var unsuccessfulEmail = new ApplicationResponseUnsuccessfulEmailTemplate(
-                _emailEnvironmentHelper.UnsuccessfulApplicationEmailTemplateId,
+                emailEnvironmentHelper.UnsuccessfulApplicationEmailTemplateId,
                 candidate.Body.Email,
                 candidate.Body.FirstName, request.VacancyTitle, request.VacancyEmployerName,
                 GetLocation(request.VacancyLocation),
-                request.Feedback, _emailEnvironmentHelper.CandidateApplicationUrl);
+                request.Feedback, emailEnvironmentHelper.CandidateApplicationUrl);
             sendEmailCommand = new SendEmailCommand(unsuccessfulEmail.TemplateId, unsuccessfulEmail.RecipientAddress, unsuccessfulEmail.Tokens);
         }
         
-        await Task.WhenAll(_notificationService.Send(sendEmailCommand), _candidateApiClient.PatchWithResponseCode(patchRequest));
+        await Task.WhenAll(
+            notificationService.Send(sendEmailCommand), 
+            candidateApiClient.PatchWithResponseCode(patchRequest),
+            recruitApiClient.PatchWithResponseCode(patchApplicationReviewApiRequest));
         return new Unit();
     }
 

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/PatchRecruitApplicationReviewApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/PatchRecruitApplicationReviewApiRequest.cs
@@ -1,0 +1,21 @@
+using System;
+using Microsoft.AspNetCore.JsonPatch;
+using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.Recruit.InnerApi.Requests;
+
+public record PatchRecruitApplicationReviewApiRequest(
+    Guid ApplicationId,
+    JsonPatchDocument<ApplicationReview> Data)
+    : IPatchApiRequest<JsonPatchDocument<ApplicationReview>>
+{
+    public JsonPatchDocument<ApplicationReview> Data { get; set; } = Data;
+
+    public string PatchUrl => $"api/applicationReviews/{ApplicationId}";
+}
+public abstract record ApplicationReview
+{
+    public string CandidateFeedback { get; set; }
+    public string Status { get; set; }
+    public DateTime StatusUpdatedDate { get; set; }
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi/Services/RecruitApiClient.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/Services/RecruitApiClient.cs
@@ -8,84 +8,77 @@ using SFA.DAS.SharedOuterApi.Models;
 
 namespace SFA.DAS.SharedOuterApi.Services;
 
-public class RecruitApiClient : IRecruitApiClient<RecruitApiConfiguration>
+public class RecruitApiClient(IInternalApiClient<RecruitApiConfiguration> apiClient)
+    : IRecruitApiClient<RecruitApiConfiguration>
+{
+    public Task<TResponse> Get<TResponse>(IGetApiRequest request)
     {
-        private readonly IInternalApiClient<RecruitApiConfiguration> _apiClient;
+        return apiClient.Get<TResponse>(request);
+    }
 
-        public RecruitApiClient (IInternalApiClient<RecruitApiConfiguration> apiClient)
-        {
-            _apiClient = apiClient;
-        }
+    public Task<HttpStatusCode> GetResponseCode(IGetApiRequest request)
+    {
+        return apiClient.GetResponseCode(request);
+    }
 
-        public Task<TResponse> Get<TResponse>(IGetApiRequest request)
-        {
-            return _apiClient.Get<TResponse>(request);
-        }
+    public Task<ApiResponse<TResponse>> GetWithResponseCode<TResponse>(IGetApiRequest request)
+    {
+        return apiClient.GetWithResponseCode<TResponse>(request);
+    }
 
-        public Task<HttpStatusCode> GetResponseCode(IGetApiRequest request)
-        {
-            return _apiClient.GetResponseCode(request);
-        }
+    public Task<IEnumerable<TResponse>> GetAll<TResponse>(IGetAllApiRequest request)
+    {
+        throw new System.NotImplementedException();
+    }
 
-        public Task<ApiResponse<TResponse>> GetWithResponseCode<TResponse>(IGetApiRequest request)
-        {
-            return _apiClient.GetWithResponseCode<TResponse>(request);
-        }
+    public Task<PagedResponse<TResponse>> GetPaged<TResponse>(IGetPagedApiRequest request)
+    {
+        throw new System.NotImplementedException();
+    }
 
-        public Task<IEnumerable<TResponse>> GetAll<TResponse>(IGetAllApiRequest request)
-        {
-            throw new System.NotImplementedException();
-        }
+    public Task<TResponse> Post<TResponse>(IPostApiRequest request)
+    {
+        throw new System.NotImplementedException();
+    }
 
-        public Task<PagedResponse<TResponse>> GetPaged<TResponse>(IGetPagedApiRequest request)
-        {
-            throw new System.NotImplementedException();
-        }
+    public Task Post<TData>(IPostApiRequest<TData> request)
+    {
+        throw new System.NotImplementedException();
+    }
 
-        public Task<TResponse> Post<TResponse>(IPostApiRequest request)
-        {
-            throw new System.NotImplementedException();
-        }
+    public async Task Delete(IDeleteApiRequest request)
+    {
+        await apiClient.Delete(request);
+    }
 
-        public Task Post<TData>(IPostApiRequest<TData> request)
-        {
-            throw new System.NotImplementedException();
-        }
+    public Task Patch<TData>(IPatchApiRequest<TData> request)
+    {
+        throw new System.NotImplementedException();
+    }
 
-        public Task Delete(IDeleteApiRequest request)
-        {
-            throw new System.NotImplementedException();
-        }
+    public Task Put(IPutApiRequest request)
+    {
+        return apiClient.Put(request);
+    }
 
-        public Task Patch<TData>(IPatchApiRequest<TData> request)
-        {
-            throw new System.NotImplementedException();
-        }
+    public Task Put<TData>(IPutApiRequest<TData> request)
+    {
+        return apiClient.Put(request);
+    }
 
-        public Task Put(IPutApiRequest request)
-        {
-            throw new System.NotImplementedException();
-        }
+    public Task<ApiResponse<TResponse>> PostWithResponseCode<TResponse>(IPostApiRequest request, bool includeResponse = true)
+    {
+        return apiClient.PostWithResponseCode<TResponse>(request);
+    }
 
-        public Task Put<TData>(IPutApiRequest<TData> request)
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public Task<ApiResponse<TResponse>> PostWithResponseCode<TResponse>(IPostApiRequest request, bool includeResponse = true)
-        {
-            return _apiClient.PostWithResponseCode<TResponse>(request, includeResponse);
-        }
-
-        public Task<ApiResponse<string>> PatchWithResponseCode<TData>(IPatchApiRequest<TData> request)
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public Task<ApiResponse<TResponse>> PutWithResponseCode<TResponse>(IPutApiRequest request)
-        {
-            throw new System.NotImplementedException();
-        }
+    public Task<ApiResponse<string>> PatchWithResponseCode<TData>(IPatchApiRequest<TData> request)
+    {
+        return apiClient.PatchWithResponseCode<TData>(request);
+    }
+    public Task<ApiResponse<TResponse>> PutWithResponseCode<TResponse>(IPutApiRequest request)
+    {
+        return apiClient.PutWithResponseCode<TResponse>(request);
+    }
 
     public Task<ApiResponse<TResponse>> PatchWithResponseCode<TData, TResponse>(IPatchApiRequest<TData> request, bool includeResponse = true)
     {


### PR DESCRIPTION
✨ Add Recruit API client and refactor application status handling

- Register `IRecruitApiClient<RecruitApiConfiguration>` in services.
- Update tests to mock `IRecruitApiClient` for application status commands.
- Refactor `CandidateApplicationStatusCommandHandler` to use dependency injection.
- Introduce `PatchRecruitApplicationReviewApiRequest` for API patching.
- Add `ApplicationReview` record to define review data structure.

Changes made by Balaji Jambulingam