### PR TITLE
Create Qualification Discussion History changes

### DIFF
--- a/src/Aodp/SFA.DAS.Aodp.Api.UnitTests/Controllers/Qualification/QualificationControllerTests.cs
+++ b/src/Aodp/SFA.DAS.Aodp.Api.UnitTests/Controllers/Qualification/QualificationControllerTests.cs
@@ -326,9 +326,9 @@ namespace SFA.DAS.Aodp.Api.UnitTests.Controllers.Qualification
             var commandResponse = _fixture.Create<BaseMediatrResponse<EmptyResponse>>();
             commandResponse.Success = true;
             var controller = new QualificationsController(_mediatorMock.Object, _loggerMock.Object);
-            var command = _fixture.Create<CreateQualificationDiscussionHistoryCommand>();
+            var command = _fixture.Create<CreateQualificationDiscussionHistoryNoteForFundingOffersCommand>();
 
-            _mediatorMock.Setup(m => m.Send(It.IsAny<CreateQualificationDiscussionHistoryCommand>(), default))
+            _mediatorMock.Setup(m => m.Send(It.IsAny<CreateQualificationDiscussionHistoryNoteForFundingOffersCommand>(), default))
                          .ReturnsAsync(commandResponse);
 
             // Act

--- a/src/Aodp/SFA.DAS.Aodp.Api.UnitTests/Controllers/Qualification/QualificationControllerTests.cs
+++ b/src/Aodp/SFA.DAS.Aodp.Api.UnitTests/Controllers/Qualification/QualificationControllerTests.cs
@@ -320,7 +320,7 @@ namespace SFA.DAS.Aodp.Api.UnitTests.Controllers.Qualification
         }
 
         [Test]
-        public async Task QualificationFundingOffersSummary_ReturnsOkResult()
+        public async Task CreateQualificationDiscussionHistoryNoteForFundingOffers_ReturnsOkResult()
         {
             // Arrange
             var commandResponse = _fixture.Create<BaseMediatrResponse<EmptyResponse>>();
@@ -332,7 +332,7 @@ namespace SFA.DAS.Aodp.Api.UnitTests.Controllers.Qualification
                          .ReturnsAsync(commandResponse);
 
             // Act
-            var result = await controller.QualificationFundingOffersSummary(command, Guid.NewGuid());
+            var result = await controller.CreateQualificationDiscussionHistoryNoteForFundingOffers(command, Guid.NewGuid());
 
             // Assert
             Assert.That(result, Is.InstanceOf<OkObjectResult>());

--- a/src/Aodp/SFA.DAS.Aodp.Api/Controllers/Qualification/QualificationsController.cs
+++ b/src/Aodp/SFA.DAS.Aodp.Api/Controllers/Qualification/QualificationsController.cs
@@ -225,7 +225,7 @@ namespace SFA.DAS.AODP.Api.Controllers.Qualification
         [HttpPut("/api/qualifications/{qualificationVersionId}/funding-offers-history-note")]
         [ProducesResponseType(typeof(EmptyResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult> QualificationFundingOffersSummary(CreateQualificationDiscussionHistoryNoteForFundingOffersCommand command, Guid qualificationVersionId)
+        public async Task<IActionResult> CreateQualificationDiscussionHistoryNoteForFundingOffers(CreateQualificationDiscussionHistoryNoteForFundingOffersCommand command, Guid qualificationVersionId)
         {
             command.QualificationVersionId = qualificationVersionId;
             return await SendRequestAsync(command);

--- a/src/Aodp/SFA.DAS.Aodp.Api/Controllers/Qualification/QualificationsController.cs
+++ b/src/Aodp/SFA.DAS.Aodp.Api/Controllers/Qualification/QualificationsController.cs
@@ -222,10 +222,10 @@ namespace SFA.DAS.AODP.Api.Controllers.Qualification
             return await SendRequestAsync(command);
         }
 
-        [HttpPut("/api/qualifications/{qualificationVersionId}/Create-QualificationDiscussionHistory")]
+        [HttpPut("/api/qualifications/{qualificationVersionId}/funding-offers-history-note")]
         [ProducesResponseType(typeof(EmptyResult), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult> QualificationFundingOffersSummary(CreateQualificationDiscussionHistoryCommand command, Guid qualificationVersionId)
+        public async Task<IActionResult> QualificationFundingOffersSummary(CreateQualificationDiscussionHistoryNoteForFundingOffersCommand command, Guid qualificationVersionId)
         {
             command.QualificationVersionId = qualificationVersionId;
             return await SendRequestAsync(command);

--- a/src/Aodp/SFA.DAS.Aodp.UnitTests/Application/Commands/Application/Qualifications/CreateQualificationDiscussionHistoryCommandHandlerTests.cs
+++ b/src/Aodp/SFA.DAS.Aodp.UnitTests/Application/Commands/Application/Qualifications/CreateQualificationDiscussionHistoryCommandHandlerTests.cs
@@ -13,25 +13,25 @@ using SFA.DAS.SharedOuterApi.Models;
 namespace SFA.DAS.Aodp.UnitTests.Application.Commands.Application.Qualifications
 {
     [TestFixture]
-    public class CreateQualificationDiscussionHistoryCommandHandlerTests
+    public class CreateQualificationDiscussionHistoryNoteForFundingOffersCommandHandlerTests
     {
         private IFixture _fixture;
         private Mock<IAodpApiClient<AodpApiConfiguration>> _apiClientMock;
-        private CreateQualificationDiscussionHistoryCommandHandler _handler;
+        private CreateQualificationDiscussionHistoryNoteForFundingOffersCommandHandler _handler;
 
         [SetUp]
         public void SetUp()
         {
             _fixture = new Fixture().Customize(new AutoMoqCustomization());
             _apiClientMock = _fixture.Freeze<Mock<IAodpApiClient<AodpApiConfiguration>>>();
-            _handler = new CreateQualificationDiscussionHistoryCommandHandler(_apiClientMock.Object);
+            _handler = new CreateQualificationDiscussionHistoryNoteForFundingOffersCommandHandler(_apiClientMock.Object);
         }
 
         [Test]
         public async Task Handle_ReturnsSuccessResponse_WhenApiCallIsSuccessful()
         {
             // Arrange
-            var command = _fixture.Create<CreateQualificationDiscussionHistoryCommand>();
+            var command = _fixture.Create<CreateQualificationDiscussionHistoryNoteForFundingOffersCommand>();
 
             _apiClientMock.Setup(x => x.Put(It.IsAny<CreateQualificationDiscussionHistoryApiRequest>()))
                           .Returns(Task.CompletedTask);
@@ -48,7 +48,7 @@ namespace SFA.DAS.Aodp.UnitTests.Application.Commands.Application.Qualifications
         public async Task Handle_ReturnsErrorResponse_WhenApiCallFails()
         {
             // Arrange
-            var command = _fixture.Create<CreateQualificationDiscussionHistoryCommand>();
+            var command = _fixture.Create<CreateQualificationDiscussionHistoryNoteForFundingOffersCommand>();
             var exceptionMessage = "API call failed";
 
             _apiClientMock.Setup(x => x.Put(It.IsAny<CreateQualificationDiscussionHistoryApiRequest>()))

--- a/src/Aodp/SFA.DAS.Aodp/Application/Commands/Application/Qualifications/CreateQualificationDiscussionHistoryCommand.cs
+++ b/src/Aodp/SFA.DAS.Aodp/Application/Commands/Application/Qualifications/CreateQualificationDiscussionHistoryCommand.cs
@@ -2,13 +2,12 @@
 
 namespace SFA.DAS.Aodp.Application.Commands.Application.Qualifications
 {
-    public class CreateQualificationDiscussionHistoryCommand : IRequest<BaseMediatrResponse<EmptyResponse>>
+    public class CreateQualificationDiscussionHistoryNoteForFundingOffersCommand : IRequest<BaseMediatrResponse<EmptyResponse>>
     {
         public Guid QualificationVersionId { get; set; }
         public Guid QualificationId { get; set; }
         public string? QualificationReference { get; set; }
         public Guid ActionTypeId { get; set; }
         public string? UserDisplayName { get; set; }
-        public string? Notes { get; set; }
     }
 }

--- a/src/Aodp/SFA.DAS.Aodp/Application/Commands/Application/Qualifications/CreateQualificationDiscussionHistoryCommandHandler.cs
+++ b/src/Aodp/SFA.DAS.Aodp/Application/Commands/Application/Qualifications/CreateQualificationDiscussionHistoryCommandHandler.cs
@@ -4,17 +4,17 @@ using SFA.DAS.SharedOuterApi.Interfaces;
 
 namespace SFA.DAS.Aodp.Application.Commands.Application.Qualifications
 {
-    public class CreateQualificationDiscussionHistoryCommandHandler : IRequestHandler<CreateQualificationDiscussionHistoryCommand, BaseMediatrResponse<EmptyResponse>>
+    public class CreateQualificationDiscussionHistoryNoteForFundingOffersCommandHandler : IRequestHandler<CreateQualificationDiscussionHistoryNoteForFundingOffersCommand, BaseMediatrResponse<EmptyResponse>>
     {
         private readonly IAodpApiClient<AodpApiConfiguration> _apiClient;
 
 
-        public CreateQualificationDiscussionHistoryCommandHandler(IAodpApiClient<AodpApiConfiguration> apiClient)
+        public CreateQualificationDiscussionHistoryNoteForFundingOffersCommandHandler(IAodpApiClient<AodpApiConfiguration> apiClient)
         {
             _apiClient = apiClient;
         }
 
-        public async Task<BaseMediatrResponse<EmptyResponse>> Handle(CreateQualificationDiscussionHistoryCommand request, CancellationToken cancellationToken)
+        public async Task<BaseMediatrResponse<EmptyResponse>> Handle(CreateQualificationDiscussionHistoryNoteForFundingOffersCommand request, CancellationToken cancellationToken)
         {
             var response = new BaseMediatrResponse<EmptyResponse>()
             {

--- a/src/Aodp/SFA.DAS.Aodp/InnerApi/AodpApi/Qualifications/CreateQualificationDiscussionHistoryApiRequest.cs
+++ b/src/Aodp/SFA.DAS.Aodp/InnerApi/AodpApi/Qualifications/CreateQualificationDiscussionHistoryApiRequest.cs
@@ -4,6 +4,6 @@ public class CreateQualificationDiscussionHistoryApiRequest : IPutApiRequest
 {
     public Guid QualificationVersionId { get; set; }
 
-    public string PutUrl => $"/api/qualifications/{QualificationVersionId}/Create-QualificationDiscussionHistory";
+    public string PutUrl => $"/api/qualifications/{QualificationVersionId}/funding-offers-history-note";
     public object Data { get; set; }
 }


### PR DESCRIPTION
Renamed the Api endpoints to 'funding-offers-history-note' Renamed the command name to 'CreateQualificationDiscussionHistoryNoteForFundingOffers'