### PR TITLE
FAI-2523 Changes to ApplicationReviewStatus Enum & other functionality

### DIFF
--- a/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/EmployerAccounts/WhenGettingDashboardByAccountId.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/EmployerAccounts/WhenGettingDashboardByAccountId.cs
@@ -1,17 +1,10 @@
-﻿using AutoFixture.NUnit3;
-using FluentAssertions;
-using MediatR;
-using Microsoft.AspNetCore.Mvc;
-using Moq;
-using NUnit.Framework;
+﻿using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Recruit.Api.Controllers;
 using SFA.DAS.Recruit.Application.Queries.GetDashboardByAccountId;
-using SFA.DAS.Recruit.InnerApi.Requests;
-using SFA.DAS.Testing.AutoFixture;
+using SFA.DAS.Recruit.Enums;
 using System;
 using System.Net;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.EmployerAccounts
 {
@@ -21,7 +14,7 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.EmployerAccounts
         [Test, MoqAutoData]
         public async Task Then_Gets_Account_From_Mediator(
             long accountId,
-            ApplicationStatus status,
+            ApplicationReviewStatus status,
             GetDashboardByAccountIdQueryResult mediatorResult,
             [Frozen] Mock<IMediator> mockMediator,
             [Greedy] EmployerAccountsController controller)
@@ -44,7 +37,7 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.EmployerAccounts
         [Test, MoqAutoData]
         public async Task And_Exception_Then_Returns_Bad_Request(
             long accountId,
-            ApplicationStatus status,
+            ApplicationReviewStatus status,
             [Frozen] Mock<IMediator> mockMediator,
             [Greedy] EmployerAccountsController controller)
         {

--- a/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/Providers/WhenGettingDashboardByUkprn.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/Providers/WhenGettingDashboardByUkprn.cs
@@ -1,17 +1,10 @@
-﻿using AutoFixture.NUnit3;
-using FluentAssertions;
-using MediatR;
-using Microsoft.AspNetCore.Mvc;
-using Moq;
-using NUnit.Framework;
+﻿using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Recruit.Api.Controllers;
 using SFA.DAS.Recruit.Application.Queries.GetDashboardByUkprn;
-using SFA.DAS.Recruit.InnerApi.Requests;
-using SFA.DAS.Testing.AutoFixture;
+using SFA.DAS.Recruit.Enums;
 using System;
 using System.Net;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.Providers
 {
@@ -21,7 +14,7 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.Providers
         [Test, MoqAutoData]
         public async Task Then_Gets_Account_From_Mediator(
             int ukprn,
-            ApplicationStatus status,
+            ApplicationReviewStatus status,
             GetDashboardByUkprnQueryResult mediatorResult,
             [Frozen] Mock<IMediator> mockMediator,
             [Greedy] ProvidersController controller)
@@ -44,7 +37,7 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.Providers
         [Test, MoqAutoData]
         public async Task And_Exception_Then_Returns_Bad_Request(
             int ukprn,
-            ApplicationStatus status,
+            ApplicationReviewStatus status,
             GetDashboardByUkprnQueryResult mediatorResult,
             [Frozen] Mock<IMediator> mockMediator,
             [Greedy] ProvidersController controller)

--- a/src/Recruit/SFA.DAS.Recruit.Api/Controllers/EmployerAccountsController.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/Controllers/EmployerAccountsController.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -9,7 +6,10 @@ using SFA.DAS.Recruit.Application.Queries.GetAccount;
 using SFA.DAS.Recruit.Application.Queries.GetAccountLegalEntities;
 using SFA.DAS.Recruit.Application.Queries.GetApplicationReviewsCountByAccountId;
 using SFA.DAS.Recruit.Application.Queries.GetDashboardByAccountId;
-using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.Recruit.Enums;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace SFA.DAS.Recruit.Api.Controllers
 {
@@ -59,7 +59,7 @@ namespace SFA.DAS.Recruit.Api.Controllers
 
         [HttpGet]
         [Route("dashboard")]
-        public async Task<IActionResult> GetDashboard([FromRoute] long accountId, [FromQuery] ApplicationStatus status)
+        public async Task<IActionResult> GetDashboard([FromRoute] long accountId, [FromQuery] ApplicationReviewStatus status)
         {
             try
             {

--- a/src/Recruit/SFA.DAS.Recruit.Api/Controllers/ProvidersController.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/Controllers/ProvidersController.cs
@@ -6,7 +6,7 @@ using SFA.DAS.Recruit.Application.Queries.GetApplicationReviewsCountByUkprn;
 using SFA.DAS.Recruit.Application.Queries.GetDashboardByUkprn;
 using SFA.DAS.Recruit.Application.Queries.GetProvider;
 using SFA.DAS.Recruit.Application.Queries.GetProviders;
-using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.Recruit.Enums;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -62,7 +62,7 @@ namespace SFA.DAS.Recruit.Api.Controllers
 
         [HttpGet]
         [Route("{ukprn:int}/dashboard")]
-        public async Task<IActionResult> GetDashboard([FromRoute] int ukprn, [FromQuery] ApplicationStatus status)
+        public async Task<IActionResult> GetDashboard([FromRoute] int ukprn, [FromQuery] ApplicationReviewStatus status)
         {
             try
             {

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Candidates/Commands/WhenHandlingCandidateApplicationStatusCommand.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Candidates/Commands/WhenHandlingCandidateApplicationStatusCommand.cs
@@ -1,19 +1,15 @@
-using AutoFixture.NUnit3;
-using Moq;
-using NUnit.Framework;
 using SFA.DAS.Notifications.Messages.Commands;
 using SFA.DAS.Recruit.Application.Candidates.Commands.CandidateApplicationStatus;
 using SFA.DAS.Recruit.Domain;
+using SFA.DAS.Recruit.Enums;
 using SFA.DAS.Recruit.InnerApi.Requests;
 using SFA.DAS.Recruit.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Configuration;
 using SFA.DAS.SharedOuterApi.Interfaces;
 using SFA.DAS.SharedOuterApi.Models;
-using SFA.DAS.Testing.AutoFixture;
 using System;
 using System.Net;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Recruit.UnitTests.Application.Candidates.Commands;
 

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingTheGetDashboardByAccountIdApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingTheGetDashboardByAccountIdApiRequest.cs
@@ -1,3 +1,4 @@
+using SFA.DAS.Recruit.Enums;
 using SFA.DAS.Recruit.InnerApi.Requests;
 
 namespace SFA.DAS.Recruit.UnitTests.Application.InnerApi.Requests
@@ -5,7 +6,7 @@ namespace SFA.DAS.Recruit.UnitTests.Application.InnerApi.Requests
     public class WhenBuildingTheGetDashboardByAccountIdApiRequest
     {
         [Test, AutoData]
-        public void Then_The_Url_Is_Correctly_Constructed(long accountId, ApplicationStatus status)
+        public void Then_The_Url_Is_Correctly_Constructed(long accountId, ApplicationReviewStatus status)
         {
             //Act
             var actual = new GetDashboardByAccountIdApiRequest(accountId, status);

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingTheGetDashboardByUkprnApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingTheGetDashboardByUkprnApiRequest.cs
@@ -1,6 +1,4 @@
-using AutoFixture.NUnit3;
-using FluentAssertions;
-using NUnit.Framework;
+using SFA.DAS.Recruit.Enums;
 using SFA.DAS.Recruit.InnerApi.Requests;
 
 namespace SFA.DAS.Recruit.UnitTests.Application.InnerApi.Requests
@@ -8,7 +6,7 @@ namespace SFA.DAS.Recruit.UnitTests.Application.InnerApi.Requests
     public class WhenBuildingTheGetDashboardByUkprnApiRequest
     {
         [Test, AutoData]
-        public void Then_The_Url_Is_Correctly_Constructed(int ukprn, ApplicationStatus status)
+        public void Then_The_Url_Is_Correctly_Constructed(int ukprn, ApplicationReviewStatus status)
         {
             //Act
             var actual = new GetDashboardByUkprnApiRequest(ukprn, status);

--- a/src/Recruit/SFA.DAS.Recruit.sln
+++ b/src/Recruit/SFA.DAS.Recruit.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.Recruit.UnitTests",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.SharedOuterApi.UnitTests", "..\Shared\SFA.DAS.SharedOuterApi.UnitTests\SFA.DAS.SharedOuterApi.UnitTests.csproj", "{41D340D7-A7E7-4430-B7F3-C5C1A90DD113}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.SharedOuterApi.Employer.GovUK.Auth", "..\Shared\SFA.DAS.SharedOuterApi.Employer.GovUK.Auth\SFA.DAS.SharedOuterApi.Employer.GovUK.Auth.csproj", "{A5A83116-5DAD-BC79-2B61-339EBE131F9A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{41D340D7-A7E7-4430-B7F3-C5C1A90DD113}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{41D340D7-A7E7-4430-B7F3-C5C1A90DD113}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41D340D7-A7E7-4430-B7F3-C5C1A90DD113}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5A83116-5DAD-BC79-2B61-339EBE131F9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5A83116-5DAD-BC79-2B61-339EBE131F9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5A83116-5DAD-BC79-2B61-339EBE131F9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5A83116-5DAD-BC79-2B61-339EBE131F9A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Recruit/SFA.DAS.Recruit/Application/Candidates/Commands/CandidateApplicationStatus/CandidateApplicationStatusCommandHandler.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Candidates/Commands/CandidateApplicationStatus/CandidateApplicationStatusCommandHandler.cs
@@ -12,6 +12,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using SFA.DAS.Recruit.Enums;
 
 namespace SFA.DAS.Recruit.Application.Candidates.Commands.CandidateApplicationStatus;
 

--- a/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetDashboardByAccountId/GetDashboardByAccountIdQuery.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetDashboardByAccountId/GetDashboardByAccountIdQuery.cs
@@ -1,8 +1,8 @@
 ﻿using MediatR;
-using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.Recruit.Enums;
 
 namespace SFA.DAS.Recruit.Application.Queries.GetDashboardByAccountId
 {
-    public record GetDashboardByAccountIdQuery(long AccountId, ApplicationStatus Status)
+    public record GetDashboardByAccountIdQuery(long AccountId, ApplicationReviewStatus Status)
         : IRequest<GetDashboardByAccountIdQueryResult>;
 }

--- a/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetDashboardByUkprn/GetDashboardByUkprnQuery.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetDashboardByUkprn/GetDashboardByUkprnQuery.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
-using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.Recruit.Enums;
 
 namespace SFA.DAS.Recruit.Application.Queries.GetDashboardByUkprn
 {
-    public record GetDashboardByUkprnQuery(int Ukprn, ApplicationStatus Status) : IRequest<GetDashboardByUkprnQueryResult>;
+    public record GetDashboardByUkprnQuery(int Ukprn, ApplicationReviewStatus Status) : IRequest<GetDashboardByUkprnQueryResult>;
 }

--- a/src/Recruit/SFA.DAS.Recruit/Enums/ApplicationReviewStatus.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Enums/ApplicationReviewStatus.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json.Serialization;
+
+namespace SFA.DAS.Recruit.Enums
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum ApplicationReviewStatus : short
+    {
+        New = 0,
+        Successful = 1,
+        Unsuccessful = 2,
+        Shared = 3,
+        InReview = 4,
+        Interviewing = 5,
+        EmployerInterviewing = 6,
+        EmployerUnsuccessful = 7,
+        PendingShared = 8,
+        PendingToMakeUnsuccessful = 9
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Enums/ApplicationStatus.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Enums/ApplicationStatus.cs
@@ -1,0 +1,11 @@
+﻿namespace SFA.DAS.Recruit.Enums
+{
+    public enum ApplicationStatus : short
+    {
+        Draft = 0,
+        Submitted = 1,
+        Withdrawn = 2,
+        Successful = 3,
+        UnSuccessful = 4,
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetDashboardByAccountIdApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetDashboardByAccountIdApiRequest.cs
@@ -1,8 +1,9 @@
-﻿using SFA.DAS.SharedOuterApi.Interfaces;
+﻿using SFA.DAS.Recruit.Enums;
+using SFA.DAS.SharedOuterApi.Interfaces;
 
 namespace SFA.DAS.Recruit.InnerApi.Requests
 {
-    public record GetDashboardByAccountIdApiRequest(long AccountId, ApplicationStatus Status) : IGetApiRequest
+    public record GetDashboardByAccountIdApiRequest(long AccountId, ApplicationReviewStatus Status) : IGetApiRequest
     {
         public string GetUrl => $"api/employer/{AccountId}/applicationReviews/dashboard?status={Status}";
     }

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetDashboardByUkprnApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetDashboardByUkprnApiRequest.cs
@@ -1,8 +1,9 @@
-﻿using SFA.DAS.SharedOuterApi.Interfaces;
+﻿using SFA.DAS.Recruit.Enums;
+using SFA.DAS.SharedOuterApi.Interfaces;
 
 namespace SFA.DAS.Recruit.InnerApi.Requests
 {
-    public record GetDashboardByUkprnApiRequest(int Ukprn, ApplicationStatus Status) : IGetApiRequest
+    public record GetDashboardByUkprnApiRequest(int Ukprn, ApplicationReviewStatus Status) : IGetApiRequest
     {
         public string GetUrl => $"api/provider/{Ukprn}/applicationReviews/dashboard?status={Status}";
     }

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/PatchApplicationRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/PatchApplicationRequest.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.AspNetCore.JsonPatch;
+using SFA.DAS.Recruit.Enums;
 using SFA.DAS.SharedOuterApi.Interfaces;
 
 namespace SFA.DAS.Recruit.InnerApi.Requests;
@@ -26,12 +27,4 @@ public class Application
 {
     public string ResponseNotes { get; set; }
     public ApplicationStatus Status { get; set; }
-}
-public enum ApplicationStatus
-{
-    Draft = 0,
-    Submitted = 1,
-    Withdrawn = 2,
-    Successful = 3,
-    UnSuccessful = 4,
 }


### PR DESCRIPTION
✨ Refactor application status handling to use enums

- Transitioned from `ApplicationStatus` to `ApplicationReviewStatus`.
- Updated test files to reflect new status parameter type.
- Modified controller methods to accept `ApplicationReviewStatus`.
- Adjusted query and API request classes for new status type.
- Added new enum definitions for better application status granularity.

Changes made by Balaji Jambulingam