### PR TITLE
CSP-2063 - Upgraded das-platform-building-blocks to tag number 3.0.8

### DIFF
--- a/src/AdminAan/azure-pipelines.yml
+++ b/src/AdminAan/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/AparRegister/azure-pipelines.yml
+++ b/src/AparRegister/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/EmployerAan/azure-pipelines.yml
+++ b/src/EmployerAan/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/EmployerPR/azure-pipelines.yml
+++ b/src/EmployerPR/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/FindApprenticeshipTraining/azure-pipelines.yml
+++ b/src/FindApprenticeshipTraining/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/ProviderPR/azure-pipelines.yml
+++ b/src/ProviderPR/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/Roatp/azure-pipelines.yml
+++ b/src/Roatp/azure-pipelines.yml
@@ -34,7 +34,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/RoatpCourseManagement/azure-pipelines.yml
+++ b/src/RoatpCourseManagement/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/RoatpOversight/azure-pipelines.yml
+++ b/src/RoatpOversight/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/src/RoatpProviderModeration/azure-pipelines.yml
+++ b/src/RoatpProviderModeration/azure-pipelines.yml
@@ -35,7 +35,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/3.0.6
+    ref: refs/tags/3.0.8
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github


### PR DESCRIPTION
CSP-2063 - Upgraded the following outers to use das-platform-building-blocks to tag number 3.0.8:

AdminAan
AparRegister
EmployerAan
EmployerPR
FindApprenticeshipTraining
ProviderPR
Roatp
RoatpCourseManagement
RoatpOversight
RoatpProviderModeration