### PR TITLE
FAI-1929 Recruit - Remove and replace EmployerInfo view in mongoDb

### DIFF
--- a/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/EmployerAccounts/WhenGettingAllAccountLegalEntities.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/EmployerAccounts/WhenGettingAllAccountLegalEntities.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Recruit.Api.Controllers;
+using SFA.DAS.Recruit.Application.Queries.GetAllAccountLegalEntities;
+using System;
+using System.Net;
+using System.Threading;
+
+namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.EmployerAccounts
+{
+    [TestFixture]
+    public class WhenGettingAllAccountLegalEntities
+    {
+        [Test, MoqAutoData]
+        public async Task Then_Gets_Account_From_Mediator(
+            long accountId,
+            int pageNumber,
+            int pageSize,
+            string sortColumn,
+            bool isAscending,
+            GetAllAccountLegalEntitiesQueryResult mediatorResult,
+            [Frozen] Mock<IMediator> mockMediator,
+            [Greedy] EmployerAccountsController controller)
+        {
+            mockMediator
+                .Setup(mediator => mediator.Send(
+                    It.Is<GetAllAccountLegalEntitiesQuery>(c => c.AccountId.Equals(accountId) 
+                                                                && c.PageNumber.Equals(pageNumber)
+                                                                && c.PageSize.Equals(pageSize)
+                                                                && c.SortColumn.Equals(sortColumn)
+                                                                && c.IsAscending.Equals(isAscending)),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mediatorResult);
+
+            var controllerResult = await controller.GetAllAccountLegalEntities(accountId, pageNumber, pageSize, sortColumn, isAscending) as ObjectResult;
+
+            Assert.That(controllerResult, Is.Not.Null);
+            controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+            var model = controllerResult.Value as GetAllAccountLegalEntitiesQueryResult;
+            Assert.That(model, Is.Not.Null);
+            model.LegalEntities.Should().BeEquivalentTo(mediatorResult.LegalEntities);
+            model.PageInfo.Should().Be(mediatorResult.PageInfo);
+        }
+
+        [Test, MoqAutoData]
+        public async Task And_Exception_Then_Returns_Bad_Request(
+            long accountId,
+            int pageNumber,
+            int pageSize,
+            string sortColumn,
+            bool isAscending,
+            GetAllAccountLegalEntitiesQueryResult mediatorResult,
+            [Frozen] Mock<IMediator> mockMediator,
+            [Greedy] EmployerAccountsController controller)
+        {
+            mockMediator
+                .Setup(mediator => mediator.Send(
+                    It.Is<GetAllAccountLegalEntitiesQuery>(c => c.AccountId.Equals(accountId)
+                                                                && c.PageNumber.Equals(pageNumber)
+                                                                && c.PageSize.Equals(pageSize)
+                                                                && c.SortColumn.Equals(sortColumn)
+                                                                && c.IsAscending.Equals(isAscending)),
+                    It.IsAny<CancellationToken>()))
+                .Throws<InvalidOperationException>();
+
+            var controllerResult = await controller.GetAllAccountLegalEntities(accountId, pageNumber, pageSize, sortColumn, isAscending) as StatusCodeResult;
+
+            controllerResult!.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.Api/Controllers/EmployerAccountsController.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/Controllers/EmployerAccountsController.cs
@@ -6,10 +6,13 @@ using SFA.DAS.Recruit.Application.Queries.GetAccount;
 using SFA.DAS.Recruit.Application.Queries.GetAccountLegalEntities;
 using SFA.DAS.Recruit.Application.Queries.GetApplicationReviewsCountByAccountId;
 using SFA.DAS.Recruit.Application.Queries.GetDashboardByAccountId;
-using SFA.DAS.Recruit.Application.Queries.GetDashboardByUkprn;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
 using System.Threading.Tasks;
+using SFA.DAS.Recruit.Application.Queries.GetAllAccountLegalEntities;
+using System.Net;
 
 namespace SFA.DAS.Recruit.Api.Controllers
 {
@@ -54,6 +57,29 @@ namespace SFA.DAS.Recruit.Api.Controllers
             {
                 logger.LogError(e, "Error getting account legal entities for account");
                 return BadRequest();
+            }
+        }
+
+        [HttpGet]
+        [Route("getAllLegalEntities")]
+        public async Task<IActionResult> GetAllAccountLegalEntities(
+            [FromRoute, Required] long accountId,
+            [FromQuery] int pageNumber = 1,
+            [FromQuery] int pageSize = 10,
+            [FromQuery] string sortColumn = "Name",
+            [FromQuery] bool isAscending = false, 
+            CancellationToken token = default)
+        {
+            try
+            {
+                var queryResult = await mediator.Send(new GetAllAccountLegalEntitiesQuery(accountId, pageNumber, pageSize, sortColumn, isAscending), token);
+
+                return Ok(queryResult);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error getting all legal entities for account");
+                return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }
 

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Queries/GetAccountLegalEntities/WhenHandlingGetAllAccountLegalEntitiesQuery.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Queries/GetAccountLegalEntities/WhenHandlingGetAllAccountLegalEntitiesQuery.cs
@@ -1,0 +1,40 @@
+﻿using SFA.DAS.Recruit.Application.Queries.GetAllAccountLegalEntities;
+using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.Recruit.InnerApi.Responses;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using System.Threading;
+
+namespace SFA.DAS.Recruit.UnitTests.Application.Queries.GetAccountLegalEntities
+{
+    [TestFixture]
+    public class WhenHandlingGetAllAccountLegalEntitiesQuery
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_Query_Is_Handled_And_Data_Returned(
+            GetAllAccountLegalEntitiesQuery query,
+            GetAllAccountLegalEntitiesApiResponse apiResponse,
+            [Frozen] Mock<IAccountsApiClient<AccountsConfiguration>> accountApiClient,
+            [Greedy] GetAllAccountLegalEntitiesQueryHandler handler)
+        {
+            //Arrange
+            var expectedGet = new GetAllAccountLegalEntitiesApiRequest(
+                query.AccountId,
+                query.PageNumber,
+                query.PageSize,
+                query.SortColumn,
+                query.IsAscending);
+
+            accountApiClient
+                .Setup(x => x.Get<GetAllAccountLegalEntitiesApiResponse>(
+                    It.Is<GetAllAccountLegalEntitiesApiRequest>(c => c.GetUrl.Equals(expectedGet.GetUrl))))
+                .ReturnsAsync(apiResponse);
+
+            //Act
+            var actual = await handler.Handle(query, CancellationToken.None);
+
+            //Assert
+            actual.Should().BeEquivalentTo(apiResponse);
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Queries/GetAccountLegalEntities/WhenMappingApiResponseWithGetAllAccountLegalEntitiesResult.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Queries/GetAccountLegalEntities/WhenMappingApiResponseWithGetAllAccountLegalEntitiesResult.cs
@@ -1,0 +1,21 @@
+﻿using SFA.DAS.Recruit.Application.Queries.GetAllAccountLegalEntities;
+using SFA.DAS.Recruit.InnerApi.Responses;
+
+namespace SFA.DAS.Recruit.UnitTests.Application.Queries.GetAccountLegalEntities
+{
+    [TestFixture]
+    public class WhenMappingApiResponseWithGetAllAccountLegalEntitiesResult
+    {
+        [Test, MoqAutoData]
+        public void ImplicitOperator_MapsApiResponseToQueryResult(
+            GetAllAccountLegalEntitiesApiResponse response)
+        {
+            // Act
+            GetAllAccountLegalEntitiesQueryResult result = response;
+
+            // Assert
+            result.PageInfo.Should().Be(response.PageInfo);
+            result.LegalEntities.Should().BeEquivalentTo(response.LegalEntities);
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/InnerApi/WhenBuildingGetAllAccountLegalEntitiesApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/InnerApi/WhenBuildingGetAllAccountLegalEntitiesApiRequest.cs
@@ -1,0 +1,15 @@
+﻿using SFA.DAS.Recruit.InnerApi.Requests;
+
+namespace SFA.DAS.Recruit.UnitTests.InnerApi
+{
+    [TestFixture]
+    public class WhenBuildingGetAllAccountLegalEntitiesApiRequest
+    {
+        [Test, AutoData]
+        public void Then_The_Url_Is_Constructed(long accountId, int pageNumber, int pageSize, string sortColumn, bool isAscending)
+        {
+            var actual = new GetAllAccountLegalEntitiesApiRequest(accountId, pageNumber, pageSize, sortColumn, isAscending);
+            actual.GetUrl.Should().Be($"api/accounts/{accountId}/legalentities/getall?pageNumber={pageNumber}&pageSize={pageSize}&sortColumn={sortColumn}&isAscending={isAscending}");
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetAllAccountLegalEntities/GetAllAccountLegalEntitiesQuery.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetAllAccountLegalEntities/GetAllAccountLegalEntitiesQuery.cs
@@ -1,0 +1,7 @@
+﻿using MediatR;
+
+namespace SFA.DAS.Recruit.Application.Queries.GetAllAccountLegalEntities
+{
+    public sealed record GetAllAccountLegalEntitiesQuery(long AccountId, int PageNumber, int PageSize, string SortColumn, bool IsAscending)
+        : IRequest<GetAllAccountLegalEntitiesQueryResult>;
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetAllAccountLegalEntities/GetAllAccountLegalEntitiesQueryHandler.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetAllAccountLegalEntities/GetAllAccountLegalEntitiesQueryHandler.cs
@@ -1,0 +1,23 @@
+﻿using MediatR;
+using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.Recruit.InnerApi.Responses;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Recruit.Application.Queries.GetAllAccountLegalEntities
+{
+    public class GetAllAccountLegalEntitiesQueryHandler(IAccountsApiClient<AccountsConfiguration> apiClient)
+        : IRequestHandler<GetAllAccountLegalEntitiesQuery, GetAllAccountLegalEntitiesQueryResult>
+    {
+        public async Task<GetAllAccountLegalEntitiesQueryResult> Handle(GetAllAccountLegalEntitiesQuery request, CancellationToken cancellationToken)
+        {
+            var response =
+                await apiClient.Get<GetAllAccountLegalEntitiesApiResponse>(
+                    new GetAllAccountLegalEntitiesApiRequest(request.AccountId, request.PageNumber, request.PageSize, request.SortColumn, request.IsAscending));
+
+            return response;
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetAllAccountLegalEntities/GetAllAccountLegalEntitiesQueryResult.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetAllAccountLegalEntities/GetAllAccountLegalEntitiesQueryResult.cs
@@ -1,0 +1,20 @@
+﻿using SFA.DAS.Recruit.InnerApi.Responses;
+using System.Collections.Generic;
+
+namespace SFA.DAS.Recruit.Application.Queries.GetAllAccountLegalEntities
+{
+    public record GetAllAccountLegalEntitiesQueryResult
+    {
+        public GetAllAccountLegalEntitiesApiResponse.PaginationInfo PageInfo { get; set; }
+        public List<GetAccountLegalEntityResponseItem> LegalEntities { get; set; }
+
+        public static implicit operator GetAllAccountLegalEntitiesQueryResult(GetAllAccountLegalEntitiesApiResponse response)
+        {
+            return new GetAllAccountLegalEntitiesQueryResult
+            {
+                PageInfo = response.PageInfo,
+                LegalEntities = response.LegalEntities
+            };
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetAllAccountLegalEntitiesApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetAllAccountLegalEntitiesApiRequest.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.Recruit.InnerApi.Requests
+{
+    public record GetAllAccountLegalEntitiesApiRequest(long AccountId, int PageNumber, int PageSize, string SortColumn, bool IsAscending) : IGetApiRequest
+    {
+        public string GetUrl => $"api/accounts/{AccountId}/legalentities/getall?pageNumber={PageNumber}&pageSize={PageSize}&sortColumn={SortColumn}&isAscending={IsAscending}";
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetAccountLegalEntitiesResponse.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetAccountLegalEntitiesResponse.cs
@@ -16,5 +16,4 @@ namespace SFA.DAS.Recruit.InnerApi.Responses
         public long AccountLegalEntityId { get; set; }
         public string DasAccountId { get; set; }
     }
-    
 }

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetAllAccountLegalEntitiesApiResponse.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetAllAccountLegalEntitiesApiResponse.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace SFA.DAS.Recruit.InnerApi.Responses
+{
+    public record GetAllAccountLegalEntitiesApiResponse
+    {
+        [JsonProperty("pageInfo")]
+        public PaginationInfo PageInfo { get; set; }
+
+        [JsonProperty("legalEntities")]
+        public List<GetAccountLegalEntityResponseItem> LegalEntities { get; set; }
+
+        public class PaginationInfo
+        {
+            [JsonProperty("totalCount")]
+            public int TotalCount { get; set; }
+
+            [JsonProperty("pageIndex")]
+            public int PageIndex { get; set; }
+
+            [JsonProperty("pageSize")]
+            public int PageSize { get; set; }
+
+            [JsonProperty("totalPages")]
+            public int TotalPages { get; set; }
+
+            [JsonProperty("hasPreviousPage")]
+            public bool HasPreviousPage { get; set; }
+
+            [JsonProperty("hasNextPage")]
+            public bool HasNextPage { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
✨ Add endpoint to retrieve all account legal entities

- Introduced `GetAllAccountLegalEntities` method in `EmployerAccountsController`.
- Created `GetAllAccountLegalEntitiesQuery` for query parameters.
- Implemented `GetAllAccountLegalEntitiesQueryHandler` for data retrieval.
- Added unit tests for successful retrieval and error handling.
- Cleaned up using directives for better code organization.

Changes made by Balaji Jambulingam