### PR TITLE
FAI-2472 View an application foundation apprenticeships

### DIFF
--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Controllers/ApplicationController.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Controllers/ApplicationController.cs
@@ -25,23 +25,14 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
 {
     [ApiController]
     [Route("[controller]s/{applicationId}")]
-    public class ApplicationController : Controller
+    public class ApplicationController(IMediator mediator, ILogger<ApplicationController> logger) : Controller
     {
-        private readonly IMediator _mediator;
-        private readonly ILogger<ApplicationController> _logger;
-
-        public ApplicationController(IMediator mediator, ILogger<ApplicationController> logger)
-        {
-            _mediator = mediator;
-            _logger = logger;
-        }
-
         [HttpGet]
         public async Task<IActionResult> Index([FromRoute] Guid applicationId, [FromQuery] Guid candidateId)
         {
             try
             {
-                var result = await _mediator.Send(new GetIndexQuery
+                var result = await mediator.Send(new GetIndexQuery
                 { CandidateId = candidateId, ApplicationId = applicationId });
 
                 if (result == null) return NotFound();
@@ -50,7 +41,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"Error getting application index {applicationId}", applicationId);
+                logger.LogError(e, $"Error getting application index {applicationId}", applicationId);
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }
@@ -60,7 +51,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
         {
             try
             {
-                var result = await _mediator.Send(new GetApplicationQuery
+                var result = await mediator.Send(new GetApplicationQuery
                     { CandidateId = candidateId, ApplicationId = applicationId });
 
                 if (result == null) return NotFound();
@@ -69,7 +60,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"Error getting GetApplicationDetails {applicationId}", applicationId);
+                logger.LogError(e, $"Error getting GetApplicationDetails {applicationId}", applicationId);
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }
@@ -79,7 +70,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
         {
             try
             {
-                var result = await _mediator.Send(new GetApplicationViewQuery
+                var result = await mediator.Send(new GetApplicationViewQuery
                 { CandidateId = candidateId, ApplicationId = applicationId });
 
                 if (result == null) return NotFound();
@@ -88,7 +79,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"Error getting GetApplication {applicationId}", applicationId);
+                logger.LogError(e, "Error getting GetApplication {Id}", applicationId);
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }
@@ -103,7 +94,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             [FromBody] UpdateApplicationStatusModel request,
             CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(new PatchApplicationStatusCommand
+            var result = await mediator.Send(new PatchApplicationStatusCommand
             {
                 ApplicationId = applicationId,
                 CandidateId = candidateId,
@@ -128,7 +119,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             [FromBody] UpdateApplicationWorkHistoryModel request,
             CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(new PatchApplicationWorkHistoryCommand
+            var result = await mediator.Send(new PatchApplicationWorkHistoryCommand
             {
                 ApplicationId = applicationId,
                 CandidateId = candidateId,
@@ -153,7 +144,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             [FromBody] UpdateApplicationTrainingCoursesModel request,
             CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(new PatchApplicationTrainingCoursesCommand
+            var result = await mediator.Send(new PatchApplicationTrainingCoursesCommand
             {
                 ApplicationId = applicationId,
                 CandidateId = candidateId,
@@ -178,7 +169,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             [FromBody] UpdateVolunteeringAndWorkExperienceModel request,
             CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(new PatchApplicationVolunteeringAndWorkExperienceCommand
+            var result = await mediator.Send(new PatchApplicationVolunteeringAndWorkExperienceCommand
             {
                 ApplicationId = applicationId,
                 CandidateId = candidateId,
@@ -203,7 +194,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             [FromBody] UpdateDisabilityConfidenceModel request,
             CancellationToken cancellationToken)
         {
-            var result = await _mediator.Send(new PatchApplicationDisabilityConfidenceCommand
+            var result = await mediator.Send(new PatchApplicationDisabilityConfidenceCommand
             {
                 ApplicationId = applicationId,
                 CandidateId = candidateId,
@@ -227,7 +218,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
         {
             try
             {
-                await _mediator.Send(new SubmitApplicationCommand
+                await mediator.Send(new SubmitApplicationCommand
                 {
                     ApplicationId = applicationId,
                     CandidateId = candidateId
@@ -237,7 +228,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Error submitting submitted {applicationId}", applicationId);
+                logger.LogError(ex, $"Error submitting submitted {applicationId}", applicationId);
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
             
@@ -248,7 +239,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
         {
             try
             {
-                var result = await _mediator.Send(new GetApplicationSubmittedQuery
+                var result = await mediator.Send(new GetApplicationSubmittedQuery
                 {
                     ApplicationId = applicationId,
                     CandidateId = candidateId
@@ -260,7 +251,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Error getting application submitted {applicationId}", applicationId);
+                logger.LogError(ex, $"Error getting application submitted {applicationId}", applicationId);
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }
@@ -270,7 +261,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
         {
             try
             {
-                var result = await _mediator.Send(new WithdrawApplicationQuery
+                var result = await mediator.Send(new WithdrawApplicationQuery
                     { ApplicationId = applicationId, CandidateId = candidateId });
 
                 if (result == null || result.ApplicationId == Guid.Empty)
@@ -282,7 +273,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"Error getting withdrawn application {applicationId}", applicationId);
+                logger.LogError(e, $"Error getting withdrawn application {applicationId}", applicationId);
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }
@@ -292,7 +283,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
         {
             try
             {
-                await _mediator.Send(new WithdrawApplicationCommand
+                await mediator.Send(new WithdrawApplicationCommand
                 {
                     ApplicationId = applicationId,
                     CandidateId = candidateId
@@ -301,7 +292,7 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Controllers
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"Error posting withdrawn application {applicationId}", applicationId);
+                logger.LogError(e, $"Error posting withdrawn application {applicationId}", applicationId);
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Models/Applications/GetApplicationViewApiResponse.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship.Api/Models/Applications/GetApplicationViewApiResponse.cs
@@ -1,4 +1,5 @@
 using SFA.DAS.FindAnApprenticeship.Application.Queries.Applications.GetApplication;
+using SFA.DAS.SharedOuterApi.Domain;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,19 +8,20 @@ namespace SFA.DAS.FindAnApprenticeship.Api.Models.Applications;
 
 public record GetApplicationViewApiResponse
 {
-    public VacancyDetailsSection VacancyDetails { get; set; }
+    public AboutYouSection AboutYou { get; set; }
+    public ApplicationQuestionsSection ApplicationQuestions { get; set; }
+    public ApprenticeshipTypes? ApprenticeshipType { get; set; } = ApprenticeshipTypes.Standard;
     public bool IsDisabilityConfident { get; set; }
     public CandidateDetailsSection Candidate { get; set; }
-    public AboutYouSection AboutYou { get; set; }
-    public EducationHistorySection EducationHistory { get; set; }
-    public WorkHistorySection WorkHistory { get; set; }
-    public ApplicationQuestionsSection ApplicationQuestions { get; set; }
-    public InterviewAdjustmentsSection InterviewAdjustments { get; set; }
-    public DisabilityConfidenceSection DisabilityConfidence { get; set; }
-    public WhatIsYourInterestSection WhatIsYourInterest { get; set; }
-    public string ApplicationStatus { get; set; }
-    public DateTime? WithdrawnDate { get; set; }
     public DateTime? MigrationDate { get; set; }
+    public DateTime? WithdrawnDate { get; set; }
+    public DisabilityConfidenceSection DisabilityConfidence { get; set; }
+    public EducationHistorySection EducationHistory { get; set; }
+    public InterviewAdjustmentsSection InterviewAdjustments { get; set; }
+    public string ApplicationStatus { get; set; }
+    public VacancyDetailsSection VacancyDetails { get; set; }
+    public WhatIsYourInterestSection WhatIsYourInterest { get; set; }
+    public WorkHistorySection WorkHistory { get; set; }
 
     public static implicit operator GetApplicationViewApiResponse(GetApplicationViewQueryResult source)
     {
@@ -38,6 +40,7 @@ public record GetApplicationViewApiResponse
             ApplicationStatus = source.ApplicationStatus,
             WithdrawnDate = source.WithdrawnDate,
             MigrationDate = source.MigrationDate,
+            ApprenticeshipType = source.ApprenticeshipType
         };
     }
 

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplication/GetApplicationViewQueryHandler.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplication/GetApplicationViewQueryHandler.cs
@@ -133,6 +133,7 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.Applications.GetAppli
                 ApplicationStatus = application.Status.ToString(),
                 WithdrawnDate = application.WithdrawnDate,
                 MigrationDate = application.MigrationDate,
+                ApprenticeshipType = vacancy.ApprenticeshipType,
             };
         }
     }

--- a/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplication/GetApplicationViewQueryResult.cs
+++ b/src/FindAnApprenticeship/SFA.DAS.FindAnApprenticeship/Application/Queries/Applications/GetApplication/GetApplicationViewQueryResult.cs
@@ -1,4 +1,5 @@
 ﻿using SFA.DAS.FindAnApprenticeship.InnerApi.CandidateApi.Responses;
+using SFA.DAS.SharedOuterApi.Domain;
 using System;
 using System.Collections.Generic;
 
@@ -6,19 +7,20 @@ namespace SFA.DAS.FindAnApprenticeship.Application.Queries.Applications.GetAppli
 {
     public record GetApplicationViewQueryResult
     {
-        public VacancyDetailsSection VacancyDetails { get; set; }
+        public AboutYouSection AboutYou { get; set; }
+        public ApplicationQuestionsSection ApplicationQuestions { get; set; }
+        public ApprenticeshipTypes? ApprenticeshipType { get; set; } = ApprenticeshipTypes.Standard;
         public bool IsDisabilityConfident { get; set; }
         public Candidate CandidateDetails { get; set; }
-        public AboutYouSection AboutYou { get; set; }
-        public EducationHistorySection EducationHistory { get; set; }
-        public WorkHistorySection WorkHistory { get; set; }
-        public ApplicationQuestionsSection ApplicationQuestions { get; set; }
-        public InterviewAdjustmentsSection InterviewAdjustments { get; set; }
-        public DisabilityConfidenceSection DisabilityConfidence { get; set; }
-        public WhatIsYourInterestSection WhatIsYourInterest { get; set; }
-        public string ApplicationStatus { get; set; }
-        public DateTime? WithdrawnDate { get; set; }
         public DateTime? MigrationDate { get; set; }
+        public DateTime? WithdrawnDate { get; set; }
+        public DisabilityConfidenceSection DisabilityConfidence { get; set; }
+        public EducationHistorySection EducationHistory { get; set; }
+        public InterviewAdjustmentsSection InterviewAdjustments { get; set; }
+        public string ApplicationStatus { get; set; }
+        public VacancyDetailsSection VacancyDetails { get; set; }
+        public WhatIsYourInterestSection WhatIsYourInterest { get; set; }
+        public WorkHistorySection WorkHistory { get; set; }
 
         public record VacancyDetailsSection
         {


### PR DESCRIPTION
✨ Refactor ApplicationController and response models

- Use constructor injection for IMediator and ILogger in ApplicationController.
- Update method calls to use injected parameters instead of private fields.
- Reorder and modify properties in GetApplicationViewApiResponse and GetApplicationViewQueryResult.
- Add new properties like MigrationDate and WithdrawnDate to response models.
- Improve logging practices by using injected logger parameter.

Changes made by Balaji Jambulingam