### PR TITLE
FAI-2618 Recruit - sharing applications need updating in recruit v2

### DIFF
--- a/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/ApplicationReviews/WhenPostingApplicationReview.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/ApplicationReviews/WhenPostingApplicationReview.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Recruit.Api.Controllers;
+using SFA.DAS.Recruit.Api.Models;
+using SFA.DAS.Recruit.Application.ApplicationReview.Command.PatchApplicationReview;
+using System;
+using System.Net;
+using System.Threading;
+
+namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.ApplicationReviews
+{
+    [TestFixture]
+    public class WhenPostingApplicationReview
+    {
+        [Test, MoqAutoData]
+        public async Task Then_Gets_Account_From_Mediator(
+            Guid applicationId,
+            PostApplicationReviewApiRequest request,
+            [Frozen] Mock<IMediator> mockMediator,
+            [Greedy] ApplicationReviewsController controller)
+        {
+
+            var actual = await controller.UpdateApplicationReview(applicationId, request) as NoContentResult;
+
+            actual.Should().NotBeNull();
+            mockMediator.Verify(x => x.Send(It.Is<PatchApplicationReviewCommand>(
+                c =>
+                    c.Id == applicationId
+                    && c.Status == request.Status
+                    && c.DateSharedWithEmployer == request.DateSharedWithEmployer
+                    && c.TemporaryReviewStatus == request.TemporaryReviewStatus
+                    && c.HasEverBeenEmployerInterviewing == request.HasEverBeenEmployerInterviewing
+                    && c.EmployerFeedback == request.EmployerFeedback
+            ), CancellationToken.None), Times.Once);
+        }
+
+        [Test, MoqAutoData]
+        public async Task And_Exception_Then_Returns_Bad_Request(
+            Guid applicationId,
+            PostApplicationReviewApiRequest request,
+            [Frozen] Mock<IMediator> mockMediator,
+            [Greedy] ApplicationReviewsController controller)
+        {
+            mockMediator
+                .Setup(mediator => mediator.Send(
+                    It.IsAny<PatchApplicationReviewCommand>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws<InvalidOperationException>();
+
+            var actual = await controller.UpdateApplicationReview(applicationId, request) as StatusCodeResult;
+
+            actual.Should().NotBeNull();
+            actual!.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.Api/Controllers/ApplicationReviewsController.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/Controllers/ApplicationReviewsController.cs
@@ -1,0 +1,44 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.Recruit.Api.Models;
+using SFA.DAS.Recruit.Application.ApplicationReview.Command.PatchApplicationReview;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Recruit.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ApplicationReviewsController(IMediator mediator,
+        ILogger<ApplicationReviewsController> logger) : ControllerBase
+    {
+        [HttpPost]
+        [Route("{id:guid}")]
+        public async Task<IActionResult> UpdateApplicationReview(
+            [FromRoute, Required] Guid id,
+            [FromBody] PostApplicationReviewApiRequest request,
+            CancellationToken token = default)
+        {
+            try
+            {
+                await mediator.Send(new PatchApplicationReviewCommand(id,
+                    request.Status,
+                    request.TemporaryReviewStatus,
+                    request.EmployerFeedback,
+                    request.HasEverBeenEmployerInterviewing,
+                    request.DateSharedWithEmployer), token);
+
+                return NoContent();
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error posting application review");
+                return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
+            }
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.Api/Models/PostApplicationReviewApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/Models/PostApplicationReviewApiRequest.cs
@@ -1,0 +1,14 @@
+﻿#nullable enable
+using System;
+
+namespace SFA.DAS.Recruit.Api.Models
+{
+    public sealed record PostApplicationReviewApiRequest
+    {
+        public bool HasEverBeenEmployerInterviewing { get; init; }
+        public DateTime? DateSharedWithEmployer { get; init; }
+        public string? EmployerFeedback { get; init; } = null;
+        public required string Status { get; init; }
+        public string? TemporaryReviewStatus { get; init; } = null;
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/ApplicationReviews/Command/WhenHandlingPatchApplicationReviewCommand.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/ApplicationReviews/Command/WhenHandlingPatchApplicationReviewCommand.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.AspNetCore.JsonPatch;
+using SFA.DAS.Recruit.Application.ApplicationReview.Command.PatchApplicationReview;
+using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using SFA.DAS.SharedOuterApi.Models;
+using System;
+using System.Net;
+using System.Threading;
+
+namespace SFA.DAS.Recruit.UnitTests.Application.ApplicationReviews.Command
+{
+    [TestFixture]
+    public class WhenHandlingPatchApplicationReviewCommand
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_Command_Is_Handled_And_The_Api_Called_And_Success(
+         PatchApplicationReviewCommand request,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+         PatchApplicationReviewCommandHandler handler)
+        {
+            recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewApiRequest>()))
+                .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
+
+            await handler.Handle(request, CancellationToken.None);
+            
+            recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewApiRequest>(c =>
+                    c.PatchUrl.Contains(request.Id.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
+
+                    c.Data.Operations[0].path == "/Status" &&
+                    c.Data.Operations[0].value.ToString() == request.Status &&
+
+                    c.Data.Operations[1].path == "/HasEverBeenEmployerInterviewing" &&
+                    c.Data.Operations[1].value.ToString() == request.HasEverBeenEmployerInterviewing.ToString() &&
+
+                    c.Data.Operations[2].path == "/EmployerFeedback" &&
+                    c.Data.Operations[2].value.ToString() == request.EmployerFeedback
+                )), Times.Once
+            );
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_The_Api_Response_NotFound_CommandResult_Is_Returned_As_Expected(
+            PatchApplicationReviewCommand request,
+            [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+            PatchApplicationReviewCommandHandler handler)
+        {
+            var expectedPatchRequest = new PatchRecruitApplicationReviewApiRequest(request.Id, new JsonPatchDocument<ApplicationReview>());
+
+            recruitApiClient
+                .Setup(client => client.PatchWithResponseCode(It.Is<PatchApplicationApiRequest>(r => r.PatchUrl == expectedPatchRequest.PatchUrl)))
+                .ReturnsAsync(new ApiResponse<string>("", HttpStatusCode.BadRequest, string.Empty));
+
+            Func<Task> act = async () => { await handler.Handle(request, CancellationToken.None); };
+            await act.Should().ThrowAsync<ArgumentException>();
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Candidates/Commands/WhenHandlingCandidateApplicationStatusCommand.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/Candidates/Commands/WhenHandlingCandidateApplicationStatusCommand.cs
@@ -30,7 +30,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
         apiClient.Setup(x => x.GetWithResponseCode<GetCandidateApiResponse>(It.Is<GetCandidateByIdApiRequest>(c=>c.GetUrl.Contains(request.CandidateId.ToString()))))
             .ReturnsAsync(new ApiResponse<GetCandidateApiResponse>(candidateResponse, HttpStatusCode.OK, ""));
-        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewApiRequest>()))
+        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewStatusApiRequest>()))
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
 
         await handler.Handle(request, CancellationToken.None);
@@ -44,7 +44,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
                 (ApplicationStatus)c.Data.Operations[1].value == ApplicationStatus.Successful
             )), Times.Once
         );
-        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewApiRequest>(c =>
+        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewStatusApiRequest>(c =>
                 c.PatchUrl.Contains(request.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
                 c.Data.Operations[0].path == "/CandidateFeedback" &&
                 c.Data.Operations[0].value.ToString() == request.Feedback &&
@@ -79,7 +79,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
         apiClient.Setup(x => x.GetWithResponseCode<GetCandidateApiResponse>(It.Is<GetCandidateByIdApiRequest>(c=>c.GetUrl.Contains(request.CandidateId.ToString()))))
             .ReturnsAsync(new ApiResponse<GetCandidateApiResponse>(candidateResponse, HttpStatusCode.OK, ""));
-        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewApiRequest>()))
+        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewStatusApiRequest>()))
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
 
         await handler.Handle(request, CancellationToken.None);
@@ -93,7 +93,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
                 (ApplicationStatus)c.Data.Operations[1].value == ApplicationStatus.UnSuccessful
             )), Times.Once
         );
-        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewApiRequest>(c =>
+        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewStatusApiRequest>(c =>
                 c.PatchUrl.Contains(request.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
                 c.Data.Operations[0].path == "/CandidateFeedback" &&
                 c.Data.Operations[0].value.ToString() == request.Feedback &&
@@ -129,7 +129,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
         apiClient.Setup(x => x.GetWithResponseCode<GetCandidateApiResponse>(It.Is<GetCandidateByIdApiRequest>(c=>c.GetUrl.Contains(request.CandidateId.ToString()))))
             .ReturnsAsync(new ApiResponse<GetCandidateApiResponse>(candidateResponse, HttpStatusCode.OK, ""));
-        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewApiRequest>()))
+        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewStatusApiRequest>()))
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
 
         await handler.Handle(request, CancellationToken.None);
@@ -143,7 +143,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
                 (ApplicationStatus)c.Data.Operations[1].value == ApplicationStatus.Successful
             )), Times.Once
         );
-        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewApiRequest>(c =>
+        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewStatusApiRequest>(c =>
                 c.PatchUrl.Contains(request.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
                 c.Data.Operations[0].path == "/CandidateFeedback" &&
                 c.Data.Operations[0].value.ToString() == request.Feedback &&
@@ -179,7 +179,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
         apiClient.Setup(x => x.GetWithResponseCode<GetCandidateApiResponse>(It.Is<GetCandidateByIdApiRequest>(c=>c.GetUrl.Contains(request.CandidateId.ToString()))))
             .ReturnsAsync(new ApiResponse<GetCandidateApiResponse>(candidateResponse, HttpStatusCode.OK, ""));
-        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewApiRequest>()))
+        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewStatusApiRequest>()))
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
 
         await handler.Handle(request, CancellationToken.None);
@@ -194,7 +194,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
             )), Times.Once
         );
 
-        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewApiRequest>(c =>
+        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewStatusApiRequest>(c =>
                 c.PatchUrl.Contains(request.ApplicationId.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
                 c.Data.Operations[0].path == "/CandidateFeedback" &&
                 c.Data.Operations[0].value.ToString() == request.Feedback &&
@@ -238,7 +238,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
             .ReturnsAsync(new ApiResponse<GetApplicationByReferenceApiResponse>(apiResponse, HttpStatusCode.OK, ""));
         apiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>()))
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
-        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewApiRequest>()))
+        recruitApiClient.Setup(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewStatusApiRequest>()))
             .ReturnsAsync(new ApiResponse<string>(null!, HttpStatusCode.Accepted, ""));
 
         await handler.Handle(request, CancellationToken.None);
@@ -253,7 +253,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
             )), Times.Once
         );
 
-        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewApiRequest>(c =>
+        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.Is<PatchRecruitApplicationReviewStatusApiRequest>(c =>
                 c.PatchUrl.Contains(apiResponse.Id.ToString(), StringComparison.CurrentCultureIgnoreCase) &&
                 c.Data.Operations[0].path == "/CandidateFeedback" &&
                 c.Data.Operations[0].value.ToString() == request.Feedback &&
@@ -283,7 +283,7 @@ public class WhenHandlingCandidateApplicationStatusCommand
         apiClient.Verify(x => x.PatchWithResponseCode(It.IsAny<PatchApplicationApiRequest>(
             )), Times.Never
         );
-        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewApiRequest>(
+        recruitApiClient.Verify(x => x.PatchWithResponseCode(It.IsAny<PatchRecruitApplicationReviewStatusApiRequest>(
             )), Times.Never
         );
     }

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingPatchRecruitApplicationReviewStatusRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingPatchRecruitApplicationReviewStatusRequest.cs
@@ -3,12 +3,12 @@ using System;
 
 namespace SFA.DAS.Recruit.UnitTests.Application.InnerApi.Requests;
 
-public class WhenBuildingPatchRecruitApplicationReviewRequest
+public class WhenBuildingPatchRecruitApplicationReviewStatusRequest
 {
     [Test, AutoData]
     public void Then_The_Request_Is_Correctly_Built(Guid applicationId)
     {
-        var actual = new PatchRecruitApplicationReviewApiRequest(applicationId, null);
+        var actual = new PatchRecruitApplicationReviewStatusApiRequest(applicationId, null);
 
         actual.PatchUrl.Should().Be($"api/applicationReviews/{applicationId}");
     }

--- a/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Command/PatchApplicationReview/PatchApplicationReviewCommand.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Command/PatchApplicationReview/PatchApplicationReviewCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using MediatR;
+
+namespace SFA.DAS.Recruit.Application.ApplicationReview.Command.PatchApplicationReview
+{
+    public sealed record PatchApplicationReviewCommand(Guid Id,
+        string Status,
+        string? TemporaryReviewStatus,
+        string? EmployerFeedback,
+        bool HasEverBeenEmployerInterviewing,
+        DateTime? DateSharedWithEmployer) : IRequest;
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Command/PatchApplicationReview/PatchApplicationReviewCommandHandler.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Command/PatchApplicationReview/PatchApplicationReviewCommandHandler.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using MediatR;
+using Microsoft.AspNetCore.JsonPatch;
+using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Recruit.Application.ApplicationReview.Command.PatchApplicationReview
+{
+    public class PatchApplicationReviewCommandHandler(
+        IRecruitApiClient<RecruitApiConfiguration> recruitApiClient) : IRequestHandler<PatchApplicationReviewCommand>
+    {
+        public async Task Handle(PatchApplicationReviewCommand request, CancellationToken cancellationToken)
+        {
+            var jsonPatchApplicationReviewDocument = new JsonPatchDocument<InnerApi.Requests.ApplicationReview>();
+            jsonPatchApplicationReviewDocument.Replace(x => x.Status, request.Status);
+            jsonPatchApplicationReviewDocument.Replace(x => x.HasEverBeenEmployerInterviewing, request.HasEverBeenEmployerInterviewing);            
+            jsonPatchApplicationReviewDocument.Replace(x => x.EmployerFeedback, request.EmployerFeedback);
+            jsonPatchApplicationReviewDocument.Replace(x => x.StatusUpdatedDate, DateTime.UtcNow);
+            if (request.TemporaryReviewStatus != null)
+            {
+                jsonPatchApplicationReviewDocument.Replace(x => x.TemporaryReviewStatus, request.TemporaryReviewStatus);
+            }  
+            if(request.DateSharedWithEmployer.HasValue)
+            {
+                jsonPatchApplicationReviewDocument.Replace(x => x.DateSharedWithEmployer, request.DateSharedWithEmployer.Value);
+            }
+
+
+            var patchApplicationReviewApiRequest = new PatchRecruitApplicationReviewApiRequest(request.Id, jsonPatchApplicationReviewDocument);
+            var patchResponse = await recruitApiClient.PatchWithResponseCode(patchApplicationReviewApiRequest);
+
+            patchResponse.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/Candidates/Commands/CandidateApplicationStatus/CandidateApplicationStatusCommandHandler.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Candidates/Commands/CandidateApplicationStatus/CandidateApplicationStatusCommandHandler.cs
@@ -54,11 +54,11 @@ public class CandidateApplicationStatusCommandHandler(
         jsonPatchDocument.Replace(x => x.Status, applicationStatus);
         var patchRequest = new PatchApplicationApiRequest(request.ApplicationId, request.CandidateId, jsonPatchDocument);
 
-        var jsonPatchApplicationReviewDocument = new JsonPatchDocument<ApplicationReview>();
+        var jsonPatchApplicationReviewDocument = new JsonPatchDocument<ApplicationReviewStatusData>();
         jsonPatchApplicationReviewDocument.Replace(x => x.CandidateFeedback, request.Feedback);
         jsonPatchApplicationReviewDocument.Replace(x => x.Status, Enum.GetName(applicationStatus));
         jsonPatchApplicationReviewDocument.Replace(x => x.StatusUpdatedDate, DateTime.UtcNow);
-        var patchApplicationReviewApiRequest = new PatchRecruitApplicationReviewApiRequest(request.ApplicationId, jsonPatchApplicationReviewDocument);
+        var patchApplicationReviewApiRequest = new PatchRecruitApplicationReviewStatusApiRequest(request.ApplicationId, jsonPatchApplicationReviewDocument);
         
         SendEmailCommand sendEmailCommand;
         if (applicationStatus == ApplicationStatus.Successful)

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/PatchRecruitApplicationReviewApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/PatchRecruitApplicationReviewApiRequest.cs
@@ -15,7 +15,10 @@ public record PatchRecruitApplicationReviewApiRequest(
 }
 public abstract record ApplicationReview
 {
-    public string CandidateFeedback { get; set; }
+    public bool HasEverBeenEmployerInterviewing { get; set; }
+    public DateTime? DateSharedWithEmployer { get; set; }
+    public DateTime? StatusUpdatedDate { get; set; }
+    public string? EmployerFeedback { get; set; }
     public string Status { get; set; }
-    public DateTime StatusUpdatedDate { get; set; }
+    public string? TemporaryReviewStatus { get; set; }
 }

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/PatchRecruitApplicationReviewStatusApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/PatchRecruitApplicationReviewStatusApiRequest.cs
@@ -1,0 +1,21 @@
+using System;
+using Microsoft.AspNetCore.JsonPatch;
+using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.Recruit.InnerApi.Requests;
+
+public record PatchRecruitApplicationReviewStatusApiRequest(
+    Guid ApplicationId,
+    JsonPatchDocument<ApplicationReviewStatusData> Data)
+    : IPatchApiRequest<JsonPatchDocument<ApplicationReviewStatusData>>
+{
+    public JsonPatchDocument<ApplicationReviewStatusData> Data { get; set; } = Data;
+
+    public string PatchUrl => $"api/applicationReviews/{ApplicationId}";
+}
+public abstract record ApplicationReviewStatusData
+{
+    public string CandidateFeedback { get; set; }
+    public string Status { get; set; }
+    public DateTime StatusUpdatedDate { get; set; }
+}


### PR DESCRIPTION
✨ Refactor application review request handling
- Renamed `PatchRecruitApplicationReviewApiRequest` to `PatchRecruitApplicationReviewStatusApiRequest`.
- Updated tests to verify the new request type for API calls.
- Enhanced `ApplicationReview` class with new properties.
- Added new test cases for processing application review statuses.
- Modified `ApplicationReviewsController` to handle new request structure.

Changes made by Balaji Jambulingam