### PR TITLE
FAI-2409 Update Application form in RAA with locations applied

### DIFF
--- a/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/ApplicationReviews/WhenGettingApplicationReviewById.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/ApplicationReviews/WhenGettingApplicationReviewById.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Recruit.Api.Controllers;
+using SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetApplicationReviewById;
+using System;
+using System.Net;
+using System.Threading;
+
+namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.ApplicationReviews;
+[TestFixture]
+public class WhenGettingApplicationReviewById
+{
+    [Test, MoqAutoData]
+    public async Task Then_Gets_Account_From_Mediator(
+        Guid applicationReviewId,
+        GetApplicationReviewByIdQueryResult mediatorResponse,
+        [Frozen] Mock<IMediator> mockMediator,
+        [Greedy] ApplicationReviewsController controller)
+    {
+        mockMediator
+            .Setup(mediator => mediator.Send(
+                It.IsAny<GetApplicationReviewByIdQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mediatorResponse);
+
+        var actual = await controller.Get(applicationReviewId, CancellationToken.None) as OkObjectResult;
+        actual.Should().NotBeNull();
+        mockMediator.Verify(x => x.Send(It.Is<GetApplicationReviewByIdQuery>(
+            c => c.ApplicationReviewId == applicationReviewId), CancellationToken.None), Times.Once);
+    }
+
+    [Test, MoqAutoData]
+    public async Task And_Not_Found_Then_Returns_NotFound(
+        Guid applicationReviewId,
+        GetApplicationReviewByIdQueryResult mediatorResponse,
+        [Frozen] Mock<IMediator> mockMediator,
+        [Greedy] ApplicationReviewsController controller)
+    {
+        mockMediator
+            .Setup(mediator => mediator.Send(
+                It.IsAny<GetApplicationReviewByIdQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetApplicationReviewByIdQueryResult());
+
+        var actual = await controller.Get(applicationReviewId, CancellationToken.None) as NotFoundResult;
+        actual!.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
+    }
+
+
+
+    [Test, MoqAutoData]
+    public async Task And_Exception_Then_Returns_Bad_Request(
+        Guid applicationReviewId,
+        GetApplicationReviewByIdQueryResult mediatorResponse,
+        [Frozen] Mock<IMediator> mockMediator,
+        [Greedy] ApplicationReviewsController controller)
+    {
+        mockMediator
+            .Setup(mediator => mediator.Send(
+                It.IsAny<GetApplicationReviewByIdQuery>(),
+                It.IsAny<CancellationToken>()))
+           .Throws<InvalidOperationException>();
+
+        var actual = await controller.Get(applicationReviewId, CancellationToken.None) as StatusCodeResult;
+
+        actual.Should().NotBeNull();
+        actual!.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.Api/Controllers/ApplicationReviewsController.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/Controllers/ApplicationReviewsController.cs
@@ -9,6 +9,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetApplicationReviewById;
 
 namespace SFA.DAS.Recruit.Api.Controllers
 {
@@ -32,6 +33,30 @@ namespace SFA.DAS.Recruit.Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error getting application reviews");
+                return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
+            }
+        }
+
+        [HttpGet]
+        [Route("{id:guid}")]
+        public async Task<IActionResult> Get(
+            [FromRoute, Required] Guid id,
+            CancellationToken token = default)
+        {
+            try
+            {
+                var result = await mediator.Send(new GetApplicationReviewByIdQuery(id), token);
+
+                if (result.ApplicationReview == null)
+                {
+                    return NotFound();
+                }
+
+                return Ok(result);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error getting application review by id");
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/ApplicationReviews/Queries/WhenHandingGetApplicationReviewsByVacancyReferenceQuery.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/ApplicationReviews/Queries/WhenHandingGetApplicationReviewsByVacancyReferenceQuery.cs
@@ -10,7 +10,7 @@ using ApplicationReview = SFA.DAS.Recruit.Domain.ApplicationReview;
 namespace SFA.DAS.Recruit.UnitTests.Application.ApplicationReviews.Queries
 {
     [TestFixture]
-    public class WhenHandingGetApplicationReviewsByVacancyReferenceCommand
+    public class WhenHandingGetApplicationReviewsByVacancyReferenceQuery
     {
         [Test, MoqAutoData]
         public async Task Then_The_Query_Is_Handled_And_Data_Returned(

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/ApplicationReviews/Queries/WhenHandlingGetApplicationReviewByIdQuery.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/ApplicationReviews/Queries/WhenHandlingGetApplicationReviewByIdQuery.cs
@@ -1,0 +1,105 @@
+﻿using SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetApplicationReviewById;
+using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using System;
+using System.Threading;
+
+namespace SFA.DAS.Recruit.UnitTests.Application.ApplicationReviews.Queries;
+[TestFixture]
+public class WhenHandlingGetApplicationReviewByIdQuery
+{
+    [Test, MoqAutoData]
+    public async Task Then_The_Query_Is_Handled_And_Data_Returned(
+        Guid applicationId,
+        Guid candidateId,
+            GetApplicationReviewByIdQuery query,
+            Recruit.Domain.ApplicationReview apiResponse,
+            Recruit.Domain.Application candidateApiResponse,
+            [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+            [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+            GetApplicationReviewByIdQueryHandler handler)
+    {
+        //Arrange
+        apiResponse.ApplicationId = applicationId;
+        apiResponse.CandidateId = candidateId;
+        var expectedGetUrl = new GetApplicationReviewByIdApiRequest(query.ApplicationReviewId);
+        recruitApiClient
+            .Setup(x => x.Get<Recruit.Domain.ApplicationReview>(
+                It.Is<GetApplicationReviewByIdApiRequest>(r => r.GetUrl == expectedGetUrl.GetUrl)))
+            .ReturnsAsync(apiResponse);
+
+        var expectedCandidateGetUrl = new GetApplicationByIdApiRequest(applicationId, candidateId);
+        candidateApiClient
+            .Setup(x => x.Get<Recruit.Domain.Application>(
+                It.Is<GetApplicationByIdApiRequest>(r =>
+                    r.GetUrl == expectedCandidateGetUrl.GetUrl)))
+            .ReturnsAsync(candidateApiResponse);
+
+        //Act
+        var actual = await handler.Handle(query, CancellationToken.None);
+
+        //Assert
+        actual.ApplicationReview.Should().BeEquivalentTo(apiResponse, options => options.ExcludingMissingMembers());
+        recruitApiClient.Verify(x => x.Get<Recruit.Domain.ApplicationReview>(It.IsAny<GetApplicationReviewByIdApiRequest>()), Times.Once);
+        candidateApiClient.Verify(x => x.Get<Recruit.Domain.Application>(It.IsAny<GetApplicationByIdApiRequest>()), Times.Once);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_ApplicationId_Is_Null_Query_Is_Handled_And_Returned(
+        Guid applicationId,
+        Guid candidateId,
+        GetApplicationReviewByIdQuery query,
+        Recruit.Domain.ApplicationReview apiResponse,
+        Recruit.Domain.Application candidateApiResponse,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+        GetApplicationReviewByIdQueryHandler handler)
+    {
+        //Arrange
+        apiResponse.ApplicationId = null;
+        apiResponse.CandidateId = candidateId;
+        var expectedGetUrl = new GetApplicationReviewByIdApiRequest(query.ApplicationReviewId);
+        recruitApiClient
+            .Setup(x => x.Get<Recruit.Domain.ApplicationReview>(
+                It.Is<GetApplicationReviewByIdApiRequest>(r => r.GetUrl == expectedGetUrl.GetUrl)))
+            .ReturnsAsync(apiResponse);
+
+        //Act
+        var actual = await handler.Handle(query, CancellationToken.None);
+
+        //Assert
+        actual.ApplicationReview.Should().BeEquivalentTo(apiResponse, options => options.ExcludingMissingMembers());
+        recruitApiClient.Verify(x => x.Get<Recruit.Domain.ApplicationReview>(It.IsAny<GetApplicationReviewByIdApiRequest>()), Times.Once);
+        candidateApiClient.Verify(x => x.Get<Recruit.Domain.Application>(It.IsAny<GetApplicationByIdApiRequest>()), Times.Never);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Query_Is_Handled_And_Null_Returned(
+        Guid applicationId,
+        Guid candidateId,
+        GetApplicationReviewByIdQuery query,
+        Recruit.Domain.ApplicationReview apiResponse,
+        Recruit.Domain.Application candidateApiResponse,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        [Frozen] Mock<ICandidateApiClient<CandidateApiConfiguration>> candidateApiClient,
+        GetApplicationReviewByIdQueryHandler handler)
+    {
+        //Arrange
+        apiResponse.ApplicationId = applicationId;
+        apiResponse.CandidateId = candidateId;
+        var expectedGetUrl = new GetApplicationReviewByIdApiRequest(query.ApplicationReviewId);
+        recruitApiClient
+            .Setup(x => x.Get<Recruit.Domain.ApplicationReview>(
+                It.Is<GetApplicationReviewByIdApiRequest>(r => r.GetUrl == expectedGetUrl.GetUrl)))
+            .ReturnsAsync((Recruit.Domain.ApplicationReview)null!);
+
+        //Act
+        var actual = await handler.Handle(query, CancellationToken.None);
+
+        //Assert
+        actual.Should().BeEquivalentTo(new GetApplicationReviewByIdQueryResult());
+        recruitApiClient.Verify(x => x.Get<Recruit.Domain.ApplicationReview>(It.IsAny<GetApplicationReviewByIdApiRequest>()), Times.Once);
+        candidateApiClient.Verify(x => x.Get<Recruit.Domain.Application>(It.IsAny<GetApplicationByIdApiRequest>()), Times.Never);
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingGetApplicationByIdApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingGetApplicationByIdApiRequest.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace SFA.DAS.Recruit.UnitTests.Application.InnerApi.Requests;
+[TestFixture]
+public class WhenBuildingGetApplicationByIdApiRequest
+{
+    [Test, MoqAutoData]
+    public void Then_The_GetUrl_Is_Correct(Guid applicationId, Guid candidateId)
+    {
+        // Arrange
+        var expectedUrl = $"api/candidates/{candidateId}/applications/{applicationId}";
+        // Act
+        var request = new SFA.DAS.Recruit.InnerApi.Requests.GetApplicationByIdApiRequest(applicationId, candidateId);
+        // Assert
+        request.GetUrl.Should().Be(expectedUrl);
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingGetApplicationReviewByIdApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingGetApplicationReviewByIdApiRequest.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace SFA.DAS.Recruit.UnitTests.Application.InnerApi.Requests;
+[TestFixture]
+public class WhenBuildingGetApplicationReviewByIdApiRequest
+{
+    [Test, MoqAutoData]
+    public void Then_The_GetUrl_Is_Correct(Guid applicationReviewId)
+    {
+        // Arrange
+        var expectedUrl = $"api/applicationReviews/{applicationReviewId}";
+        // Act
+        var request = new SFA.DAS.Recruit.InnerApi.Requests.GetApplicationReviewByIdApiRequest(applicationReviewId);
+        // Assert
+        request.GetUrl.Should().Be(expectedUrl);
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetApplicationReviewById/GetApplicationReviewByIdQuery.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetApplicationReviewById/GetApplicationReviewByIdQuery.cs
@@ -1,0 +1,7 @@
+﻿using MediatR;
+using System;
+
+namespace SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetApplicationReviewById;
+
+public sealed record GetApplicationReviewByIdQuery(Guid ApplicationReviewId)
+    : IRequest<GetApplicationReviewByIdQueryResult>;

--- a/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetApplicationReviewById/GetApplicationReviewByIdQueryHandler.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetApplicationReviewById/GetApplicationReviewByIdQueryHandler.cs
@@ -1,0 +1,32 @@
+﻿using MediatR;
+using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetApplicationReviewById;
+public class GetApplicationReviewByIdQueryHandler(
+    IRecruitApiClient<RecruitApiConfiguration> recruitApiClient,
+    ICandidateApiClient<CandidateApiConfiguration> candidateApiClient) : IRequestHandler<GetApplicationReviewByIdQuery, GetApplicationReviewByIdQueryResult>
+{
+    public async Task<GetApplicationReviewByIdQueryResult> Handle(GetApplicationReviewByIdQuery request, CancellationToken cancellationToken)
+    {
+        var recruitApiResponse = await recruitApiClient.Get<Domain.ApplicationReview>(
+            new GetApplicationReviewByIdApiRequest(request.ApplicationReviewId));
+
+        if (recruitApiResponse == null) return new GetApplicationReviewByIdQueryResult();
+
+        if (recruitApiResponse.ApplicationId != null)
+        {
+            var candidateApiResponse = await candidateApiClient.Get<Domain.Application>(
+                new GetApplicationByIdApiRequest(recruitApiResponse.ApplicationId.Value, recruitApiResponse.CandidateId));
+            recruitApiResponse.Application = candidateApiResponse;
+        }
+
+        return new GetApplicationReviewByIdQueryResult
+        {
+            ApplicationReview = recruitApiResponse
+        };
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetApplicationReviewById/GetApplicationReviewByIdQueryResult.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetApplicationReviewById/GetApplicationReviewByIdQueryResult.cs
@@ -1,0 +1,5 @@
+﻿namespace SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetApplicationReviewById;
+public record GetApplicationReviewByIdQueryResult
+{
+    public Domain.ApplicationReview ApplicationReview { get; init; }
+}

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetApplicationByIdApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetApplicationByIdApiRequest.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.SharedOuterApi.Interfaces;
+using System;
+
+namespace SFA.DAS.Recruit.InnerApi.Requests;
+public record GetApplicationByIdApiRequest(Guid ApplicationId, Guid CandidateId)
+    : IGetApiRequest
+{
+    public string GetUrl => $"api/candidates/{CandidateId}/applications/{ApplicationId}";
+}

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetApplicationReviewByIdApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetApplicationReviewByIdApiRequest.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.SharedOuterApi.Interfaces;
+using System;
+
+namespace SFA.DAS.Recruit.InnerApi.Requests;
+public record GetApplicationReviewByIdApiRequest(Guid ApplicationReviewId)
+    : IGetApiRequest
+{
+    public string GetUrl => $"api/applicationReviews/{ApplicationReviewId}";
+}

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetApplicationReviewByIdApiResponse.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetApplicationReviewByIdApiResponse.cs
@@ -1,0 +1,6 @@
+﻿using SFA.DAS.Recruit.Domain;
+namespace SFA.DAS.Recruit.InnerApi.Responses;
+public record GetApplicationReviewByIdApiResponse
+{
+    public ApplicationReview ApplicationReview { get; set; }
+}


### PR DESCRIPTION
✨ Add endpoint to retrieve application review by ID

- Introduced a new `Get` method in `ApplicationReviewsController`.
- Implemented `GetApplicationReviewByIdQuery` and its handler.
- Added unit tests in `WhenGettingApplicationReviewById` for the new endpoint.
- Created supporting classes: `GetApplicationReviewByIdQueryResult`, `GetApplicationReviewByIdApiRequest`, and `GetApplicationReviewByIdApiResponse`.
- Updated existing tests to cover new functionality.

Changes made by Balaji Jambulingam