### PR TITLE
Automated: Add vnetRouteAllEnabled parameter

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -120,6 +120,10 @@
         },
         "deployPrivateLinkedScopedResource": {
             "type": "bool"
+        },
+        "vnetRouteAllEnabled": {
+            "type": "bool",
+            "defaultValue": false
         }
     },
     "variables": {
@@ -130,7 +134,6 @@
         "alertActionGroupResourceIdFailedRequests": "[if(and(equals(parameters('environmentName'), 'PROD'), equals(parameters('productShortName'), 'ea')), parameters('preProdAlertActionGroupResourceId'), parameters('alertActionGroupResourceId'))]",
         "alertActionGroupResourceIdResponseTime": "[if(and(equals(parameters('environmentName'), 'PROD'), equals(parameters('productShortName'), 'ya')), parameters('preProdAlertActionGroupResourceId'), parameters('alertActionGroupResourceId'))]",
         "privateLinkScopeName": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-shared-ampls'))]"
-
     },
     "resources": [
         {
@@ -281,6 +284,9 @@
                     },
                     "subnetResourceId": {
                         "value": "[parameters('apimEndpointsSubnetResourceId')]"
+                    },
+                    "vnetRouteAllEnabled": {
+                        "value": "[parameters('vnetRouteAllEnabled')]"
                     }
                 }
             }


### PR DESCRIPTION
This PR adds the 'vnetRouteAllEnabled' parameter to the ARM template and its corresponding usage in the app-service-v2 and function-app-v2 deployments.