### PR TITLE
modified products sending alerts to das-alerts-test

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -132,7 +132,7 @@
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
         "appServicePlanName": "[if(empty(parameters('appServicePlanName')), concat(variables('resourceNamePrefix'), '-asp'), parameters('appServicePlanName'))]",
         "alertActionGroupResourceIdFailedRequests": "[if(and(equals(parameters('environmentName'), 'PROD'), equals(parameters('productShortName'), 'ea')), parameters('preProdAlertActionGroupResourceId'), parameters('alertActionGroupResourceId'))]",
-        "alertActionGroupResourceIdResponseTime": "[if(and(equals(parameters('environmentName'), 'PROD'), equals(parameters('productShortName'), 'ya')), parameters('preProdAlertActionGroupResourceId'), parameters('alertActionGroupResourceId'))]",
+        "alertActionGroupResourceIdResponseTime": "[if(and(equals(parameters('environmentName'), 'PROD'), or(equals(parameters('productShortName'), 'faa'), equals(parameters('productShortName'), 'ea'))), parameters('preProdAlertActionGroupResourceId'), parameters('alertActionGroupResourceId'))]",
         "privateLinkScopeName": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-shared-ampls'))]"
     },
     "resources": [


### PR DESCRIPTION
This PR does 2 things:
1) Point the Your Apprentice App alerts to the main slack channel
2) Due to the nature of this repositroy/variable structure, it's hard to manage the rollout of these alerts granually, this change ensures that FAA and EA Outer API response alerting gets sent to the test channel.