### PR TITLE
FAI-2424 Add pagination to the Vacancy manage page

### DIFF
--- a/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/ApplicationReviews/WhenGettingPagedApplicationReviewsByVacancyReference.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api.UnitTests/Controllers/ApplicationReviews/WhenGettingPagedApplicationReviewsByVacancyReference.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Recruit.Api.Controllers;
+using SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetPagedApplicationReviewsByVacancyReference;
+using System;
+using System.Net;
+using System.Threading;
+
+namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.ApplicationReviews;
+[TestFixture]
+internal class WhenGettingPagedApplicationReviewsByVacancyReference
+{
+    [Test, MoqAutoData]
+    public async Task Then_Gets_ApplicationReviews_From_Mediator(
+        long vacancyReference,
+        int pageNumber,
+        int pageSize,
+        string sortColumn,
+        bool isAscending,
+        GetPagedApplicationReviewsByVacancyReferenceQueryResult mediatorResponse,
+        [Frozen] Mock<IMediator> mockMediator,
+        [Greedy] ApplicationReviewsController controller)
+    {
+        mockMediator
+            .Setup(mediator => mediator.Send(
+                It.IsAny<GetPagedApplicationReviewsByVacancyReferenceQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mediatorResponse);
+
+        var actual = await controller.GetPagedByVacancyReference(vacancyReference, pageNumber, pageSize, sortColumn, isAscending, CancellationToken.None) as OkObjectResult;
+        actual.Should().NotBeNull();
+        mockMediator.Verify(x => x.Send(It.Is<GetPagedApplicationReviewsByVacancyReferenceQuery>(
+            c => c.VacancyReference == vacancyReference), CancellationToken.None), Times.Once);
+    }
+
+    [Test, MoqAutoData]
+    public async Task And_Exception_Then_Returns_Bad_Request(
+        long vacancyReference,
+        int pageNumber,
+        int pageSize,
+        string sortColumn,
+        bool isAscending,
+        GetPagedApplicationReviewsByVacancyReferenceQueryResult mediatorResponse,
+        [Frozen] Mock<IMediator> mockMediator,
+        [Greedy] ApplicationReviewsController controller)
+    {
+        mockMediator
+            .Setup(mediator => mediator.Send(
+                It.IsAny<GetPagedApplicationReviewsByVacancyReferenceQuery>(),
+                It.IsAny<CancellationToken>()))
+            .Throws<InvalidOperationException>();
+
+        var actual = await controller.GetPagedByVacancyReference(vacancyReference, pageNumber, pageSize, sortColumn, isAscending, CancellationToken.None) as StatusCodeResult;
+
+        actual.Should().NotBeNull();
+        actual!.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.Api/Controllers/ApplicationReviewsController.cs
+++ b/src/Recruit/SFA.DAS.Recruit.Api/Controllers/ApplicationReviewsController.cs
@@ -3,13 +3,14 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Recruit.Api.Models;
 using SFA.DAS.Recruit.Application.ApplicationReview.Command.PatchApplicationReview;
+using SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetApplicationReviewById;
 using SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetApplicationReviewsByVacancyReference;
+using SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetPagedApplicationReviewsByVacancyReference;
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetApplicationReviewById;
 
 namespace SFA.DAS.Recruit.Api.Controllers
 {
@@ -33,6 +34,34 @@ namespace SFA.DAS.Recruit.Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Error getting application reviews");
+                return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
+            }
+        }
+
+        [HttpGet]
+        [Route("vacancyReference/paginated/{vacancyReference:long}")]
+        public async Task<IActionResult> GetPagedByVacancyReference(
+            [FromRoute, Required] long vacancyReference,
+            [FromQuery] int pageNumber = 1,
+            [FromQuery] int pageSize = 20,
+            [FromQuery] string sortColumn = "CreatedDate",
+            [FromQuery] bool isAscending = false,
+            CancellationToken token = default)
+        {
+            try
+            {
+                var result = await mediator.Send(new GetPagedApplicationReviewsByVacancyReferenceQuery(vacancyReference,
+                        pageNumber,
+                        pageSize,
+                        sortColumn,
+                        isAscending),
+                    token);
+
+                return Ok(result);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error getting paged application reviews");
                 return new StatusCodeResult((int)HttpStatusCode.InternalServerError);
             }
         }

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/ApplicationReviews/Queries/WhenHandlingGetPagedApplicationReviewsByVacancyReference.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/ApplicationReviews/Queries/WhenHandlingGetPagedApplicationReviewsByVacancyReference.cs
@@ -1,0 +1,54 @@
+﻿using SFA.DAS.Recruit.Application.Queries.GetDashboardVacanciesCountByUkprn;
+using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.Recruit.InnerApi.Responses;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using System.Threading;
+
+namespace SFA.DAS.Recruit.UnitTests.Application.ApplicationReviews.Queries;
+[TestFixture]
+internal class WhenHandlingGetPagedApplicationReviewsByVacancyReference
+{
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Query_Is_Handled_And_Data_Returned(
+        GetDashboardVacanciesCountByUkprnQuery query,
+        GetDashboardVacanciesCountApiResponse apiResponse,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        GetDashboardVacanciesCountByUkprnQueryHandler handler)
+    {
+        //Arrange
+        var expectedGetUrl = new GetDashboardVacanciesCountByUkprnApiRequest(query.Ukprn, query.PageNumber, query.PageSize, query.SortColumn, query.IsAscending, query.Status);
+        recruitApiClient
+            .Setup(x => x.Get<GetDashboardVacanciesCountApiResponse>(
+                It.Is<GetDashboardVacanciesCountByUkprnApiRequest>(r => r.GetUrl == expectedGetUrl.GetUrl)))
+            .ReturnsAsync(apiResponse);
+
+        //Act
+        var actual = await handler.Handle(query, CancellationToken.None);
+
+        //Assert
+        actual.Items.Should().BeEquivalentTo(apiResponse.Items);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Query_Is_Handled_And_Null_Returned(
+        GetDashboardVacanciesCountByUkprnQuery query,
+        GetDashboardVacanciesCountApiResponse apiResponse,
+        [Frozen] Mock<IRecruitApiClient<RecruitApiConfiguration>> recruitApiClient,
+        GetDashboardVacanciesCountByUkprnQueryHandler handler)
+    {
+        //Arrange
+        var expectedGetUrl = new GetDashboardVacanciesCountByUkprnApiRequest(query.Ukprn, query.PageNumber, query.PageSize, query.SortColumn, query.IsAscending, query.Status);
+        recruitApiClient
+            .Setup(x => x.Get<GetDashboardVacanciesCountApiResponse>(
+                It.Is<GetDashboardVacanciesCountByUkprnApiRequest>(r => r.GetUrl == expectedGetUrl.GetUrl)))
+            .ReturnsAsync((GetDashboardVacanciesCountApiResponse)null!);
+
+        //Act
+        var actual = await handler.Handle(query, CancellationToken.None);
+
+        //Assert
+        actual.Items.Count.Should().Be(0);
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingTheGetPagedApplicationReviewsByVacancyReferenceApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit.UnitTests/Application/InnerApi/Requests/WhenBuildingTheGetPagedApplicationReviewsByVacancyReferenceApiRequest.cs
@@ -1,0 +1,22 @@
+﻿using SFA.DAS.Recruit.InnerApi.Requests;
+
+namespace SFA.DAS.Recruit.UnitTests.Application.InnerApi.Requests;
+[TestFixture]
+internal class WhenBuildingTheGetPagedApplicationReviewsByVacancyReferenceApiRequest
+{
+    [Test, MoqAutoData]
+    public void Then_The_Request_Is_Built_Correctly(long vacancyReference,
+        int pageNumber,
+        int pageSize,
+        string sortColumn,
+        bool isAscending)
+    {
+        // Arrange
+        var expectedUrl = $"api/applicationreviews/paginated/{vacancyReference}?pageNumber={pageNumber}&pageSize={pageSize}&sortColumn={sortColumn}&isAscending={isAscending}";
+        // Act
+        var request = new GetPagedApplicationReviewsByVacancyReferenceApiRequest(vacancyReference, pageNumber, pageSize, sortColumn, isAscending);
+
+        // Assert
+        request.GetUrl.Should().Be(expectedUrl);
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetPagedApplicationReviewsByVacancyReference/GetPagedApplicationReviewsByVacancyReferenceQuery.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetPagedApplicationReviewsByVacancyReference/GetPagedApplicationReviewsByVacancyReferenceQuery.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetPagedApplicationReviewsByVacancyReference;
+
+public sealed record GetPagedApplicationReviewsByVacancyReferenceQuery(
+    long VacancyReference,
+    int PageNumber = 1,
+    int PageSize = 10,
+    string SortColumn = "CreatedDate",
+    bool IsAscending = false) : IRequest<GetPagedApplicationReviewsByVacancyReferenceQueryResult>;

--- a/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetPagedApplicationReviewsByVacancyReference/GetPagedApplicationReviewsByVacancyReferenceQueryHandler.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetPagedApplicationReviewsByVacancyReference/GetPagedApplicationReviewsByVacancyReferenceQueryHandler.cs
@@ -1,0 +1,27 @@
+﻿using MediatR;
+using SFA.DAS.Recruit.InnerApi.Requests;
+using SFA.DAS.Recruit.InnerApi.Responses;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetPagedApplicationReviewsByVacancyReference;
+public class GetPagedApplicationReviewsByVacancyReferenceQueryHandler(
+    IRecruitApiClient<RecruitApiConfiguration> recruitApiClient)
+    : IRequestHandler<GetPagedApplicationReviewsByVacancyReferenceQuery,
+        GetPagedApplicationReviewsByVacancyReferenceQueryResult>
+{
+    public async Task<GetPagedApplicationReviewsByVacancyReferenceQueryResult> Handle(GetPagedApplicationReviewsByVacancyReferenceQuery request, CancellationToken cancellationToken)
+    {
+        var response = await recruitApiClient.Get<GetPagedApplicationReviewsByVacancyReferenceApiResponse>(
+            new GetPagedApplicationReviewsByVacancyReferenceApiRequest(
+                request.VacancyReference,
+                request.PageNumber,
+                request.PageSize,
+                request.SortColumn,
+                request.IsAscending));
+
+        return response;
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetPagedApplicationReviewsByVacancyReference/GetPagedApplicationReviewsByVacancyReferenceQueryResult.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/ApplicationReview/Queries/GetPagedApplicationReviewsByVacancyReference/GetPagedApplicationReviewsByVacancyReferenceQueryResult.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+
+namespace SFA.DAS.Recruit.Application.ApplicationReview.Queries.GetPagedApplicationReviewsByVacancyReference;
+public sealed record GetPagedApplicationReviewsByVacancyReferenceQueryResult
+{
+    public int TotalCount { get; init; }
+    public int PageIndex { get; init; }
+    public int PageSize { get; init; }
+    public int TotalPages { get; init; }
+    public bool HasPreviousPage { get; init; }
+    public bool HasNextPage { get; init; }
+    public List<Domain.ApplicationReview> Items { get; init; } = [];
+
+    public static implicit operator GetPagedApplicationReviewsByVacancyReferenceQueryResult(InnerApi.Responses.GetPagedApplicationReviewsByVacancyReferenceApiResponse source)
+    {
+        if (source?.Info == null || source.Items == null)
+        {
+            return new GetPagedApplicationReviewsByVacancyReferenceQueryResult
+            {
+                TotalCount = 0,
+                PageIndex = 0,
+                PageSize = 0,
+                TotalPages = 0,
+                HasPreviousPage = false,
+                HasNextPage = false,
+                Items = []
+            };
+        }
+        return new GetPagedApplicationReviewsByVacancyReferenceQueryResult
+        {
+            TotalCount = source.Info.TotalCount,
+            PageIndex = source.Info.PageIndex,
+            PageSize = source.Info.PageSize,
+            TotalPages = source.Info.TotalPages,
+            HasPreviousPage = source.Info.HasPreviousPage,
+            HasNextPage = source.Info.HasNextPage,
+            Items = source.Items
+        };
+    }
+}

--- a/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetAllAccountLegalEntities/GetAllAccountLegalEntitiesQueryResult.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetAllAccountLegalEntities/GetAllAccountLegalEntitiesQueryResult.cs
@@ -5,8 +5,8 @@ namespace SFA.DAS.Recruit.Application.Queries.GetAllAccountLegalEntities
 {
     public record GetAllAccountLegalEntitiesQueryResult
     {
-        public GetAllAccountLegalEntitiesApiResponse.PaginationInfo PageInfo { get; set; }
-        public List<GetAccountLegalEntityResponseItem> LegalEntities { get; set; }
+        public PageInfo PageInfo { get; set; }
+        public List<GetAccountLegalEntityResponseItem> LegalEntities { get; set; } = [];
 
         public static implicit operator GetAllAccountLegalEntitiesQueryResult(GetAllAccountLegalEntitiesApiResponse response)
         {

--- a/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetDashboardVacanciesCountByAccountId/GetDashboardVacanciesCountByAccountIdQueryResult.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Application/Queries/GetDashboardVacanciesCountByAccountId/GetDashboardVacanciesCountByAccountIdQueryResult.cs
@@ -16,7 +16,7 @@ public record GetDashboardVacanciesCountByAccountIdQueryResult
 
     public static implicit operator GetDashboardVacanciesCountByAccountIdQueryResult(GetDashboardVacanciesCountApiResponse source)
     {
-        if ( source?.Info == null || source.Items == null)
+        if (source?.Info == null || source.Items == null)
         {
             return new GetDashboardVacanciesCountByAccountIdQueryResult
             {

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetPagedApplicationReviewsByVacancyReferenceApiRequest.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Requests/GetPagedApplicationReviewsByVacancyReferenceApiRequest.cs
@@ -1,0 +1,11 @@
+﻿using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.Recruit.InnerApi.Requests;
+public record GetPagedApplicationReviewsByVacancyReferenceApiRequest(long VacancyReference, 
+    int PageNumber = 1, 
+    int PageSize = 10, 
+    string SortColumn = "CreatedDate", 
+    bool IsAscending = false) : IGetApiRequest
+{
+    public string GetUrl => $"api/applicationreviews/paginated/{VacancyReference}?pageNumber={PageNumber}&pageSize={PageSize}&sortColumn={SortColumn}&isAscending={IsAscending}";
+}

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetAllAccountLegalEntitiesApiResponse.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetAllAccountLegalEntitiesApiResponse.cs
@@ -6,30 +6,9 @@ namespace SFA.DAS.Recruit.InnerApi.Responses
     public record GetAllAccountLegalEntitiesApiResponse
     {
         [JsonProperty("pageInfo")]
-        public PaginationInfo PageInfo { get; set; }
+        public PageInfo PageInfo { get; set; }
 
         [JsonProperty("legalEntities")]
         public List<GetAccountLegalEntityResponseItem> LegalEntities { get; set; }
-
-        public class PaginationInfo
-        {
-            [JsonProperty("totalCount")]
-            public int TotalCount { get; set; }
-
-            [JsonProperty("pageIndex")]
-            public int PageIndex { get; set; }
-
-            [JsonProperty("pageSize")]
-            public int PageSize { get; set; }
-
-            [JsonProperty("totalPages")]
-            public int TotalPages { get; set; }
-
-            [JsonProperty("hasPreviousPage")]
-            public bool HasPreviousPage { get; set; }
-
-            [JsonProperty("hasNextPage")]
-            public bool HasNextPage { get; set; }
-        }
     }
 }

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetDashboardVacanciesCountApiResponse.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetDashboardVacanciesCountApiResponse.cs
@@ -6,18 +6,9 @@ public record GetDashboardVacanciesCountApiResponse
 {
     [JsonProperty("info")]
     public PageInfo Info { get; set; }
-    [JsonProperty("items")]
-    public List<Item> Items { get; set; }
 
-    public record PageInfo
-    {
-        public int TotalCount { get; set; }
-        public int PageIndex { get; set; }
-        public int PageSize { get; set; }
-        public int TotalPages { get; set; }
-        public bool HasPreviousPage { get; set; }
-        public bool HasNextPage { get; set; }
-    }
+    [JsonProperty("items")] 
+    public List<Item> Items { get; set; } = [];
 
     public record Item
     {

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetPagedApplicationReviewsByVacancyReferenceApiResponse.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/GetPagedApplicationReviewsByVacancyReferenceApiResponse.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace SFA.DAS.Recruit.InnerApi.Responses;
+public record GetPagedApplicationReviewsByVacancyReferenceApiResponse
+{
+    [JsonProperty("info")]
+    public PageInfo Info { get; set; }
+
+    [JsonProperty("items")] 
+    public List<Domain.ApplicationReview> Items { get; set; } = [];
+}

--- a/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/PageInfo.cs
+++ b/src/Recruit/SFA.DAS.Recruit/InnerApi/Responses/PageInfo.cs
@@ -1,0 +1,10 @@
+﻿namespace SFA.DAS.Recruit.InnerApi.Responses;
+public record PageInfo
+{
+    public int TotalCount { get; set; }
+    public int PageIndex { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages { get; set; }
+    public bool HasPreviousPage { get; set; }
+    public bool HasNextPage { get; set; }
+}


### PR DESCRIPTION
✨ Add paginated application reviews endpoint

- Implemented `GetPagedByVacancyReference` in `ApplicationReviewsController`.
- Simplified `PageInfo` structure in response classes.
- Added unit tests for the new paginated endpoint.
- Introduced `GetPagedApplicationReviewsByVacancyReferenceQuery` and handler.
- Enhanced API structure for better clarity and maintainability.

Changes made by Balaji Jambulingam