### PR TITLE
FAI-2702 Template Id Correction

### DIFF
--- a/src/Recruit/SFA.DAS.Recruit/Handlers/SharedApplicationReviewedEventHandler.cs
+++ b/src/Recruit/SFA.DAS.Recruit/Handlers/SharedApplicationReviewedEventHandler.cs
@@ -77,7 +77,7 @@ public class SharedApplicationReviewedEventHandler(IMediator mediator,
         return users.Select(user =>
         {
             var email = new SharedApplicationsReturnedEmailTemplate(
-                emailEnvironmentHelper.ApplicationReviewSharedEmailTemplatedId,
+                emailEnvironmentHelper.SharedApplicationsReturned,
                 user.Email,
                 vacancy.Title,
                 user.FirstName,


### PR DESCRIPTION
✨ Update email template for Shared Applications notification

- Changed email template ID in `SharedApplicationsReturnedEmailTemplate`.
- Replaced `ApplicationReviewSharedEmailTemplatedId` with `SharedApplicationsReturned`.
- Reflects a change in the context of the email being sent.
- Ensures the correct template is used for user notifications.
- Improves clarity and relevance of email communications.

Changes made by Balaji Jambulingam