### PR TITLE
CSP-2229 Implements search organisation endpoint

### DIFF
--- a/src/AdminRoatp/SFA.DAS.AdminRoatp.Api.UnitTests/Controllers/OrganisationsControllerTests/OrganisationsControllerGetOrganisationTests.cs
+++ b/src/AdminRoatp/SFA.DAS.AdminRoatp.Api.UnitTests/Controllers/OrganisationsControllerTests/OrganisationsControllerGetOrganisationTests.cs
@@ -1,0 +1,44 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SFA.DAS.AdminRoatp.Api.Controllers;
+using SFA.DAS.AdminRoatp.Application.Queries.GetOrganisation;
+using SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.AdminRoatp.Api.UnitTests.Controllers.OrganisationsControllerTests;
+public class OrganisationsControllerGetOrganisationTests
+{
+    [Test, MoqAutoData]
+    public async Task GetOrganisationByUkprn_ReturnSuccessfulResponse(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] OrganisationsController sut,
+        GetOrganisationQuery request,
+        GetOrganisationResponse expectedResponse)
+    {
+        mediatorMock.Setup(m => m.Send(It.IsAny<GetOrganisationQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResponse);
+
+        var result = await sut.GetOrganisation(request.ukprn, It.IsAny<CancellationToken>());
+        var response = (OkObjectResult)result;
+
+        mediatorMock.Verify(m => m.Send(It.Is<GetOrganisationQuery>(r => r.ukprn == request.ukprn), It.IsAny<CancellationToken>()), Times.Once());
+        response.Value.Should().BeEquivalentTo(expectedResponse);
+    }
+
+    [Test, MoqAutoData]
+    public async Task GetOrganisationByUkprn_ReturnNotFoundResponse(
+        [Frozen] Mock<IMediator> mediatorMock,
+        [Greedy] OrganisationsController sut,
+        GetOrganisationQuery request)
+    {
+        GetOrganisationResponse? expectedResponse = null;
+        mediatorMock.Setup(m => m.Send(It.IsAny<GetOrganisationQuery>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResponse);
+
+        var result = await sut.GetOrganisation(request.ukprn, It.IsAny<CancellationToken>());
+
+        mediatorMock.Verify(m => m.Send(It.Is<GetOrganisationQuery>(r => r.ukprn == request.ukprn), It.IsAny<CancellationToken>()), Times.Once());
+        result.Should().BeOfType<NotFoundResult>();
+    }
+}

--- a/src/AdminRoatp/SFA.DAS.AdminRoatp.Api.UnitTests/Controllers/OrganisationsControllerTests/OrganisationsControllerGetOrganisationsTests.cs
+++ b/src/AdminRoatp/SFA.DAS.AdminRoatp.Api.UnitTests/Controllers/OrganisationsControllerTests/OrganisationsControllerGetOrganisationsTests.cs
@@ -7,12 +7,11 @@ using SFA.DAS.AdminRoatp.Api.Controllers;
 using SFA.DAS.AdminRoatp.Application.Queries.GetOrganisations;
 using SFA.DAS.Testing.AutoFixture;
 
-namespace SFA.DAS.AdminRoatp.Api.UnitTests.Controllers;
-public class OrganisationsControllerTests
+namespace SFA.DAS.AdminRoatp.Api.UnitTests.Controllers.OrganisationsControllerTests;
+public class OrganisationsControllerGetOrganisationsTests
 {
     [Test, MoqAutoData]
-
-    public async Task GetOrganisations(
+    public async Task GetOrganisations_ReturnSuccessfulResponse(
         [Frozen] Mock<IMediator> mediatorMock,
         [Greedy] OrganisationsController sut,
         GetOrganisationsQuery request,

--- a/src/AdminRoatp/SFA.DAS.AdminRoatp.Api/Controllers/OrganisationsController.cs
+++ b/src/AdminRoatp/SFA.DAS.AdminRoatp.Api/Controllers/OrganisationsController.cs
@@ -1,6 +1,8 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.AdminRoatp.Application.Queries.GetOrganisation;
 using SFA.DAS.AdminRoatp.Application.Queries.GetOrganisations;
+using SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp;
 using System.Net;
 
 namespace SFA.DAS.AdminRoatp.Api.Controllers;
@@ -17,5 +19,17 @@ public class OrganisationsController(IMediator _mediator, ILogger<OrganisationsC
         _logger.LogInformation("Received request to get organisations with Search Term: {SearchTerm}", searchTerm);
         GetOrganisationsQueryResponse response = await _mediator.Send(new GetOrganisationsQuery(searchTerm), cancellationToken);
         return Ok(response);
+    }
+
+    [HttpGet]
+    [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(GetOrganisationResponse))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType((int)HttpStatusCode.BadRequest, Type = typeof(IDictionary<string, string>))]
+    [Route("{ukprn}")]
+    public async Task<IActionResult> GetOrganisation([FromRoute] int ukprn, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Received request to get organisation for Ukprn: {Ukprn}", ukprn);
+        GetOrganisationResponse? response = await _mediator.Send(new GetOrganisationQuery(ukprn), cancellationToken);
+        return response == null ? NotFound() : Ok(response);
     }
 }

--- a/src/AdminRoatp/SFA.DAS.AdminRoatp.UnitTests/Application/Queries/GetOrganisation/GetOrganisationQueryHandlerTests.cs
+++ b/src/AdminRoatp/SFA.DAS.AdminRoatp.UnitTests/Application/Queries/GetOrganisation/GetOrganisationQueryHandlerTests.cs
@@ -1,0 +1,59 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Moq;
+using SFA.DAS.AdminRoatp.Application.Queries.GetOrganisation;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Exceptions;
+using SFA.DAS.SharedOuterApi.InnerApi.Requests.Roatp;
+using SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using SFA.DAS.SharedOuterApi.Models;
+using SFA.DAS.Testing.AutoFixture;
+using System.Net;
+
+namespace SFA.DAS.AdminRoatp.UnitTests.Application.Queries.GetOrganisation;
+public class GetOrganisationQueryHandlerTests
+{
+    [Test, MoqAutoData]
+
+    public async Task Handle_SuccessfulResponse_ReturnsData(
+        [Frozen] Mock<IRoatpServiceApiClient<RoatpConfiguration>> apiClient,
+        GetOrganisationQueryHandler sut,
+        GetOrganisationQuery request,
+        GetOrganisationResponse apiResponse)
+    {
+        apiClient.Setup(a => a.GetWithResponseCode<GetOrganisationResponse>(It.Is<GetOrganisationRequest>(r => r.GetUrl.Equals(new GetOrganisationRequest(request.ukprn).GetUrl)))).ReturnsAsync(new ApiResponse<GetOrganisationResponse>(apiResponse, HttpStatusCode.OK, ""));
+
+        var result = await sut.Handle(request, CancellationToken.None);
+
+        result.Should().BeEquivalentTo(apiResponse);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Handle_Unsuccessful404Response_ReturnNullResponse(
+    [Frozen] Mock<IRoatpServiceApiClient<RoatpConfiguration>> apiClientMock,
+    GetOrganisationQuery query,
+    GetOrganisationQueryHandler sut)
+    {
+        var apiResponse = new ApiResponse<GetOrganisationResponse>(It.IsAny<GetOrganisationResponse>(), HttpStatusCode.NotFound, "");
+        apiClientMock.Setup(a => a.GetWithResponseCode<GetOrganisationResponse>(It.IsAny<GetOrganisationRequest>())).ReturnsAsync(apiResponse);
+
+        var result = await sut.Handle(query, It.IsAny<CancellationToken>());
+
+        result.Should().BeNull();
+    }
+
+    [Test, MoqAutoData]
+    public async Task Handle_UnsuccessfulResponse_ThrowsException(
+        [Frozen] Mock<IRoatpServiceApiClient<RoatpConfiguration>> apiClientMock,
+        GetOrganisationQuery query,
+        GetOrganisationQueryHandler sut)
+    {
+        var apiResponse = new ApiResponse<GetOrganisationResponse>(It.IsAny<GetOrganisationResponse>(), HttpStatusCode.InternalServerError, "");
+        apiClientMock.Setup(a => a.GetWithResponseCode<GetOrganisationResponse>(It.IsAny<GetOrganisationRequest>())).ReturnsAsync(apiResponse);
+
+        Func<Task> result = () => sut.Handle(query, It.IsAny<CancellationToken>());
+
+        await result.Should().ThrowAsync<ApiResponseException>();
+    }
+}

--- a/src/AdminRoatp/SFA.DAS.AdminRoatp.UnitTests/Application/Queries/GetOrganisation/GetOrganisationQueryTests.cs
+++ b/src/AdminRoatp/SFA.DAS.AdminRoatp.UnitTests/Application/Queries/GetOrganisation/GetOrganisationQueryTests.cs
@@ -1,0 +1,20 @@
+﻿using FluentAssertions;
+using SFA.DAS.AdminRoatp.Application.Queries.GetOrganisation;
+using SFA.DAS.SharedOuterApi.InnerApi.Requests.Roatp;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.AdminRoatp.UnitTests.Application.Queries.GetOrganisation;
+public class GetOrganisationQueryTests
+{
+    [Test, MoqAutoData]
+
+    public void GetOrganisationRequest_ReturnsCorrectGetUrl(
+        GetOrganisationQuery request)
+    {
+        var expectedUrl = $"organisations/{request.ukprn}";
+
+        GetOrganisationRequest apiRequest = new(request.ukprn);
+
+        apiRequest.GetUrl.Should().Be(expectedUrl);
+    }
+}

--- a/src/AdminRoatp/SFA.DAS.AdminRoatp/Application/Queries/GetOrganisation/GetOrganisationQuery.cs
+++ b/src/AdminRoatp/SFA.DAS.AdminRoatp/Application/Queries/GetOrganisation/GetOrganisationQuery.cs
@@ -1,0 +1,5 @@
+﻿using MediatR;
+using SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp;
+
+namespace SFA.DAS.AdminRoatp.Application.Queries.GetOrganisation;
+public record GetOrganisationQuery(int ukprn) : IRequest<GetOrganisationResponse?>;

--- a/src/AdminRoatp/SFA.DAS.AdminRoatp/Application/Queries/GetOrganisation/GetOrganisationQueryHandler.cs
+++ b/src/AdminRoatp/SFA.DAS.AdminRoatp/Application/Queries/GetOrganisation/GetOrganisationQueryHandler.cs
@@ -1,0 +1,28 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.SharedOuterApi.Configuration;
+using SFA.DAS.SharedOuterApi.Extensions;
+using SFA.DAS.SharedOuterApi.InnerApi.Requests.Roatp;
+using SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp;
+using SFA.DAS.SharedOuterApi.Interfaces;
+using System.Net;
+
+namespace SFA.DAS.AdminRoatp.Application.Queries.GetOrganisation;
+public class GetOrganisationQueryHandler(IRoatpServiceApiClient<RoatpConfiguration> _apiClient, ILogger<GetOrganisationQueryHandler> _logger) : IRequestHandler<GetOrganisationQuery, GetOrganisationResponse?>
+{
+    public async Task<GetOrganisationResponse?> Handle(GetOrganisationQuery request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Get Organisation request received for Ukprn {Ukprn}", request.ukprn);
+
+        var result = await _apiClient.GetWithResponseCode<GetOrganisationResponse>(new GetOrganisationRequest(request.ukprn));
+
+        if (result.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        result.EnsureSuccessStatusCode();
+
+        return result.Body;
+    }
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Requests/Roatp/GetOrganisationRequest.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Requests/Roatp/GetOrganisationRequest.cs
@@ -1,0 +1,14 @@
+﻿using SFA.DAS.SharedOuterApi.Interfaces;
+
+namespace SFA.DAS.SharedOuterApi.InnerApi.Requests.Roatp;
+public class GetOrganisationRequest : IGetApiRequest
+{
+    public int Ukprn { get; set; }
+
+    public GetOrganisationRequest(int ukprn)
+    {
+        Ukprn = ukprn;
+    }
+
+    public string GetUrl => $"organisations/{Ukprn}";
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/AllowedCourseType.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/AllowedCourseType.cs
@@ -1,0 +1,4 @@
+﻿using SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp.Common;
+
+namespace SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp;
+public record AllowedCourseType(int CourseTypeId, string CourseTypeName, LearningType LearningType);

--- a/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/Common/LearningType.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/Common/LearningType.cs
@@ -1,0 +1,6 @@
+﻿namespace SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp.Common;
+public enum LearningType
+{
+    Standard = 1,
+    ShortCourse = 2
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/Common/OrganisationStatus.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/Common/OrganisationStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp.Common;
+public enum OrganisationStatus
+{
+    Removed = 0,
+    Active = 1,
+    ActiveNoStarts = 2,
+    OnBoarding = 3
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/Common/ProviderType.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/Common/ProviderType.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp.Common;
+public enum ProviderType
+{
+    Main = 1,
+    Employer = 2,
+    Supporting = 3
+}

--- a/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/GetOrganisationResponse.cs
+++ b/src/Shared/SFA.DAS.SharedOuterApi/InnerApi/Responses/Roatp/GetOrganisationResponse.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SFA.DAS.SharedOuterApi.InnerApi.Responses.Roatp;
+public class GetOrganisationResponse
+{
+    public Guid OrganisationId { get; set; }
+    public int Ukprn { get; set; }
+    public string LegalName { get; set; }
+    public string TradingName { get; set; }
+    public string CompanyNumber { get; set; }
+    public string CharityNumber { get; set; }
+    public Common.ProviderType ProviderType { get; set; }
+    public int OrganisationTypeId { get; set; }
+    public string OrganisationType { get; set; }
+    public Common.OrganisationStatus Status { get; set; }
+    public DateTime? LastUpdatedDate { get; set; }
+    public DateTime? ApplicationDeterminedDate { get; set; }
+    public int? RemovedReasonId { get; set; }
+    public string RemovedReason { get; set; }
+    public DateTime? RemovedDate { get; set; }
+    public IEnumerable<AllowedCourseType> AllowedCourseTypes { get; set; } = [];
+}


### PR DESCRIPTION
CSP-2229 Implements search organisation endpoint

CSP-2229 Separated search organisation response class to different class files

CSP-2229 Removed unnecessary code block and added loging

CSP-2229 Added code to handle not found response

CSP-2229 Added swagger doc ref for not found

CSP-2229 Amended code to resolve review comments

CSP-2229 Reverted changes to controller name and route

CSP-2229 Amendments made to address further review comments

CSP-2229 Amended route to fix build error