### PR TITLE
FAI-3265 Update call to get standards in employer finance to use courses endpoint

### DIFF
--- a/src/EmployerFinance/SFA.DAS.EmployerFinance.Api.UnitTests/Models/WhenMappingGetStandardResponseFromMediatorType.cs
+++ b/src/EmployerFinance/SFA.DAS.EmployerFinance.Api.UnitTests/Models/WhenMappingGetStandardResponseFromMediatorType.cs
@@ -13,14 +13,8 @@ namespace SFA.DAS.EmployerFinance.Api.UnitTests.Models
 
             //Assert
             actual.Should().BeEquivalentTo(source, options=> options
-                .Excluding(x=>x.ApprenticeshipFunding)
-                .Excluding(x=>x.StandardDates)
-                .Excluding(x=>x.TypicalDuration)
-                .Excluding(x=>x.IsActive)
-                .Excluding(x => x.StandardUId)
                 .Excluding(x => x.LarsCode)
             );
-            actual.Duration.Should().Be(source.TypicalDuration);
             actual.Id.Should().Be(source.LarsCode);
         }
     }

--- a/src/EmployerFinance/SFA.DAS.EmployerFinance.Api/Models/TrainingCourses/GetStandardsResponse.cs
+++ b/src/EmployerFinance/SFA.DAS.EmployerFinance.Api/Models/TrainingCourses/GetStandardsResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using SFA.DAS.EmployerFinance.InnerApi.Responses;
 
 namespace SFA.DAS.EmployerFinance.Api.Models
@@ -10,21 +11,19 @@ namespace SFA.DAS.EmployerFinance.Api.Models
 
     public class StandardResponse
     {
-        public int Id { get; set; }
+        public string Id { get; set; }
         public int Level { get; set; }
         public string Title { get; set; }
-        public int Duration { get; set; }
-        public int MaxFunding { get; set; }
+        public string LearningType { get; set; }
 
         public static implicit operator StandardResponse(GetStandardsListItem source)
         {
             return new StandardResponse
             {
                 Id = source.LarsCode,
-                Duration = source.TypicalDuration,
                 Level = source.Level,
                 Title = source.Title,
-                MaxFunding = source.MaxFunding
+                LearningType = source.LearningType
             };
         }
     }

--- a/src/EmployerFinance/SFA.DAS.EmployerFinance.Api/appsettings.json
+++ b/src/EmployerFinance/SFA.DAS.EmployerFinance.Api/appsettings.json
@@ -10,6 +10,7 @@
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
   "ConfigNames": "SFA.DAS.EmployerFinance.OuterApi",
   "Environment": "LOCAL",
+  "ResourceEnvironmentName": "LOCAL",
   "Version": "1.0",
   "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
 }

--- a/src/EmployerFinance/SFA.DAS.EmployerFinance.UnitTests/Application/InnerApi/Requests/WhenBuildingGetCoursesRequest.cs
+++ b/src/EmployerFinance/SFA.DAS.EmployerFinance.UnitTests/Application/InnerApi/Requests/WhenBuildingGetCoursesRequest.cs
@@ -1,0 +1,14 @@
+using SFA.DAS.EmployerFinance.InnerApi.Requests;
+using SFA.DAS.SharedOuterApi.Types.InnerApi.Requests.Courses;
+
+namespace SFA.DAS.EmployerFinance.UnitTests.Application.InnerApi.Requests;
+
+public class WhenBuildingGetCoursesRequest
+{
+    [Test]
+    public void Then_The_Request_Url_Is_Active_Courses_Ordered_By_Score()
+    {
+        var request = new GetCoursesRequest();
+        request.GetUrl.Should().Be($"api/courses/search?filter=Active&orderby={CoursesOrderBy.Score}");
+    }
+}

--- a/src/EmployerFinance/SFA.DAS.EmployerFinance.UnitTests/Application/Queries/GetStandards/WhenHandlingTheGetStandardsQuery.cs
+++ b/src/EmployerFinance/SFA.DAS.EmployerFinance.UnitTests/Application/Queries/GetStandards/WhenHandlingTheGetStandardsQuery.cs
@@ -1,18 +1,8 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
-using AutoFixture.NUnit3;
-using FluentAssertions;
-using Moq;
-using NUnit.Framework;
-using SFA.DAS.EmployerFinance.Application.Queries.GetStandards;
+﻿using SFA.DAS.EmployerFinance.Application.Queries.GetStandards;
 using SFA.DAS.EmployerFinance.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Types.Configuration;
-
-using SFA.DAS.SharedOuterApi.Types.InnerApi.Requests;
-using SFA.DAS.SharedOuterApi.Types.InnerApi.Requests.Courses;
 using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
-using SFA.DAS.Testing.AutoFixture;
+using SFA.DAS.EmployerFinance.InnerApi.Requests;
 
 namespace SFA.DAS.EmployerFinance.UnitTests.Application.Queries.GetStandards
 {
@@ -26,12 +16,12 @@ namespace SFA.DAS.EmployerFinance.UnitTests.Application.Queries.GetStandards
             GetStandardsQueryHandler handler)
         {
             mockApiClient
-                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetActiveStandardsListRequest>()))
+                .Setup(client => client.Get<GetStandardsListResponse>(It.IsAny<GetCoursesRequest>()))
                 .ReturnsAsync(apiResponse);
 
             var result = await handler.Handle(query, CancellationToken.None);
 
-            result.Standards.Should().BeEquivalentTo(apiResponse.Standards);
+            result.Standards.Should().BeEquivalentTo(apiResponse.Courses);
         }
     }
 }

--- a/src/EmployerFinance/SFA.DAS.EmployerFinance/Application/Queries/GetStandards/GetStandardsQueryHandler.cs
+++ b/src/EmployerFinance/SFA.DAS.EmployerFinance/Application/Queries/GetStandards/GetStandardsQueryHandler.cs
@@ -1,13 +1,10 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using SFA.DAS.EmployerFinance.InnerApi.Requests;
 using SFA.DAS.EmployerFinance.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Types.Configuration;
-
-using SFA.DAS.SharedOuterApi.Types.InnerApi.Requests;
-using SFA.DAS.SharedOuterApi.Types.InnerApi.Requests.Courses;
 using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.EmployerFinance.Application.Queries.GetStandards
 {
@@ -21,11 +18,11 @@ namespace SFA.DAS.EmployerFinance.Application.Queries.GetStandards
         }
         public async Task<GetStandardsQueryResult> Handle(GetStandardsQuery request, CancellationToken cancellationToken)
         {
-            var response = await _coursesApiClient.Get<GetStandardsListResponse>(new GetActiveStandardsListRequest());
+            var response = await _coursesApiClient.Get<GetStandardsListResponse>(new GetCoursesRequest());
             
             return new GetStandardsQueryResult
             {
-                Standards = response.Standards
+                Standards = response.Courses
             };
         }
     }

--- a/src/EmployerFinance/SFA.DAS.EmployerFinance/InnerApi/Requests/GetCoursesRequest.cs
+++ b/src/EmployerFinance/SFA.DAS.EmployerFinance/InnerApi/Requests/GetCoursesRequest.cs
@@ -1,0 +1,9 @@
+using SFA.DAS.Apim.Shared.Interfaces;
+using SFA.DAS.SharedOuterApi.Types.InnerApi.Requests.Courses;
+
+namespace SFA.DAS.EmployerFinance.InnerApi.Requests;
+
+public class GetCoursesRequest : IGetApiRequest
+{
+    public string GetUrl => $"api/courses/search?filter=Active&orderby={CoursesOrderBy.Score}";
+}

--- a/src/EmployerFinance/SFA.DAS.EmployerFinance/InnerApi/Responses/GetStandardsListItem.cs
+++ b/src/EmployerFinance/SFA.DAS.EmployerFinance/InnerApi/Responses/GetStandardsListItem.cs
@@ -1,13 +1,10 @@
-﻿using SFA.DAS.SharedOuterApi.Types.InnerApi.Responses.Courses;
+﻿namespace SFA.DAS.EmployerFinance.InnerApi.Responses;
 
-namespace SFA.DAS.EmployerFinance.InnerApi.Responses
+public class GetStandardsListItem
 {
-    public class GetStandardsListItem : StandardApiResponseBase
-    {
-        public string StandardUId { get; set; }
-        public int LarsCode { get; set; }
+    public string LarsCode { get; set; }
 
-        public string Title { get; set; }
-        public int Level { get; set; }
-    }
+    public string Title { get; set; }
+    public int Level { get; set; }
+    public string LearningType { get; set; }
 }

--- a/src/EmployerFinance/SFA.DAS.EmployerFinance/InnerApi/Responses/GetStandardsListResponse.cs
+++ b/src/EmployerFinance/SFA.DAS.EmployerFinance/InnerApi/Responses/GetStandardsListResponse.cs
@@ -4,6 +4,6 @@ namespace SFA.DAS.EmployerFinance.InnerApi.Responses
 {
     public class GetStandardsListResponse
     {
-        public IEnumerable<GetStandardsListItem> Standards { get; set; }
+        public IEnumerable<GetStandardsListItem> Courses { get; set; }
     }
 }


### PR DESCRIPTION
Update to use courses endpoint instead of the standards one so that we can map through LearningType and also updated Id to be string for change to LARS code now being a string