### PR TITLE
FAI-3415 NHS Jobs - 429's are not being retried

### DIFF
--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/AppStart/ServiceCollectionExtensions.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs.Api/AppStart/ServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@ using SFA.DAS.FindApprenticeshipJobs.Domain.EmailTemplates;
 using SFA.DAS.FindApprenticeshipJobs.Interfaces;
 using SFA.DAS.FindApprenticeshipJobs.Services;
 using SFA.DAS.SharedOuterApi.Types.Configuration;
-
 using SFA.DAS.Apim.Shared.Infrastructure;
 using SFA.DAS.Apim.Shared.Infrastructure.Services;
 using SFA.DAS.SharedOuterApi.Types.Interfaces;

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/Candidates/UpdateCandidateStatusCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/Candidates/UpdateCandidateStatusCommandHandler.cs
@@ -5,7 +5,6 @@ using SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Types.Configuration;
 
 using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Application.Commands.Candidates
 {

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessApplicationReminderCommandHandler.cs
@@ -6,8 +6,6 @@ using SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;
 using SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
 using SFA.DAS.Notifications.Messages.Commands;
 using SFA.DAS.SharedOuterApi.Types.Configuration;
-
-using SFA.DAS.Apim.Shared.Extensions;
 using SFA.DAS.SharedOuterApi.Types.Interfaces;
 using SFA.DAS.Apim.Shared.Interfaces;
 using SFA.DAS.SharedOuterApi.Types.Extensions;

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Commands/ProcessVacancyClosedEarlyCommandHandler.cs
@@ -9,9 +9,7 @@ using SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Types.Configuration;
 
 using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
 using SFA.DAS.Apim.Shared.Models;
-using SFA.DAS.SharedOuterApi.Types.Models;
 using System.Net;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Application.Commands;

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/CivilServiceJobs/GetCivilServiceJobsQueryHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/CivilServiceJobs/GetCivilServiceJobsQueryHandler.cs
@@ -6,11 +6,8 @@ using SFA.DAS.SharedOuterApi.Types.Configuration;
 
 using SFA.DAS.SharedOuterApi.Types.InnerApi.Requests.Location;
 using SFA.DAS.SharedOuterApi.Types.InnerApi.Responses;
-using SFA.DAS.SharedOuterApi.Types.InnerApi.Responses.Courses;
 using SFA.DAS.SharedOuterApi.Types.InnerApi.Responses.Location;
 using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
-using SFA.DAS.Apim.Shared.Models;
 using SFA.DAS.SharedOuterApi.Types.Models;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Application.Queries.CivilServiceJobs;

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/GetLiveVacancyQueryHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/GetLiveVacancyQueryHandler.cs
@@ -9,9 +9,7 @@ using SFA.DAS.FindApprenticeshipJobs.Interfaces;
 using SFA.DAS.SharedOuterApi.Types.Configuration;
 
 using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
 using SFA.DAS.Apim.Shared.Models;
-using SFA.DAS.SharedOuterApi.Types.Models;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Application.Queries;
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearches/GetSavedSearchesQueryHandler.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Application/Queries/SavedSearch/GetSavedSearches/GetSavedSearchesQueryHandler.cs
@@ -4,7 +4,6 @@ using SFA.DAS.FindApprenticeshipJobs.InnerApi.Responses;
 using SFA.DAS.SharedOuterApi.Types.Configuration;
 
 using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Application.Queries.SavedSearch.GetSavedSearches
 {

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Configuration/NhsJobsConfiguration.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Configuration/NhsJobsConfiguration.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using SFA.DAS.SharedOuterApi.Types.Interfaces;
 using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Configuration;

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetCandidateApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetCandidateApiRequest.cs
@@ -1,5 +1,4 @@
-﻿using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
+﻿using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests
 {

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetCandidateApplicationsByVacancyRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetCandidateApplicationsByVacancyRequest.cs
@@ -1,4 +1,3 @@
-using SFA.DAS.SharedOuterApi.Types.Interfaces;
 using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetCandidatePreferencesRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetCandidatePreferencesRequest.cs
@@ -1,4 +1,3 @@
-using SFA.DAS.SharedOuterApi.Types.Interfaces;
 using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetCivilServiceJobsApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetCivilServiceJobsApiRequest.cs
@@ -1,5 +1,4 @@
-﻿using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
+﻿using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;
 public record GetCivilServiceJobsApiRequest : IGetApiRequest

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetClosedVacancyApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetClosedVacancyApiRequest.cs
@@ -1,4 +1,3 @@
-using SFA.DAS.SharedOuterApi.Types.Interfaces;
 using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetLiveVacancyApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetLiveVacancyApiRequest.cs
@@ -1,5 +1,4 @@
-﻿using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
+﻿using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests;
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetSavedSearchesApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetSavedSearchesApiRequest.cs
@@ -1,5 +1,4 @@
-﻿using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
+﻿using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests
 {

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetVacancyRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/GetVacancyRequest.cs
@@ -1,5 +1,4 @@
-﻿using SFA.DAS.SharedOuterApi.Types.Interfaces;
-using SFA.DAS.Apim.Shared.Interfaces;
+﻿using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests
 {

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/PatchSavedSearchApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/PatchSavedSearchApiRequest.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
 using SFA.DAS.FindApprenticeshipJobs.Domain.Models;
-using SFA.DAS.SharedOuterApi.Types.Interfaces;
 using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/PutCandidateApiRequest.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/InnerApi/Requests/PutCandidateApiRequest.cs
@@ -1,5 +1,4 @@
 ﻿using SFA.DAS.FindApprenticeshipJobs.Domain.Models;
-using SFA.DAS.SharedOuterApi.Types.Interfaces;
 using SFA.DAS.Apim.Shared.Interfaces;
 
 namespace SFA.DAS.FindApprenticeshipJobs.InnerApi.Requests

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Interfaces/INhsJobsApiClient.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Interfaces/INhsJobsApiClient.cs
@@ -1,7 +1,5 @@
-using SFA.DAS.SharedOuterApi.Types.Interfaces;
 using SFA.DAS.Apim.Shared.Interfaces;
 using SFA.DAS.Apim.Shared.Models;
-using SFA.DAS.SharedOuterApi.Types.Models;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Interfaces;
 

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Services/NhsJobsApiClient.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Services/NhsJobsApiClient.cs
@@ -1,11 +1,11 @@
 using System.Net;
+using Polly;
+using Polly.Retry;
 using SFA.DAS.FindApprenticeshipJobs.Configuration;
 using SFA.DAS.FindApprenticeshipJobs.Interfaces;
 using SFA.DAS.Apim.Shared.Infrastructure;
-using SFA.DAS.SharedOuterApi.Types.Interfaces;
 using SFA.DAS.Apim.Shared.Interfaces;
 using SFA.DAS.Apim.Shared.Models;
-using SFA.DAS.SharedOuterApi.Types.Models;
 
 namespace SFA.DAS.FindApprenticeshipJobs.Services;
 
@@ -21,11 +21,14 @@ public class NhsJobsApiClient : INhsJobsApiClient
     
     public async Task<ApiResponse<string>> GetWithResponseCode(IGetApiRequest request)
     {
-        var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, request.GetUrl);
-        httpRequestMessage.AddVersion(request.Version);
+        var response = await RetryPipeline.ExecuteAsync(async token =>
+        {
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Get, request.GetUrl);
+            requestMessage.AddVersion(request.Version);
 
-        var response = await _httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
-
+            return await _httpClient.SendAsync(requestMessage, token);
+        });
+        
         var stringResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
         var errorContent = "";
@@ -38,7 +41,7 @@ public class NhsJobsApiClient : INhsJobsApiClient
         else if (string.IsNullOrWhiteSpace(stringResponse))
         {
             // 204 No Content from a potential returned null
-            // Will throw if attempts to deserialise but didn't
+            // Will throw if attempts to deserialize but didn't
             // feel right making it part of the error if branch
             // even if there is no content.
         }
@@ -52,9 +55,35 @@ public class NhsJobsApiClient : INhsJobsApiClient
         return getWithResponseCode;
     }
 
+    private static readonly ResiliencePipeline<HttpResponseMessage> RetryPipeline =
+        new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddRetry(new RetryStrategyOptions<HttpResponseMessage>
+            {
+                MaxRetryAttempts = 3,
+
+                ShouldHandle = args => ValueTask.FromResult(
+                    args.Outcome.Result is not null &&
+                    (
+                        args.Outcome.Result.StatusCode == HttpStatusCode.TooManyRequests ||
+                        args.Outcome.Result.StatusCode == HttpStatusCode.RequestTimeout ||
+                        (int)args.Outcome.Result.StatusCode >= 500
+                    )),
+
+                DelayGenerator = args =>
+                {
+                    var retryAfter = args.Outcome.Result?
+                        .Headers
+                        .RetryAfter?
+                        .Delta;
+
+                    return ValueTask.FromResult<TimeSpan?>(
+                        retryAfter ?? TimeSpan.FromSeconds(2));
+                }
+            })
+            .Build();
+
     private static bool IsNot200RangeResponseCode(HttpStatusCode statusCode)
     {
         return !((int)statusCode >= 200 && (int)statusCode <= 299);
     }
-    
 }

--- a/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Services/NhsJobsApiClient.cs
+++ b/src/FindApprenticeshipJobs/SFA.DAS.FindApprenticeshipJobs/Services/NhsJobsApiClient.cs
@@ -77,7 +77,7 @@ public class NhsJobsApiClient : INhsJobsApiClient
                         .Delta;
 
                     return ValueTask.FromResult<TimeSpan?>(
-                        retryAfter ?? TimeSpan.FromSeconds(2));
+                        retryAfter ?? TimeSpan.FromSeconds(15));
                 }
             })
             .Build();


### PR DESCRIPTION
Introduce Polly for resilience in HTTP requests, replacing direct
HTTP calls with a retry pipeline in `GetWithResponseCode`. The retry
strategy handles transient errors like `TooManyRequests`,
`RequestTimeout`, and server errors (5xx), with up to 3 retries and
configurable delays using the `Retry-After` header or a 2-second
default.

Refactored HTTP request creation to ensure new requests for each
retry. Removed unused imports and added a static `RetryPipeline`
field for better code organization.

No changes were made to non-retry logic.