### PR TITLE
FAI-3444 FAI-3445 Submitter Details not recorded on VacancyReview

### DIFF
--- a/src/VacanciesManage/SFA.DAS.VacanciesManage.UnitTests/Application/Recruit/Commands/WhenHandlingCreateVacancyCommand.cs
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage.UnitTests/Application/Recruit/Commands/WhenHandlingCreateVacancyCommand.cs
@@ -22,8 +22,12 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using SFA.DAS.Apim.Shared.Interfaces;
+using SFA.DAS.SharedOuterApi.Types.Domain.Recruit;
 using HttpRequestContentException = SFA.DAS.Apim.Shared.Infrastructure.HttpRequestContentException;
+using OwnerType = SFA.DAS.Recruit.Contracts.ApiResponses.OwnerType;
+using ReviewStatus = SFA.DAS.Recruit.Contracts.ApiResponses.ReviewStatus;
 using Vacancy = SFA.DAS.Recruit.Contracts.ApiResponses.Vacancy;
+using VacancyStatus = SFA.DAS.Recruit.Contracts.ApiResponses.VacancyStatus;
 
 namespace SFA.DAS.VacanciesManage.UnitTests.Application.Recruit.Commands;
 
@@ -108,10 +112,19 @@ public class WhenHandlingCreateVacancyCommand
         capturedVacancyReviewRequest.Data.CreatedDate.Should().NotBeNull();
         capturedVacancyReviewRequest.Data.Status.Should().Be(ReviewStatus.New);
 
+        var vacancyUser = new VacancyUser
+        {
+            UserId = apiResponse.Body.SubmittedByUserId.ToString(),
+            Name = apiResponse.Body.Contact.Name,
+            Email = apiResponse.Body.Contact.Email
+        };
         var snapshotOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, Converters = { new JsonStringEnumConverter() } };
         var expectedVacancyNode = JsonSerializer.SerializeToNode(apiResponse.Body, snapshotOptions)!.AsObject();
         expectedVacancyNode["EmployerAccountId"] = accountLegalEntityItem.AccountHashedId;
         expectedVacancyNode["AccountLegalEntityPublicHashedId"] = accountLegalEntityItem.AccountLegalEntityPublicHashedId;
+        expectedVacancyNode["SubmittedByUser"] = JsonSerializer.SerializeToNode(vacancyUser, snapshotOptions);
+        expectedVacancyNode["CreatedByUser"] = JsonSerializer.SerializeToNode(vacancyUser, snapshotOptions);
+        expectedVacancyNode["LastUpdatedByUser"] = JsonSerializer.SerializeToNode(vacancyUser, snapshotOptions);
 
         capturedVacancyReviewRequest.Data.VacancySnapshot.Should().BeEquivalentTo(expectedVacancyNode.ToJsonString(snapshotOptions));
         capturedVacancyReviewRequest.Data.SubmittedByUserEmail.Should().Be(apiResponse.Body.Contact.Email);

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage/Application/Recruit/Commands/CreateVacancy/CreateVacancyCommandHandler.cs
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage/Application/Recruit/Commands/CreateVacancy/CreateVacancyCommandHandler.cs
@@ -19,6 +19,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using SFA.DAS.SharedOuterApi.Types.Domain.Recruit;
 using EmployerNameOption = SFA.DAS.Recruit.Contracts.ApiResponses.EmployerNameOption;
 using HttpRequestContentException = SFA.DAS.Apim.Shared.Infrastructure.HttpRequestContentException;
 using IRecruitApiClient = SFA.DAS.Recruit.Contracts.Client.IRecruitApiClient<SFA.DAS.Recruit.Contracts.Client.RecruitApiConfiguration>;
@@ -92,9 +93,19 @@ public class CreateVacancyCommandHandler(
     private async Task CreateVacancyReview(Vacancy vacancy, string employerAccountId, string accountLegalEntityPublicHashedId, string vacancyReference, DateTime createdDate)
     {
         var snapshotOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, Converters = { new JsonStringEnumConverter() } };
+        var vacancyUser = new VacancyUser
+        {
+            UserId = vacancy.SubmittedByUserId.ToString(),
+            Name = vacancy.Contact.Name,
+            Email = vacancy.Contact.Email,
+        };
+        
         var vacancyNode = JsonSerializer.SerializeToNode(vacancy, snapshotOptions)!.AsObject();
         vacancyNode[nameof(PostVacancyRequestData.EmployerAccountId)] = employerAccountId;
         vacancyNode[nameof(PostVacancyRequestData.AccountLegalEntityPublicHashedId)] = accountLegalEntityPublicHashedId;
+        vacancyNode[nameof(PostVacancyRequestData.SubmittedByUser)] = JsonSerializer.SerializeToNode(vacancyUser, snapshotOptions);
+        vacancyNode[nameof(PostVacancyRequestData.CreatedByUser)] = JsonSerializer.SerializeToNode(vacancyUser, snapshotOptions);
+        vacancyNode[nameof(PostVacancyRequestData.LastUpdatedByUser)] = JsonSerializer.SerializeToNode(vacancyUser, snapshotOptions);
 
         var slaDeadline = await slaService.GetSlaDeadlineAsync(createdDate);
         var reviewRequest = new PutVacancyreviewsByIdApiRequest
@@ -116,6 +127,7 @@ public class CreateVacancyCommandHandler(
                 AccountId = vacancy.AccountId!.Value,
                 AccountLegalEntityId = vacancy.AccountLegalEntityId!.Value,
                 OwnerType = vacancy.OwnerType,
+                SubmittedByUserId = vacancy.SubmittedByUserId.ToString()
             }
         };
 
@@ -297,10 +309,13 @@ public class CreateVacancyCommandHandler(
 
         return response;
     }
-    
-    public class PostVacancyRequestData : Vacancy
+
+    private class PostVacancyRequestData : Vacancy
     {
         public string EmployerAccountId { get; set; }
         public string AccountLegalEntityPublicHashedId { get; set; }
+        public VacancyUser SubmittedByUser { get; set; }
+        public VacancyUser CreatedByUser { get; set; }
+        public VacancyUser LastUpdatedByUser { get; set; }
     }
 }

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage/Application/Recruit/Commands/CreateVacancy/CreateVacancyCommandHandler.cs
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage/Application/Recruit/Commands/CreateVacancy/CreateVacancyCommandHandler.cs
@@ -27,6 +27,7 @@ using Operation = SFA.DAS.SharedOuterApi.Types.Models.ProviderRelationships.Oper
 using OwnerType = SFA.DAS.Recruit.Contracts.ApiResponses.OwnerType;
 using PutVacancyReviewRequest = SFA.DAS.Recruit.Contracts.ApiResponses.PutVacancyReviewRequest;
 using ReviewStatus = SFA.DAS.Recruit.Contracts.ApiResponses.ReviewStatus;
+using TrainingProvider = SFA.DAS.Recruit.Contracts.ApiResponses.TrainingProvider;
 using Vacancy = SFA.DAS.Recruit.Contracts.ApiResponses.Vacancy;
 using VacancyStatus = SFA.DAS.Recruit.Contracts.ApiResponses.VacancyStatus;
 
@@ -168,6 +169,20 @@ public class CreateVacancyCommandHandler(
         {
             throw new HttpRequestContentException("UKPRN of a training provider must be registered to deliver apprenticeship training", HttpStatusCode.Forbidden);
         }
+
+        vacancy.TrainingProvider = new TrainingProvider
+        {
+            Name = provider.Name,
+            Ukprn = provider.Ukprn,
+            Address = provider.Address is not null ? new TrainingProviderAddress
+            {
+                AddressLine1 = provider.Address.AddressLine1,
+                AddressLine2 = provider.Address.AddressLine2,
+                AddressLine3 = provider.Address.AddressLine3,
+                AddressLine4 = provider.Address.AddressLine4,
+                Postcode = provider.Address.Postcode,
+            } : new TrainingProviderAddress()
+        };
     }
 
     private static void EnrichVacancy(PostVacancyRequest vacancy, CreateVacancyCommand request, AccountLegalEntityItem accountLegalEntity)

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage/InnerApi/Responses/GetProvidersListItem.cs
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage/InnerApi/Responses/GetProvidersListItem.cs
@@ -9,4 +9,5 @@ public record GetProvidersListItem
     public string Phone { get; set; }
     public int ProviderTypeId { get; set; }
     public int StatusId { get; set; }
+    public GetProvidersListItemAddress Address { get; set; }
 }

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage/InnerApi/Responses/GetProvidersListItemAddress.cs
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage/InnerApi/Responses/GetProvidersListItemAddress.cs
@@ -1,0 +1,11 @@
+﻿namespace SFA.DAS.VacanciesManage.InnerApi.Responses;
+
+public sealed record GetProvidersListItemAddress
+{
+    public string AddressLine1 { get; set; }
+    public string AddressLine2 { get; set; }
+    public string AddressLine3 { get; set; }
+    public string AddressLine4 { get; set; }
+    public string Town { get; set; }
+    public string Postcode { get; set; }
+}


### PR DESCRIPTION
feat: add user metadata to vacancy submission process

Introduced `VacancyUser` to encapsulate user-related data and updated `CreateVacancyReview` to include user metadata (`SubmittedByUser`, `CreatedByUser`, `LastUpdatedByUser`) in the vacancy payload. Added `SubmittedByUserId` to `PutVacancyReviewRequest` for tracking the submitting user.

Refactored `PostVacancyRequestData` to include user metadata fields and restricted its visibility to private. Removed redundant public declaration of `PostVacancyRequestData`.

These changes ensure user-related metadata is captured and sent as part of the vacancy submission process.