### PR TITLE
FAI-3462 ArchiveType DB field auto-populating to "Auto" for vacancies from API

### DIFF
--- a/src/Shared/SFA.DAS.SharedOuterApi.Types/SFA.DAS.SharedOuterApi.Types.csproj
+++ b/src/Shared/SFA.DAS.SharedOuterApi.Types/SFA.DAS.SharedOuterApi.Types.csproj
@@ -8,7 +8,7 @@
         <PackageReference Include="Microsoft.AspNetCore.JsonPatch.SystemTextJson" Version="10.0.7" />
         <PackageReference Include="OpenTelemetry.Api" Version="1.16.0" />
         <PackageReference Include="SFA.DAS.Apim.Shared" Version="17.1.195" />
-        <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.5-prerelease-73" />
+        <PackageReference Include="SFA.DAS.Apprenticeships.Types" Version="6.8.14" />
         <PackageReference Include="MediatR" Version="12.5.0" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
     </ItemGroup>

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage.Api.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage.Api.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.VacanciesManage.Api.UnitTests.AppStart;
 public class WhenAddingServicesToTheContainer
 {
     [TestCase(typeof(IAzureClientCredentialHelper))]
-    [TestCase(typeof(SFA.DAS.Recruit.Contracts.Client.IRecruitApiClient<SFA.DAS.Recruit.Contracts.Client.RecruitApiConfiguration>))]
+    [TestCase(typeof(SFA.DAS.Recruit.Contracts.Client.IRecruitApiClient<SFA.DAS.   Recruit.Contracts.Client.RecruitApiConfiguration>))]
     [TestCase(typeof(IProviderRelationshipsApiClient<ProviderRelationshipsApiConfiguration>))]
     [TestCase(typeof(IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration>))]
     [TestCase(typeof(IAccountsApiClient<AccountsConfiguration>))]

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage.Api.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage.Api.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.VacanciesManage.Api.UnitTests.AppStart;
 public class WhenAddingServicesToTheContainer
 {
     [TestCase(typeof(IAzureClientCredentialHelper))]
-    [TestCase(typeof(SFA.DAS.Recruit.Contracts.Client.IRecruitApiClient<SFA.DAS.   Recruit.Contracts.Client.RecruitApiConfiguration>))]
+    [TestCase(typeof(SFA.DAS.Recruit.Contracts.Client.IRecruitApiClient<SFA.DAS.Recruit.Contracts.Client.RecruitApiConfiguration>))]
     [TestCase(typeof(IProviderRelationshipsApiClient<ProviderRelationshipsApiConfiguration>))]
     [TestCase(typeof(IRoatpCourseManagementApiClient<RoatpV2ApiConfiguration>))]
     [TestCase(typeof(IAccountsApiClient<AccountsConfiguration>))]

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage/Application/Recruit/Commands/CreateVacancy/CreateVacancyCommandHandler.cs
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage/Application/Recruit/Commands/CreateVacancy/CreateVacancyCommandHandler.cs
@@ -127,7 +127,7 @@ public class CreateVacancyCommandHandler(
                 Ukprn = vacancy.TrainingProvider.Ukprn!.Value,
                 AccountId = vacancy.AccountId!.Value,
                 AccountLegalEntityId = vacancy.AccountLegalEntityId!.Value,
-                OwnerType = (OwnerType)vacancy.OwnerType,
+                OwnerType = vacancy.OwnerType,
                 SubmittedByUserId = vacancy.SubmittedByUserId.ToString(),
                 AutomatedQaOutcomeIndicators = []
             }

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage/Application/Recruit/Commands/CreateVacancy/CreateVacancyCommandHandler.cs
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage/Application/Recruit/Commands/CreateVacancy/CreateVacancyCommandHandler.cs
@@ -127,7 +127,7 @@ public class CreateVacancyCommandHandler(
                 Ukprn = vacancy.TrainingProvider.Ukprn!.Value,
                 AccountId = vacancy.AccountId!.Value,
                 AccountLegalEntityId = vacancy.AccountLegalEntityId!.Value,
-                OwnerType = vacancy.OwnerType,
+                OwnerType = (OwnerType)vacancy.OwnerType,
                 SubmittedByUserId = vacancy.SubmittedByUserId.ToString(),
                 AutomatedQaOutcomeIndicators = []
             }
@@ -281,7 +281,7 @@ public class CreateVacancyCommandHandler(
             return false;
         }
 
-        if (vacancy.TrainingProvider.Ukprn is null)
+        if (vacancy.TrainingProvider?.Ukprn is null)
         {
             return false;
         }
@@ -311,6 +311,7 @@ public class CreateVacancyCommandHandler(
 
         vacancy.Status = VacancyStatus.Submitted;
         vacancy.SubmittedDate = now;
+        vacancy.ArchiveType = null;
     }
 
     private async Task<ApiResponse<Vacancy>> CreateVacancy(PostVacancyRequest vacancy, bool isSandbox)

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage/SFA.DAS.VacanciesManage.csproj
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage/SFA.DAS.VacanciesManage.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.5.0" />
-    <PackageReference Include="SFA.DAS.Recruit.Contracts" Version="0.8.103" />
+    <PackageReference Include="SFA.DAS.Recruit.Contracts" Version="0.8.106-prerelease-6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VacanciesManage/SFA.DAS.VacanciesManage/SFA.DAS.VacanciesManage.csproj
+++ b/src/VacanciesManage/SFA.DAS.VacanciesManage/SFA.DAS.VacanciesManage.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.5.0" />
-    <PackageReference Include="SFA.DAS.Recruit.Contracts" Version="0.8.106-prerelease-6" />
+    <PackageReference Include="SFA.DAS.Recruit.Contracts" Version="0.8.106-prerelease-7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update package refs and improve vacancy submission logic

Updated SFA.DAS.Apprenticeships.Types and SFA.DAS.Recruit.Contracts package versions. Fixed test case attribute formatting for long generic types. In CreateVacancyCommandHandler, cast OwnerType to enum, added null check for TrainingProvider.Ukprn, and set ArchiveType to null on submission.