### PR TITLE
Redirects WIP

### DIFF
--- a/src/Campaign/SFA.DAS.Campaign.Api.UnitTests/Controllers/Redirects/WhenGettingTheRedirects.cs
+++ b/src/Campaign/SFA.DAS.Campaign.Api.UnitTests/Controllers/Redirects/WhenGettingTheRedirects.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Campaign.Api.Controllers;
+using SFA.DAS.Campaign.Api.Models;
+using SFA.DAS.Campaign.Application.Queries.Redirects;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.Campaign.Api.UnitTests.Controllers.Redirects
+{
+    public class WhenGettingTheRedirects
+    {
+        [Test, RecursiveMoqAutoData]
+        public async Task Then_The_Redirects_Are_Returned(
+            GetRedirectsQueryResult mediatorResult,
+            [Frozen] Mock<IMediator> mockMediator,
+            [Greedy] RedirectsController controller)
+        {
+            mockMediator
+                .Setup(mediator => mediator.Send(It.IsAny<GetRedirectsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mediatorResult);
+
+            var controllerResult = await controller.GetRedirectsAsync(CancellationToken.None) as OkObjectResult;
+
+            var actualResult = controllerResult.Value as GetRedirectsResponse;
+            Assert.That(actualResult, Is.Not.Null);
+            actualResult.Redirects.Should().BeEquivalentTo(mediatorResult.Redirects);
+        }
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign.Api/Controllers/RedirectsController.cs
+++ b/src/Campaign/SFA.DAS.Campaign.Api/Controllers/RedirectsController.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using SFA.DAS.Campaign.Api.Models;
+using SFA.DAS.Campaign.Application.Queries.Redirects;
+
+namespace SFA.DAS.Campaign.Api.Controllers
+{
+    [ApiController]
+    [Route("[controller]/")]
+    public class RedirectsController : Controller
+    {
+        private readonly IMediator _mediator;
+
+        public RedirectsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetRedirectsAsync(CancellationToken cancellationToken = default)
+        {
+            var result = await _mediator.Send(new GetRedirectsQuery(), cancellationToken);
+
+            return Ok(new GetRedirectsResponse
+            {
+                Redirects = result.Redirects
+            });
+        }
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign.Api/Models/GetRedirectsResponse.cs
+++ b/src/Campaign/SFA.DAS.Campaign.Api/Models/GetRedirectsResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using SFA.DAS.Campaign.Models;
+
+namespace SFA.DAS.Campaign.Api.Models
+{
+    public class GetRedirectsResponse
+    {
+        public List<RedirectModel> Redirects { get; set; }
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign.UnitTests/Application/Queries/Redirects/WhenGettingTheRedirects.cs
+++ b/src/Campaign/SFA.DAS.Campaign.UnitTests/Application/Queries/Redirects/WhenGettingTheRedirects.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Apim.Shared.Interfaces;
+using SFA.DAS.Apim.Shared.Models;
+using SFA.DAS.Campaign.Application.Queries.Redirects;
+using SFA.DAS.Campaign.ExternalApi.Requests;
+using SFA.DAS.Campaign.ExternalApi.Responses;
+using SFA.DAS.Campaign.Interfaces;
+using SFA.DAS.Campaign.Models;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.Campaign.UnitTests.Application.Queries.Redirects
+{
+    public class WhenGettingTheRedirects
+    {
+        [Test, RecursiveMoqAutoData]
+        public async Task Then_The_Api_Is_Called_And_The_Redirects_Are_Returned(
+            GetRedirectsQuery query,
+            CmsContent apiResponse,
+            [Frozen] Mock<IContentService> contentService,
+            [Frozen] Mock<IReliableCacheStorageService> service,
+            GetRedirectsQueryHandler handler)
+        {
+            contentService.Setup(x => x.HasContent(It.IsAny<ApiResponse<CmsContent>>())).Returns(true);
+            service.Setup(o =>
+                    o.GetData<CmsContent>(
+                        It.Is<GetRedirectsRequest>(c => c.GetUrl.Equals($"entries?content_type=redirect&limit={GetRedirectsRequest.MaxRedirects}")),
+                        GetRedirectsQueryHandler.CacheKey, contentService.Object.HasContent))
+                .ReturnsAsync(apiResponse);
+
+            var actual = await handler.Handle(query, CancellationToken.None);
+
+            actual.Redirects.Should().BeEquivalentTo(RedirectModel.BuildFrom(apiResponse));
+        }
+
+        [Test, RecursiveMoqAutoData]
+        public async Task Then_No_Redirects_Are_Returned_When_There_Is_No_Content(
+            GetRedirectsQuery query,
+            [Frozen] Mock<IContentService> contentService,
+            [Frozen] Mock<IReliableCacheStorageService> service,
+            GetRedirectsQueryHandler handler)
+        {
+            contentService.Setup(x => x.HasContent(It.IsAny<ApiResponse<CmsContent>>())).Returns(false);
+            service.Setup(o => o.GetData<CmsContent>(It.IsAny<GetRedirectsRequest>(), It.IsAny<string>(), It.IsAny<System.Func<ApiResponse<CmsContent>, bool>>()))
+                .ReturnsAsync((CmsContent)null);
+
+            var actual = await handler.Handle(query, CancellationToken.None);
+
+            actual.Redirects.Should().BeEmpty();
+        }
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign.UnitTests/ExternalApi/Requests/WhenBuildingTheGetRedirectsRequest.cs
+++ b/src/Campaign/SFA.DAS.Campaign.UnitTests/ExternalApi/Requests/WhenBuildingTheGetRedirectsRequest.cs
@@ -1,0 +1,17 @@
+using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.Campaign.ExternalApi.Requests;
+
+namespace SFA.DAS.Campaign.UnitTests.ExternalApi.Requests
+{
+    public class WhenBuildingTheGetRedirectsRequest
+    {
+        [Test]
+        public void Then_The_Url_Is_Correctly_Built()
+        {
+            var actual = new GetRedirectsRequest();
+
+            actual.GetUrl.Should().Be($"entries?content_type=redirect&limit={GetRedirectsRequest.MaxRedirects}");
+        }
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign.UnitTests/Models/WhenBuildingTheRedirectModelsFromApiResponse.cs
+++ b/src/Campaign/SFA.DAS.Campaign.UnitTests/Models/WhenBuildingTheRedirectModelsFromApiResponse.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.Campaign.ExternalApi.Responses;
+using SFA.DAS.Campaign.Models;
+using SFA.DAS.Testing.AutoFixture;
+
+namespace SFA.DAS.Campaign.UnitTests.Models
+{
+    public class WhenBuildingTheRedirectModelsFromApiResponse
+    {
+        [Test]
+        public void Then_If_No_Items_Returned_Then_An_Empty_List_Is_Returned()
+        {
+            var source = new CmsContent { Items = new List<Item>(), Total = 1 };
+
+            var actual = RedirectModel.BuildFrom(source);
+
+            actual.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Then_If_The_Content_Is_Null_Then_An_Empty_List_Is_Returned()
+        {
+            var actual = RedirectModel.BuildFrom(null);
+
+            actual.Should().BeEmpty();
+        }
+
+        [Test, RecursiveMoqAutoData]
+        public void Then_If_Total_Is_Zero_Then_An_Empty_List_Is_Returned(CmsContent source)
+        {
+            source.Total = 0;
+
+            var actual = RedirectModel.BuildFrom(source);
+
+            actual.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Then_The_Redirects_Are_Built()
+        {
+            var source = BuildContent(
+                RedirectItem("/employers/old-page", "/employers/new-page", "Exact", true),
+                RedirectItem("/employers/retired-section", "/employers", "Prefix", false));
+
+            var actual = RedirectModel.BuildFrom(source);
+
+            actual.Should().BeEquivalentTo(new List<RedirectModel>
+            {
+                new RedirectModel { FromPath = "/employers/old-page", ToPath = "/employers/new-page", MatchType = "Exact", Permanent = true },
+                new RedirectModel { FromPath = "/employers/retired-section", ToPath = "/employers", MatchType = "Prefix", Permanent = false }
+            });
+        }
+
+        [TestCase("prefix")]
+        [TestCase("PREFIX")]
+        [TestCase(" Prefix ")]
+        public void Then_The_Match_Type_Is_Read_Regardless_Of_Casing_Or_Padding(string matchType)
+        {
+            var source = BuildContent(RedirectItem("/from", "/to", matchType, true));
+
+            var actual = RedirectModel.BuildFrom(source);
+
+            actual[0].MatchType.Should().Be(RedirectModel.PrefixMatchType);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("something-an-editor-typed")]
+        public void Then_An_Unrecognised_Match_Type_Falls_Back_To_Exact(string matchType)
+        {
+            var source = BuildContent(RedirectItem("/from", "/to", matchType, true));
+
+            var actual = RedirectModel.BuildFrom(source);
+
+            actual[0].MatchType.Should().Be(RedirectModel.ExactMatchType);
+        }
+
+        [Test]
+        public void Then_An_Unset_Permanent_Flag_Defaults_To_A_Permanent_Redirect()
+        {
+            var source = BuildContent(RedirectItem("/from", "/to", "Exact", null));
+
+            var actual = RedirectModel.BuildFrom(source);
+
+            actual[0].Permanent.Should().BeTrue();
+        }
+
+        [Test]
+        public void Then_The_Paths_Are_Trimmed()
+        {
+            var source = BuildContent(RedirectItem("  /from  ", "  /to  ", "Exact", true));
+
+            var actual = RedirectModel.BuildFrom(source);
+
+            actual[0].FromPath.Should().Be("/from");
+            actual[0].ToPath.Should().Be("/to");
+        }
+
+        [TestCase(null, "/to")]
+        [TestCase("", "/to")]
+        [TestCase("  ", "/to")]
+        [TestCase("/from", null)]
+        [TestCase("/from", "")]
+        [TestCase("/from", "  ")]
+        public void Then_A_Redirect_Missing_A_Path_Is_Dropped(string fromPath, string toPath)
+        {
+            var source = BuildContent(
+                RedirectItem(fromPath, toPath, "Exact", true),
+                RedirectItem("/a-complete/entry", "/a-destination", "Exact", true));
+
+            var actual = RedirectModel.BuildFrom(source);
+
+            actual.Should().HaveCount(1);
+            actual[0].FromPath.Should().Be("/a-complete/entry");
+        }
+
+        private static CmsContent BuildContent(params Item[] items)
+        {
+            return new CmsContent { Items = new List<Item>(items), Total = items.Length };
+        }
+
+        private static Item RedirectItem(string fromPath, string toPath, string matchType, bool? permanent)
+        {
+            return new Item
+            {
+                Fields = new ItemFields
+                {
+                    FromPath = fromPath,
+                    ToPath = toPath,
+                    MatchType = matchType,
+                    Permanent = permanent
+                }
+            };
+        }
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign/Application/Queries/Redirects/GetRedirectsQuery.cs
+++ b/src/Campaign/SFA.DAS.Campaign/Application/Queries/Redirects/GetRedirectsQuery.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace SFA.DAS.Campaign.Application.Queries.Redirects
+{
+    public class GetRedirectsQuery : IRequest<GetRedirectsQueryResult>
+    {
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign/Application/Queries/Redirects/GetRedirectsQueryHandler.cs
+++ b/src/Campaign/SFA.DAS.Campaign/Application/Queries/Redirects/GetRedirectsQueryHandler.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using SFA.DAS.Apim.Shared.Interfaces;
+using SFA.DAS.Campaign.ExternalApi.Requests;
+using SFA.DAS.Campaign.ExternalApi.Responses;
+using SFA.DAS.Campaign.Interfaces;
+using SFA.DAS.Campaign.Models;
+
+namespace SFA.DAS.Campaign.Application.Queries.Redirects
+{
+    public class GetRedirectsQueryHandler : IRequestHandler<GetRedirectsQuery, GetRedirectsQueryResult>
+    {
+        public const string CacheKey = "Redirects";
+
+        private readonly IReliableCacheStorageService _reliableCacheStorageService;
+        private readonly IContentService _contentService;
+
+        public GetRedirectsQueryHandler(IReliableCacheStorageService reliableCacheStorageService, IContentService contentService)
+        {
+            _reliableCacheStorageService = reliableCacheStorageService;
+            _contentService = contentService;
+        }
+
+        public async Task<GetRedirectsQueryResult> Handle(GetRedirectsQuery request, CancellationToken cancellationToken)
+        {
+            var content = await _reliableCacheStorageService.GetData<CmsContent>(new GetRedirectsRequest(), CacheKey, _contentService.HasContent);
+
+            return new GetRedirectsQueryResult
+            {
+                Redirects = RedirectModel.BuildFrom(content)
+            };
+        }
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign/Application/Queries/Redirects/GetRedirectsQueryResult.cs
+++ b/src/Campaign/SFA.DAS.Campaign/Application/Queries/Redirects/GetRedirectsQueryResult.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using SFA.DAS.Campaign.Models;
+
+namespace SFA.DAS.Campaign.Application.Queries.Redirects
+{
+    public class GetRedirectsQueryResult
+    {
+        public List<RedirectModel> Redirects { get; set; }
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign/ContentfulConstants.cs
+++ b/src/Campaign/SFA.DAS.Campaign/ContentfulConstants.cs
@@ -3,6 +3,7 @@
     public static class ContentfulConstants
     {
         public const string ArticleContentTypeId = "article";
+        public const string RedirectContentTypeId = "redirect";
         public const string ContentTypeSystemIdPath = "sys.id";
         public const string HubTypePath = "fields.hubType";
         public const string SlugPath = "fields.slug";

--- a/src/Campaign/SFA.DAS.Campaign/ExternalApi/Requests/GetRedirectsRequest.cs
+++ b/src/Campaign/SFA.DAS.Campaign/ExternalApi/Requests/GetRedirectsRequest.cs
@@ -1,0 +1,15 @@
+using SFA.DAS.Apim.Shared.Interfaces;
+
+namespace SFA.DAS.Campaign.ExternalApi.Requests
+{
+    public class GetRedirectsRequest : IGetApiRequest
+    {
+        /// <summary>
+        /// Contentful returns 100 entries by default and caps a single page at 1000, which is far more redirects
+        /// than the site is ever expected to carry. Paging would be needed beyond that.
+        /// </summary>
+        public const int MaxRedirects = 1000;
+
+        public string GetUrl => $"entries?content_type={ContentfulConstants.RedirectContentTypeId}&limit={MaxRedirects}";
+    }
+}

--- a/src/Campaign/SFA.DAS.Campaign/ExternalApi/Responses/CmsContent.cs
+++ b/src/Campaign/SFA.DAS.Campaign/ExternalApi/Responses/CmsContent.cs
@@ -371,6 +371,18 @@ namespace SFA.DAS.Campaign.ExternalApi.Responses
         public ImageContent Image { get; set; }
         [JsonPropertyName("Id")]
         public int Id { get; set; }
+
+        [JsonPropertyName("fromPath")]
+        public string FromPath { get; set; }
+
+        [JsonPropertyName("toPath")]
+        public string ToPath { get; set; }
+
+        [JsonPropertyName("matchType")]
+        public string MatchType { get; set; }
+
+        [JsonPropertyName("permanent")]
+        public bool? Permanent { get; set; }
     }
 
     public class MainContent

--- a/src/Campaign/SFA.DAS.Campaign/Models/RedirectModel.cs
+++ b/src/Campaign/SFA.DAS.Campaign/Models/RedirectModel.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SFA.DAS.Campaign.Extensions;
+using SFA.DAS.Campaign.ExternalApi.Responses;
+
+namespace SFA.DAS.Campaign.Models
+{
+    public class RedirectModel
+    {
+        public const string ExactMatchType = "Exact";
+        public const string PrefixMatchType = "Prefix";
+
+        public string FromPath { get; set; }
+        public string ToPath { get; set; }
+        public string MatchType { get; set; }
+        public bool Permanent { get; set; }
+
+        /// <summary>
+        /// Maps published redirect entries, dropping any that are missing a path. Editors work in a free text
+        /// field, so anything the consuming site can't act on is discarded here rather than being passed on and
+        /// risking the whole list failing to deserialise over one bad entry.
+        /// </summary>
+        public static List<RedirectModel> BuildFrom(CmsContent content)
+        {
+            if (content.ContentItemsAreNullOrEmpty())
+            {
+                return new List<RedirectModel>();
+            }
+
+            return content.Items
+                .Where(item => !string.IsNullOrWhiteSpace(item?.Fields?.FromPath)
+                               && !string.IsNullOrWhiteSpace(item.Fields.ToPath))
+                .Select(item => new RedirectModel
+                {
+                    FromPath = item.Fields.FromPath.Trim(),
+                    ToPath = item.Fields.ToPath.Trim(),
+                    MatchType = ParseMatchType(item.Fields.MatchType),
+                    Permanent = item.Fields.Permanent ?? true
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Anything that isn't recognisably a prefix redirect is treated as an exact one, which is both the safer
+        /// default and what an editor leaving the field alone will have meant.
+        /// </summary>
+        private static string ParseMatchType(string matchType)
+        {
+            return string.Equals(matchType?.Trim(), PrefixMatchType, StringComparison.OrdinalIgnoreCase)
+                ? PrefixMatchType
+                : ExactMatchType;
+        }
+    }
+}


### PR DESCRIPTION
Create a redirects endpoint that can be consumed by the apprenticeship.gov.uk frontend - which surfaces a list of redrects defined in contentful - to allow the content team to manage redirects without the need for a code release 